### PR TITLE
Test: PR preview deploy pipeline

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: 18
           cache: "npm"
       - run: npm ci
-      - run: partykit delete --preview pr-${{ github.event.pull_request.number }} --yes
+      - run: npx partykit delete --preview pr-${{ github.event.pull_request.number }} --yes
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 18
           cache: "npm"
       - run: npm ci
-      - run: npm run cachebust && partykit deploy --preview pr-${{ github.event.pull_request.number }} --with-vars
+      - run: npm run cachebust && npx partykit deploy --preview pr-${{ github.event.pull_request.number }} --with-vars
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - CI: PR preview deploy and cleanup workflows now use `npx partykit` instead of bare `partykit`, which isn't on PATH after `npm ci`
+- CI: PR preview workflow now has `pull-requests: write` permission so it can post the preview URL comment
 
 ### Changed
 - Index: added `[test]` suffix to landing page title to verify PR preview deploy pipeline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- Index: added `[test]` suffix to landing page title to verify PR preview deploy pipeline
+
 ### Added
 - Deploy: `npm run deploy:staging` script deploys a persistent staging environment to `staging.polislike-partykit-reaction-canvas.patcon.partykit.dev`
 - CI: PR preview environments — opening or pushing to a PR auto-deploys a preview at `pr-{N}.polislike-partykit-reaction-canvas.patcon.partykit.dev` and posts a comment with the URL; preview is deleted when the PR is closed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ All notable changes to this project will be documented in this file.
 - CI: PR preview deploy and cleanup workflows now use `npx partykit` instead of bare `partykit`, which isn't on PATH after `npm ci`
 - CI: PR preview workflow now has `pull-requests: write` permission so it can post the preview URL comment
 
-### Changed
-- Index: added `[test]` suffix to landing page title to verify PR preview deploy pipeline
 
 ### Added
 - Deploy: `npm run deploy:staging` script deploys a persistent staging environment to `staging.polislike-partykit-reaction-canvas.patcon.partykit.dev`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- CI: PR preview deploy and cleanup workflows now use `npx partykit` instead of bare `partykit`, which isn't on PATH after `npm ci`
+
 ### Changed
 - Index: added `[test]` suffix to landing page title to verify PR preview deploy pipeline
 

--- a/app/client.tsx
+++ b/app/client.tsx
@@ -9,7 +9,7 @@ import ReactionCanvasAppV5 from "./components/ReactionCanvasAppV5";
 function IndexApp() {
   return (
     <div className="index-app">
-      <h1 className="index-title">Polislike Reaction Canvas Apps</h1>
+      <h1 className="index-title">Polislike Reaction Canvas Apps [test]</h1>
       <div className="app-cards">
         <a href="?room=irc6creOFGs#v5" className="app-card app-card--youtube">
           <div className="app-card-content">

--- a/app/client.tsx
+++ b/app/client.tsx
@@ -9,7 +9,7 @@ import ReactionCanvasAppV5 from "./components/ReactionCanvasAppV5";
 function IndexApp() {
   return (
     <div className="index-app">
-      <h1 className="index-title">Polislike Reaction Canvas Apps [test]</h1>
+      <h1 className="index-title">Polislike Reaction Canvas Apps</h1>
       <div className="app-cards">
         <a href="?room=irc6creOFGs#v5" className="app-card app-card--youtube">
           <div className="app-card-content">


### PR DESCRIPTION
## Summary
- Adds `[test]` suffix to landing page title
- Purpose: verify that PR preview deploy CI triggers correctly and teardown works on close

## Test plan
- [x] Check CI triggers preview deploy on PR open
- [x] Verify preview comment is posted with URL
- [x] Visit preview URL and confirm `[test]` suffix is visible in title
- [ ] Close PR and confirm teardown CI runs and preview is deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code) (~50 words of LLM output from ~30 words of human prompt)