### PR TITLE
V4 Admin: JSON playback for recorded sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- V4 Admin: load a previously recorded JSON file and replay it as puppeted playback cursors visible to all connected participants in real time; playback cursors are rendered purple with a dashed ring to distinguish them from real users; supports both positions mode (raw x/y) and transitions mode (snaps to anchor region + deterministic per-user jitter)
 - Deploy: `npm run deploy:staging` script deploys a persistent staging environment to `staging.polislike-partykit-reaction-canvas.patcon.partykit.dev`
 - CI: PR preview environments — opening or pushing to a PR auto-deploys a preview at `pr-{N}.polislike-partykit-reaction-canvas.patcon.partykit.dev` and posts a comment with the URL; preview is deleted when the PR is closed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - Local dev now works without deploying: WebSocket host is now detected by port (1999 = local server) instead of hostname, so accessing via a local network IP (e.g. `10.x.x.x:1999`) correctly connects to the local PartyKit server rather than the deployed one.
+- Valence Viz: WebSocket host detection now uses port instead of hostname, matching the rest of the app — fixes connecting to remote server when accessed via local network IP
+- Valence Viz: live user dots now appear as soon as a participant connects (on `userJoined`) and disappear when they disconnect (on `userLeft`), rather than appearing only on first touch and never leaving
+- Valence Viz: freed live slots now restore their original sim values, so the dot snaps back to the synthetic trajectory instead of freezing at the last live position
 
 ### Added
 - Experience: Valence Viz — facilitator tool (`valence-viz.html`) wrapping the Three.js particle/wave valence visualization. Runs synthetic data by default (scrub bar + play/pause). "Audience Sync" toggle connects to a PartyKit room via WebSocket and drives valence values from live cursor positions using barycentric region weighting. Supports light-wave and charged-particle modes, group/valence coloring, and orbit camera. Index card added to landing page.

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -733,17 +733,27 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
           {/* Playback section */}
           <div style={{ marginTop: 32, borderTop: '1px solid #444', paddingTop: 24 }}>
             <p style={{ marginBottom: 12, fontWeight: 600 }}>Playback</p>
-            <label style={{ display: 'inline-block', cursor: 'pointer' }}>
-              <span className="v3-admin-btn" style={{ display: 'inline-block' }}>
-                ↑ Load JSON file
-              </span>
-              <input
-                type="file"
-                accept="application/json,.json"
-                onChange={handlePlaybackFile}
-                style={{ display: 'none' }}
-              />
-            </label>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+              <label style={{ display: 'inline-block', cursor: 'pointer' }}>
+                <span className="v3-admin-btn" style={{ display: 'inline-block' }}>
+                  ↑ Load JSON file
+                </span>
+                <input
+                  type="file"
+                  accept="application/json,.json"
+                  onChange={handlePlaybackFile}
+                  style={{ display: 'none' }}
+                />
+              </label>
+              <a
+                href="https://drive.google.com/drive/folders/12ujr5MKjs2q0vzDViyG_1U-SEyVOJZO_"
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ color: '#69f', fontSize: 13 }}
+              >
+                Valence traces ↗
+              </a>
+            </div>
             {playbackData && (() => {
               const events = playbackData.events as Record<string, unknown>[];
               const uniqueUsers = new Set(events.map(e => e.connectionId)).size;

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -12,6 +12,14 @@ interface AdminPanelV4Props {
 
 type RecordingMode = 'transitions' | 'positions';
 
+interface PlaybackFile {
+  recordingStart: number;
+  recordingEnd: number;
+  room: string;
+  mode: RecordingMode;
+  events: object[];
+}
+
 function anchorToLocal(anchors: ReactionAnchors) {
   return {
     positiveX: String(anchors.positive.x),
@@ -105,6 +113,12 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
   const prevRegionsRef = useRef<Map<string, ReactionRegion | null>>(new Map());
   const isRecordingRef = useRef(false);
   const modeRef = useRef<RecordingMode>('transitions');
+
+  // Playback state
+  const [playbackData, setPlaybackData] = useState<PlaybackFile | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const playbackIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const activePlaybackUserIds = useRef<Set<string>>(new Set());
 
   // Keep refs in sync with state so the socket handler can access current values
   // without stale closures
@@ -281,6 +295,112 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
   const handleModeChange = (newMode: RecordingMode) => {
     setMode(newMode);
     modeRef.current = newMode;
+  };
+
+  const handlePlaybackFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    file.text().then(text => {
+      try {
+        const data = JSON.parse(text) as PlaybackFile;
+        setPlaybackData(data);
+      } catch {
+        alert('Failed to parse JSON file.');
+      }
+    });
+  };
+
+  const anchorForRegion = (region: string, userId: string): { x: number; y: number } => {
+    const anchors: Record<string, { x: number; y: number }> = {
+      positive: { x: parseFloat(positiveX), y: parseFloat(positiveY) },
+      negative: { x: parseFloat(negativeX), y: parseFloat(negativeY) },
+      neutral:  { x: parseFloat(neutralX),  y: parseFloat(neutralY)  },
+    };
+    const base = anchors[region] ?? { x: 50, y: 50 };
+    // Deterministic jitter ±4 units seeded by userId so users don't pile up on the same pixel
+    const h = userId.split('').reduce((a, c) => (a * 31 + c.charCodeAt(0)) | 0, 0);
+    return {
+      x: base.x + ((Math.abs(h) % 9) - 4),
+      y: base.y + ((Math.abs(h >> 4) % 9) - 4),
+    };
+  };
+
+  const sendPlaybackEvent = (evt: Record<string, unknown>, mode: RecordingMode) => {
+    const fakeUserId = `replay_${evt.connectionId}`;
+    if (mode === 'positions') {
+      if (evt.type === 'remove') {
+        socket.send(JSON.stringify({
+          type: 'playbackCursorBroadcast',
+          cursorType: 'remove',
+          position: { x: 0, y: 0, userId: fakeUserId, timestamp: Date.now() },
+        }));
+        activePlaybackUserIds.current.delete(fakeUserId);
+      } else {
+        socket.send(JSON.stringify({
+          type: 'playbackCursorBroadcast',
+          cursorType: evt.type,
+          position: { x: evt.x, y: evt.y, userId: fakeUserId, timestamp: Date.now() },
+        }));
+        activePlaybackUserIds.current.add(fakeUserId);
+      }
+    } else {
+      // transitions mode
+      if (evt.to === null || evt.to === undefined) {
+        socket.send(JSON.stringify({
+          type: 'playbackCursorBroadcast',
+          cursorType: 'remove',
+          position: { x: 0, y: 0, userId: fakeUserId, timestamp: Date.now() },
+        }));
+        activePlaybackUserIds.current.delete(fakeUserId);
+      } else {
+        const { x, y } = anchorForRegion(String(evt.to), fakeUserId);
+        socket.send(JSON.stringify({
+          type: 'playbackCursorBroadcast',
+          cursorType: 'move',
+          position: { x, y, userId: fakeUserId, timestamp: Date.now() },
+        }));
+        activePlaybackUserIds.current.add(fakeUserId);
+      }
+    }
+  };
+
+  const stopPlayback = () => {
+    if (playbackIntervalRef.current) clearInterval(playbackIntervalRef.current);
+    playbackIntervalRef.current = null;
+    setIsPlaying(false);
+    // Send remove for all active playback cursors so they vanish immediately
+    activePlaybackUserIds.current.forEach(uid => {
+      socket.send(JSON.stringify({
+        type: 'playbackCursorBroadcast',
+        cursorType: 'remove',
+        position: { x: 0, y: 0, userId: uid, timestamp: Date.now() },
+      }));
+    });
+    activePlaybackUserIds.current.clear();
+  };
+
+  const startPlayback = () => {
+    if (!playbackData || playbackData.events.length === 0) return;
+    const mode = playbackData.mode;
+    const sorted = [...playbackData.events].sort(
+      (a, b) => (a as Record<string, number>).timestamp - (b as Record<string, number>).timestamp
+    );
+    const originTs = (sorted[0] as Record<string, number>).timestamp;
+    const wallStart = Date.now();
+    let idx = 0;
+    activePlaybackUserIds.current = new Set();
+    setIsPlaying(true);
+
+    playbackIntervalRef.current = setInterval(() => {
+      const elapsed = Date.now() - wallStart;
+      while (idx < sorted.length) {
+        const evt = sorted[idx] as Record<string, unknown>;
+        if ((evt.timestamp as number) - originTs > elapsed) break;
+        sendPlaybackEvent(evt, mode);
+        idx++;
+      }
+      if (idx >= sorted.length) stopPlayback();
+    }, 50);
   };
 
   const sendUserCap = () => {
@@ -495,6 +615,58 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
               ? <span style={{ color: '#f55' }}>REC active (participants see badge)</span>
               : <span>inactive</span>
             }
+          </div>
+
+          {/* Playback section */}
+          <div style={{ marginTop: 32, borderTop: '1px solid #444', paddingTop: 24 }}>
+            <p style={{ marginBottom: 12, fontWeight: 600 }}>Playback</p>
+            <label style={{ display: 'inline-block', cursor: 'pointer' }}>
+              <span className="v3-admin-btn" style={{ display: 'inline-block' }}>
+                ↑ Load JSON file
+              </span>
+              <input
+                type="file"
+                accept="application/json,.json"
+                onChange={handlePlaybackFile}
+                style={{ display: 'none' }}
+              />
+            </label>
+            {playbackData && (
+              <div style={{ marginTop: 12, color: '#aaa', fontSize: 13 }}>
+                <div style={{ color: '#eee', marginBottom: 4 }}>
+                  {(() => {
+                    const events = playbackData.events as Record<string, unknown>[];
+                    const uniqueUsers = new Set(events.map(e => e.connectionId)).size;
+                    const durationMs = playbackData.recordingEnd - playbackData.recordingStart;
+                    const mins = Math.floor(durationMs / 60000);
+                    const secs = Math.floor((durationMs % 60000) / 1000);
+                    return `${events.length} events · ${uniqueUsers} users · ${mins}m${String(secs).padStart(2, '0')}s`;
+                  })()}
+                </div>
+                <div style={{ color: '#888' }}>Mode: {playbackData.mode} · Room: {playbackData.room}</div>
+              </div>
+            )}
+            <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
+              {!isPlaying ? (
+                <button
+                  className="v3-admin-btn v3-admin-btn-record"
+                  onClick={startPlayback}
+                  disabled={!playbackData}
+                  style={{ background: playbackData ? undefined : '#333' }}
+                >
+                  ▶ Play
+                </button>
+              ) : (
+                <button className="v3-admin-btn v3-admin-btn-stop" onClick={stopPlayback}>
+                  ■ Stop
+                </button>
+              )}
+            </div>
+            {isPlaying && (
+              <div style={{ marginTop: 8, color: '#f55', fontSize: 13, fontWeight: 600 }}>
+                PLAYING — playback cursors visible to all participants
+              </div>
+            )}
           </div>
         </div>
 

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -120,7 +120,10 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
   const [isPaused, setIsPaused] = useState(false);
   const [playbackElapsed, setPlaybackElapsed] = useState(0);
   const playbackIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pauseHeartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const activePlaybackUserIds = useRef<Set<string>>(new Set());
+  // Last sent position per playback userId, for pause heartbeat
+  const lastPlaybackPositions = useRef<Map<string, { x: number; y: number }>>(new Map());
   // Refs shared between playback functions
   const sortedEventsRef = useRef<Record<string, unknown>[]>([]);
   const originTsRef = useRef<number>(0);
@@ -362,6 +365,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
           position: { x: evt.x, y: evt.y, userId: fakeUserId, timestamp: Date.now() },
         }));
         activePlaybackUserIds.current.add(fakeUserId);
+        lastPlaybackPositions.current.set(fakeUserId, { x: evt.x as number, y: evt.y as number });
       }
     } else {
       // transitions mode
@@ -372,6 +376,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
           position: { x: 0, y: 0, userId: fakeUserId, timestamp: Date.now() },
         }));
         activePlaybackUserIds.current.delete(fakeUserId);
+        lastPlaybackPositions.current.delete(fakeUserId);
       } else {
         const { x, y } = anchorForRegion(String(evt.to), fakeUserId);
         socket.send(JSON.stringify({
@@ -380,6 +385,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
           position: { x, y, userId: fakeUserId, timestamp: Date.now() },
         }));
         activePlaybackUserIds.current.add(fakeUserId);
+        lastPlaybackPositions.current.set(fakeUserId, { x, y });
       }
     }
   };
@@ -393,6 +399,25 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
       }));
     });
     activePlaybackUserIds.current.clear();
+    lastPlaybackPositions.current.clear();
+  };
+
+  const startPauseHeartbeat = () => {
+    if (pauseHeartbeatRef.current) clearInterval(pauseHeartbeatRef.current);
+    pauseHeartbeatRef.current = setInterval(() => {
+      lastPlaybackPositions.current.forEach(({ x, y }, uid) => {
+        socket.send(JSON.stringify({
+          type: 'playbackCursorBroadcast',
+          cursorType: 'move',
+          position: { x, y, userId: uid, timestamp: Date.now() },
+        }));
+      });
+    }, 2000);
+  };
+
+  const stopPauseHeartbeat = () => {
+    if (pauseHeartbeatRef.current) clearInterval(pauseHeartbeatRef.current);
+    pauseHeartbeatRef.current = null;
   };
 
   const runInterval = () => {
@@ -412,6 +437,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
         // Reached end — stop cleanly
         if (playbackIntervalRef.current) clearInterval(playbackIntervalRef.current);
         playbackIntervalRef.current = null;
+        stopPauseHeartbeat();
         setIsPlaying(false);
         setIsPaused(false);
         clearActiveCursors();
@@ -433,6 +459,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
     }
     setIsPlaying(true);
     setIsPaused(false);
+    stopPauseHeartbeat();
     runInterval();
   };
 
@@ -441,12 +468,14 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
     playbackIntervalRef.current = null;
     setIsPlaying(false);
     setIsPaused(true);
-    // Leave cursors visible and elapsed/idx intact
+    // Keep cursors alive with a heartbeat — Canvas removes them after 3s without an update
+    startPauseHeartbeat();
   };
 
   const stopPlayback = () => {
     if (playbackIntervalRef.current) clearInterval(playbackIntervalRef.current);
     playbackIntervalRef.current = null;
+    stopPauseHeartbeat();
     setIsPlaying(false);
     setIsPaused(false);
     setPlaybackElapsed(0);

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -45,7 +45,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
     return () => ro.disconnect();
   }, []);
   const [isRecording, setIsRecording] = useState(false);
-  const [mode, setMode] = useState<RecordingMode>('transitions');
+  const [mode, setMode] = useState<RecordingMode>('positions');
   const [configTab, setConfigTab] = useState<'labels' | 'anchors' | 'avatars' | 'activities'>('labels');
   const [eventCount, setEventCount] = useState(0);
   const [serverRecording, setServerRecording] = useState(false);
@@ -112,7 +112,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
   const recordingStartRef = useRef<number | null>(null);
   const prevRegionsRef = useRef<Map<string, ReactionRegion | null>>(new Map());
   const isRecordingRef = useRef(false);
-  const modeRef = useRef<RecordingMode>('transitions');
+  const modeRef = useRef<RecordingMode>('positions');
 
   // Playback state
   const [playbackData, setPlaybackData] = useState<PlaybackFile | null>(null);

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -117,14 +117,16 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
   // Playback state
   const [playbackData, setPlaybackData] = useState<PlaybackFile | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [isPaused, setIsPaused] = useState(false);
   const [playbackElapsed, setPlaybackElapsed] = useState(0);
   const playbackIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const activePlaybackUserIds = useRef<Set<string>>(new Set());
-  // Refs shared between startPlayback and seekPlayback
+  // Refs shared between playback functions
   const sortedEventsRef = useRef<Record<string, unknown>[]>([]);
   const originTsRef = useRef<number>(0);
   const wallStartRef = useRef<number>(0);
   const idxRef = useRef<number>(0);
+  const playbackModeRef = useRef<RecordingMode>('positions');
 
   // Keep refs in sync with state so the socket handler can access current values
   // without stale closures
@@ -309,6 +311,18 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
     file.text().then(text => {
       try {
         const data = JSON.parse(text) as PlaybackFile;
+        // Pre-sort and store refs so scrubber works before first play
+        const sorted = [...data.events].sort(
+          (a, b) => (a as Record<string, number>).timestamp - (b as Record<string, number>).timestamp
+        ) as Record<string, unknown>[];
+        sortedEventsRef.current = sorted;
+        originTsRef.current = sorted.length > 0 ? (sorted[0].timestamp as number) : 0;
+        playbackModeRef.current = data.mode;
+        idxRef.current = 0;
+        setPlaybackElapsed(0);
+        setIsPlaying(false);
+        setIsPaused(false);
+        clearActiveCursors();
         setPlaybackData(data);
       } catch {
         alert('Failed to parse JSON file.');
@@ -381,18 +395,12 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
     activePlaybackUserIds.current.clear();
   };
 
-  const stopPlayback = () => {
-    if (playbackIntervalRef.current) clearInterval(playbackIntervalRef.current);
-    playbackIntervalRef.current = null;
-    setIsPlaying(false);
-    clearActiveCursors();
-  };
-
-  const runInterval = (mode: RecordingMode) => {
+  const runInterval = () => {
     if (playbackIntervalRef.current) clearInterval(playbackIntervalRef.current);
     playbackIntervalRef.current = setInterval(() => {
       const elapsed = Date.now() - wallStartRef.current;
       const sorted = sortedEventsRef.current;
+      const mode = playbackModeRef.current;
       while (idxRef.current < sorted.length) {
         const evt = sorted[idxRef.current];
         if ((evt.timestamp as number) - originTsRef.current > elapsed) break;
@@ -400,34 +408,59 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
         idxRef.current++;
       }
       setPlaybackElapsed(elapsed);
-      if (idxRef.current >= sorted.length) stopPlayback();
+      if (idxRef.current >= sorted.length) {
+        // Reached end — stop cleanly
+        if (playbackIntervalRef.current) clearInterval(playbackIntervalRef.current);
+        playbackIntervalRef.current = null;
+        setIsPlaying(false);
+        setIsPaused(false);
+        clearActiveCursors();
+      }
     }, 50);
   };
 
-  const startPlayback = () => {
-    if (!playbackData || playbackData.events.length === 0) return;
-    const mode = playbackData.mode;
-    const sorted = [...playbackData.events].sort(
-      (a, b) => (a as Record<string, number>).timestamp - (b as Record<string, number>).timestamp
-    );
-    sortedEventsRef.current = sorted as Record<string, unknown>[];
-    originTsRef.current = (sorted[0] as Record<string, number>).timestamp;
-    wallStartRef.current = Date.now();
-    idxRef.current = 0;
-    activePlaybackUserIds.current = new Set();
-    setPlaybackElapsed(0);
+  const playPlayback = () => {
+    if (!playbackData || sortedEventsRef.current.length === 0) return;
+    if (isPaused) {
+      // Resume from current position
+      wallStartRef.current = Date.now() - playbackElapsed;
+    } else {
+      // Fresh start from beginning
+      idxRef.current = 0;
+      activePlaybackUserIds.current = new Set();
+      setPlaybackElapsed(0);
+      wallStartRef.current = Date.now();
+    }
     setIsPlaying(true);
-    runInterval(mode);
+    setIsPaused(false);
+    runInterval();
+  };
+
+  const pausePlayback = () => {
+    if (playbackIntervalRef.current) clearInterval(playbackIntervalRef.current);
+    playbackIntervalRef.current = null;
+    setIsPlaying(false);
+    setIsPaused(true);
+    // Leave cursors visible and elapsed/idx intact
+  };
+
+  const stopPlayback = () => {
+    if (playbackIntervalRef.current) clearInterval(playbackIntervalRef.current);
+    playbackIntervalRef.current = null;
+    setIsPlaying(false);
+    setIsPaused(false);
+    setPlaybackElapsed(0);
+    idxRef.current = 0;
+    clearActiveCursors();
   };
 
   // Seek to a specific elapsed time (ms from recording start). Works while playing or paused.
   const seekPlayback = (targetElapsed: number) => {
     if (!playbackData) return;
-    const mode = playbackData.mode;
+    const mode = playbackModeRef.current;
     const sorted = sortedEventsRef.current;
     if (!sorted.length) return;
 
-    // Clear all active cursors before repositioning
     clearActiveCursors();
 
     // Find the index of the first event after targetElapsed
@@ -436,26 +469,22 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
     );
     idxRef.current = newIdx === -1 ? sorted.length : newIdx;
 
-    // Compute each user's last known position/state up to targetElapsed and send it
+    // Snapshot each user's last known state up to targetElapsed and send it
     const lastState = new Map<string, Record<string, unknown>>();
     for (const evt of sorted.slice(0, idxRef.current)) {
       const uid = String(evt.connectionId);
       if (mode === 'positions') {
         lastState.set(uid, evt);
       } else {
-        // transitions: track last non-null region
         if (evt.to !== undefined) lastState.set(uid, evt);
       }
     }
-    lastState.forEach((evt, _uid) => {
-      sendPlaybackEvent(evt, mode);
-    });
+    lastState.forEach(evt => sendPlaybackEvent(evt, mode));
 
-    // Adjust wall start so elapsed continues from targetElapsed
     wallStartRef.current = Date.now() - targetElapsed;
     setPlaybackElapsed(targetElapsed);
 
-    if (isPlaying) runInterval(mode);
+    if (isPlaying) runInterval();
   };
 
   const sendUserCap = () => {
@@ -689,60 +718,80 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
             {playbackData && (() => {
               const events = playbackData.events as Record<string, unknown>[];
               const uniqueUsers = new Set(events.map(e => e.connectionId)).size;
-              const sorted = [...events].sort((a, b) => (a.timestamp as number) - (b.timestamp as number));
+              return (
+                <div style={{ marginTop: 12, color: '#aaa', fontSize: 13 }}>
+                  <div style={{ color: '#eee', marginBottom: 2 }}>
+                    {events.length} events · {uniqueUsers} users
+                  </div>
+                  <div style={{ color: '#888' }}>Mode: {playbackData.mode} · Room: {playbackData.room}</div>
+                </div>
+              );
+            })()}
+
+            {/* Timeline scrubber — always visible */}
+            {(() => {
+              const sorted = sortedEventsRef.current;
               const durationMs = sorted.length > 1
                 ? (sorted[sorted.length - 1].timestamp as number) - (sorted[0].timestamp as number)
-                : playbackData.recordingEnd - playbackData.recordingStart;
-              const clampedElapsed = Math.min(playbackElapsed, durationMs);
+                : 0;
+              const clampedElapsed = Math.min(playbackElapsed, durationMs || 1);
               const fmtTime = (ms: number) => {
                 const m = Math.floor(ms / 60000);
                 const s = Math.floor((ms % 60000) / 1000);
                 return `${m}:${String(s).padStart(2, '0')}`;
               };
+              const hasData = !!playbackData && durationMs > 0;
               return (
-                <>
-                  <div style={{ marginTop: 12, color: '#aaa', fontSize: 13 }}>
-                    <div style={{ color: '#eee', marginBottom: 4 }}>
-                      {events.length} events · {uniqueUsers} users · {fmtTime(durationMs)}
-                    </div>
-                    <div style={{ color: '#888' }}>Mode: {playbackData.mode} · Room: {playbackData.room}</div>
+                <div style={{ marginTop: 16, opacity: hasData ? 1 : 0.35 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color: '#888', marginBottom: 4 }}>
+                    <span>{fmtTime(hasData ? clampedElapsed : 0)}</span>
+                    <span>{fmtTime(hasData ? durationMs : 0)}</span>
                   </div>
-
-                  {/* Timeline scrubber */}
-                  <div style={{ marginTop: 16 }}>
-                    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color: '#888', marginBottom: 4 }}>
-                      <span>{fmtTime(clampedElapsed)}</span>
-                      <span>{fmtTime(durationMs)}</span>
-                    </div>
-                    <input
-                      type="range"
-                      min={0}
-                      max={durationMs}
-                      value={clampedElapsed}
-                      onChange={e => seekPlayback(Number(e.target.value))}
-                      style={{ width: '100%', accentColor: 'hsl(270, 70%, 65%)', cursor: 'pointer' }}
-                    />
-                  </div>
-
-                  <div style={{ marginTop: 8, display: 'flex', gap: 8 }}>
-                    {!isPlaying ? (
-                      <button className="v3-admin-btn v3-admin-btn-record" onClick={startPlayback}>
-                        ▶ Play
-                      </button>
-                    ) : (
-                      <button className="v3-admin-btn v3-admin-btn-stop" onClick={stopPlayback}>
-                        ■ Stop
-                      </button>
-                    )}
-                  </div>
-                  {isPlaying && (
-                    <div style={{ marginTop: 8, color: '#f55', fontSize: 13, fontWeight: 600 }}>
-                      PLAYING — playback cursors visible to all participants
-                    </div>
-                  )}
-                </>
+                  <input
+                    type="range"
+                    min={0}
+                    max={hasData ? durationMs : 1}
+                    value={hasData ? clampedElapsed : 0}
+                    disabled={!hasData}
+                    onChange={e => seekPlayback(Number(e.target.value))}
+                    style={{ width: '100%', accentColor: 'hsl(270, 70%, 65%)', cursor: hasData ? 'pointer' : 'default' }}
+                  />
+                </div>
               );
             })()}
+
+            <div style={{ marginTop: 8, display: 'flex', gap: 8 }}>
+              {isPlaying ? (
+                <button className="v3-admin-btn" onClick={pausePlayback}>
+                  ⏸ Pause
+                </button>
+              ) : (
+                <button
+                  className="v3-admin-btn v3-admin-btn-record"
+                  onClick={playPlayback}
+                  disabled={!playbackData}
+                >
+                  ▶ {isPaused ? 'Resume' : 'Play'}
+                </button>
+              )}
+              <button
+                className="v3-admin-btn v3-admin-btn-stop"
+                onClick={stopPlayback}
+                disabled={!isPlaying && !isPaused}
+              >
+                ■ Stop
+              </button>
+            </div>
+            {isPlaying && (
+              <div style={{ marginTop: 8, color: '#f55', fontSize: 13, fontWeight: 600 }}>
+                PLAYING — playback cursors visible to all participants
+              </div>
+            )}
+            {isPaused && (
+              <div style={{ marginTop: 8, color: '#fa0', fontSize: 13, fontWeight: 600 }}>
+                PAUSED — cursors frozen on canvas
+              </div>
+            )}
           </div>
         </div>
 

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -117,8 +117,14 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
   // Playback state
   const [playbackData, setPlaybackData] = useState<PlaybackFile | null>(null);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [playbackElapsed, setPlaybackElapsed] = useState(0);
   const playbackIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const activePlaybackUserIds = useRef<Set<string>>(new Set());
+  // Refs shared between startPlayback and seekPlayback
+  const sortedEventsRef = useRef<Record<string, unknown>[]>([]);
+  const originTsRef = useRef<number>(0);
+  const wallStartRef = useRef<number>(0);
+  const idxRef = useRef<number>(0);
 
   // Keep refs in sync with state so the socket handler can access current values
   // without stale closures
@@ -364,11 +370,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
     }
   };
 
-  const stopPlayback = () => {
-    if (playbackIntervalRef.current) clearInterval(playbackIntervalRef.current);
-    playbackIntervalRef.current = null;
-    setIsPlaying(false);
-    // Send remove for all active playback cursors so they vanish immediately
+  const clearActiveCursors = () => {
     activePlaybackUserIds.current.forEach(uid => {
       socket.send(JSON.stringify({
         type: 'playbackCursorBroadcast',
@@ -379,28 +381,81 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
     activePlaybackUserIds.current.clear();
   };
 
+  const stopPlayback = () => {
+    if (playbackIntervalRef.current) clearInterval(playbackIntervalRef.current);
+    playbackIntervalRef.current = null;
+    setIsPlaying(false);
+    clearActiveCursors();
+  };
+
+  const runInterval = (mode: RecordingMode) => {
+    if (playbackIntervalRef.current) clearInterval(playbackIntervalRef.current);
+    playbackIntervalRef.current = setInterval(() => {
+      const elapsed = Date.now() - wallStartRef.current;
+      const sorted = sortedEventsRef.current;
+      while (idxRef.current < sorted.length) {
+        const evt = sorted[idxRef.current];
+        if ((evt.timestamp as number) - originTsRef.current > elapsed) break;
+        sendPlaybackEvent(evt, mode);
+        idxRef.current++;
+      }
+      setPlaybackElapsed(elapsed);
+      if (idxRef.current >= sorted.length) stopPlayback();
+    }, 50);
+  };
+
   const startPlayback = () => {
     if (!playbackData || playbackData.events.length === 0) return;
     const mode = playbackData.mode;
     const sorted = [...playbackData.events].sort(
       (a, b) => (a as Record<string, number>).timestamp - (b as Record<string, number>).timestamp
     );
-    const originTs = (sorted[0] as Record<string, number>).timestamp;
-    const wallStart = Date.now();
-    let idx = 0;
+    sortedEventsRef.current = sorted as Record<string, unknown>[];
+    originTsRef.current = (sorted[0] as Record<string, number>).timestamp;
+    wallStartRef.current = Date.now();
+    idxRef.current = 0;
     activePlaybackUserIds.current = new Set();
+    setPlaybackElapsed(0);
     setIsPlaying(true);
+    runInterval(mode);
+  };
 
-    playbackIntervalRef.current = setInterval(() => {
-      const elapsed = Date.now() - wallStart;
-      while (idx < sorted.length) {
-        const evt = sorted[idx] as Record<string, unknown>;
-        if ((evt.timestamp as number) - originTs > elapsed) break;
-        sendPlaybackEvent(evt, mode);
-        idx++;
+  // Seek to a specific elapsed time (ms from recording start). Works while playing or paused.
+  const seekPlayback = (targetElapsed: number) => {
+    if (!playbackData) return;
+    const mode = playbackData.mode;
+    const sorted = sortedEventsRef.current;
+    if (!sorted.length) return;
+
+    // Clear all active cursors before repositioning
+    clearActiveCursors();
+
+    // Find the index of the first event after targetElapsed
+    const newIdx = sorted.findIndex(
+      e => (e.timestamp as number) - originTsRef.current > targetElapsed
+    );
+    idxRef.current = newIdx === -1 ? sorted.length : newIdx;
+
+    // Compute each user's last known position/state up to targetElapsed and send it
+    const lastState = new Map<string, Record<string, unknown>>();
+    for (const evt of sorted.slice(0, idxRef.current)) {
+      const uid = String(evt.connectionId);
+      if (mode === 'positions') {
+        lastState.set(uid, evt);
+      } else {
+        // transitions: track last non-null region
+        if (evt.to !== undefined) lastState.set(uid, evt);
       }
-      if (idx >= sorted.length) stopPlayback();
-    }, 50);
+    }
+    lastState.forEach((evt, _uid) => {
+      sendPlaybackEvent(evt, mode);
+    });
+
+    // Adjust wall start so elapsed continues from targetElapsed
+    wallStartRef.current = Date.now() - targetElapsed;
+    setPlaybackElapsed(targetElapsed);
+
+    if (isPlaying) runInterval(mode);
   };
 
   const sendUserCap = () => {
@@ -631,42 +686,63 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
                 style={{ display: 'none' }}
               />
             </label>
-            {playbackData && (
-              <div style={{ marginTop: 12, color: '#aaa', fontSize: 13 }}>
-                <div style={{ color: '#eee', marginBottom: 4 }}>
-                  {(() => {
-                    const events = playbackData.events as Record<string, unknown>[];
-                    const uniqueUsers = new Set(events.map(e => e.connectionId)).size;
-                    const durationMs = playbackData.recordingEnd - playbackData.recordingStart;
-                    const mins = Math.floor(durationMs / 60000);
-                    const secs = Math.floor((durationMs % 60000) / 1000);
-                    return `${events.length} events · ${uniqueUsers} users · ${mins}m${String(secs).padStart(2, '0')}s`;
-                  })()}
-                </div>
-                <div style={{ color: '#888' }}>Mode: {playbackData.mode} · Room: {playbackData.room}</div>
-              </div>
-            )}
-            <div style={{ marginTop: 12, display: 'flex', gap: 8 }}>
-              {!isPlaying ? (
-                <button
-                  className="v3-admin-btn v3-admin-btn-record"
-                  onClick={startPlayback}
-                  disabled={!playbackData}
-                  style={{ background: playbackData ? undefined : '#333' }}
-                >
-                  ▶ Play
-                </button>
-              ) : (
-                <button className="v3-admin-btn v3-admin-btn-stop" onClick={stopPlayback}>
-                  ■ Stop
-                </button>
-              )}
-            </div>
-            {isPlaying && (
-              <div style={{ marginTop: 8, color: '#f55', fontSize: 13, fontWeight: 600 }}>
-                PLAYING — playback cursors visible to all participants
-              </div>
-            )}
+            {playbackData && (() => {
+              const events = playbackData.events as Record<string, unknown>[];
+              const uniqueUsers = new Set(events.map(e => e.connectionId)).size;
+              const sorted = [...events].sort((a, b) => (a.timestamp as number) - (b.timestamp as number));
+              const durationMs = sorted.length > 1
+                ? (sorted[sorted.length - 1].timestamp as number) - (sorted[0].timestamp as number)
+                : playbackData.recordingEnd - playbackData.recordingStart;
+              const clampedElapsed = Math.min(playbackElapsed, durationMs);
+              const fmtTime = (ms: number) => {
+                const m = Math.floor(ms / 60000);
+                const s = Math.floor((ms % 60000) / 1000);
+                return `${m}:${String(s).padStart(2, '0')}`;
+              };
+              return (
+                <>
+                  <div style={{ marginTop: 12, color: '#aaa', fontSize: 13 }}>
+                    <div style={{ color: '#eee', marginBottom: 4 }}>
+                      {events.length} events · {uniqueUsers} users · {fmtTime(durationMs)}
+                    </div>
+                    <div style={{ color: '#888' }}>Mode: {playbackData.mode} · Room: {playbackData.room}</div>
+                  </div>
+
+                  {/* Timeline scrubber */}
+                  <div style={{ marginTop: 16 }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color: '#888', marginBottom: 4 }}>
+                      <span>{fmtTime(clampedElapsed)}</span>
+                      <span>{fmtTime(durationMs)}</span>
+                    </div>
+                    <input
+                      type="range"
+                      min={0}
+                      max={durationMs}
+                      value={clampedElapsed}
+                      onChange={e => seekPlayback(Number(e.target.value))}
+                      style={{ width: '100%', accentColor: 'hsl(270, 70%, 65%)', cursor: 'pointer' }}
+                    />
+                  </div>
+
+                  <div style={{ marginTop: 8, display: 'flex', gap: 8 }}>
+                    {!isPlaying ? (
+                      <button className="v3-admin-btn v3-admin-btn-record" onClick={startPlayback}>
+                        ▶ Play
+                      </button>
+                    ) : (
+                      <button className="v3-admin-btn v3-admin-btn-stop" onClick={stopPlayback}>
+                        ■ Stop
+                      </button>
+                    )}
+                  </div>
+                  {isPlaying && (
+                    <div style={{ marginTop: 8, color: '#f55', fontSize: 13, fontWeight: 600 }}>
+                      PLAYING — playback cursors visible to all participants
+                    </div>
+                  )}
+                </>
+              );
+            })()}
           </div>
         </div>
 

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -391,7 +391,10 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
       ? smallerDim * 0.03  // 3% when showing avatars (needs to be recognizable)
       : smallerDim * 0.01; // 1% for default colored dots (original size)
 
+    const isPlaybackCursor = (d: any): boolean => d.cursorUserId.startsWith('replay_');
+
     const cursorColor = (d: any): string => {
+      if (isPlaybackCursor(d)) return 'hsl(270, 70%, 65%)';
       if (colorCursorsByVote && d.reactionState) {
         switch (d.reactionState) {
           case 'positive': return 'rgba(0, 255, 0, 0.8)';
@@ -408,7 +411,8 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
       .data(cursorData, (d: any) => d.cursorUserId)
       .enter()
       .append('g')
-      .attr('class', 'cursor-group');
+      .attr('class', 'cursor-group')
+      .attr('opacity', (d: any) => isPlaybackCursor(d) ? 0.7 : 1.0);
 
     if (avatarStyle) {
       // Add clip paths to defs for circular avatar masking
@@ -446,8 +450,9 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
         .attr('cy', d => d.y)
         .attr('r', cursorRadius)
         .attr('fill', cursorColor)
-        .attr('stroke', '#000000')
-        .attr('stroke-width', 2);
+        .attr('stroke', (d: any) => isPlaybackCursor(d) ? 'hsl(270, 70%, 80%)' : '#000000')
+        .attr('stroke-width', 2)
+        .attr('stroke-dasharray', (d: any) => isPlaybackCursor(d) ? `${cursorRadius * 0.8} ${cursorRadius * 0.5}` : 'none');
 
       // Add user ID labels with responsive font size and positioning
       const cursorLabelFontSize = Math.min(dimensions.width, dimensions.height) * 0.015; // 1.5% of smaller dimension

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -28,6 +28,7 @@ interface CanvasProps {
   heightOffset?: number; // Pixels to subtract from window.innerHeight (default: statement panel height)
   onPresenceCount?: (count: number) => void;
   onActiveCursorCountChange?: (count: number) => void;
+  onSimulatedCursorCountChange?: (count: number) => void;
   onTimecodeUpdate?: (timecode: number) => void;
   onRecordingStateChange?: (recording: boolean) => void;
   onRoomLabelsChange?: (labels: { positive: string; negative: string; neutral: string } | null) => void;
@@ -62,7 +63,7 @@ function clipLineToRect(
   return [px + tMin * dx, py + tMin * dy, px + tMax * dx, py + tMax * dy];
 }
 
-export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, debug = false }: CanvasProps) {
+export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, debug = false }: CanvasProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [cursors, setCursors] = useState<Map<string, CursorPosition>>(new Map());
   const [anchors, setAnchors] = useState<ReactionAnchors>(DEFAULT_ANCHORS);
@@ -73,6 +74,8 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
 
   useEffect(() => {
     onActiveCursorCountChange?.(cursors.size);
+    const simulatedCount = Array.from(cursors.keys()).filter(id => id.startsWith('replay_')).length;
+    onSimulatedCursorCountChange?.(simulatedCount);
   }, [cursors.size]);
 
   const [dimensions, setDimensions] = useState({

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -54,6 +54,7 @@ export default function ReactionCanvasAppV4() {
   const [canvasBackgroundReactionState, setCanvasBackgroundReactionState] = useState<ReactionState>(null);
   const [presenceCount, setPresenceCount] = useState<number>(0);
   const [activeCursorCount, setActiveCursorCount] = useState<number>(0);
+  const [simulatedCursorCount, setSimulatedCursorCount] = useState<number>(0);
   const [isViewer, setIsViewer] = useState(false);
   const [userCap, setUserCap] = useState<number | null>(null);
   const [viewerCount, setViewerCount] = useState(0);
@@ -110,7 +111,8 @@ export default function ReactionCanvasAppV4() {
         )}
         <div className="v2-presence-counter">
           <span className="v2-counter-num">{presenceCount}</span>
-          {userCap !== null && <span className="v2-counter-dim">/{userCap}</span>} here · <span className="v2-counter-num">{activeCursorCount + (touchPos !== null ? 1 : 0)}</span> touching
+          {userCap !== null && <span className="v2-counter-dim">/{userCap}</span>} here · <span className="v2-counter-num">{activeCursorCount - simulatedCursorCount + (touchPos !== null ? 1 : 0)}</span> touching
+          {simulatedCursorCount > 0 && <> · <span className="v2-counter-num">{simulatedCursorCount}</span> simulated</>}
           {viewerCount > 0 && <> · <span className="v2-counter-num">{viewerCount}</span> watching</>}
         </div>
         <div className="debug-hint">{debug ? 'd: debug on' : 'd: debug'}</div>
@@ -129,6 +131,7 @@ export default function ReactionCanvasAppV4() {
           heightOffset={0}
           onPresenceCount={setPresenceCount}
           onActiveCursorCountChange={setActiveCursorCount}
+          onSimulatedCursorCountChange={setSimulatedCursorCount}
           onRecordingStateChange={setIsRecording}
           onRoomLabelsChange={setServerLabels}
           onRoomAnchorsChange={setServerAnchors}

--- a/party/server.ts
+++ b/party/server.ts
@@ -119,6 +119,12 @@ interface RequestJoinEvent {
   type: 'requestJoin';
 }
 
+interface PlaybackCursorBroadcastEvent {
+  type: 'playbackCursorBroadcast';
+  cursorType: 'move' | 'touch' | 'remove';
+  position: CursorPosition;
+}
+
 interface Vote {
   userId: string;
   statementId: number;
@@ -126,7 +132,7 @@ interface Vote {
   timestamp: number;
 }
 
-type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent;
+type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent;
 
 // ===== SOCCER PHYSICS CONSTANTS =====
 const SOCCER_BALL_R = 2;      // % of canvas
@@ -277,7 +283,17 @@ export default class Server implements Party.Server {
     try {
       const event: ClientEvent = JSON.parse(message);
 
-      if ('position' in event) {
+      if (event.type === 'playbackCursorBroadcast') {
+        // Admin replaying recorded events — broadcast to ALL clients (including sender)
+        // so the admin's own "Peek Canvas" tab also sees playback cursors
+        this.room.broadcast(JSON.stringify({
+          type: event.cursorType,
+          position: {
+            ...event.position,
+            isPlayback: true,
+          },
+        }));
+      } else if ('position' in event) {
         // Handle cursor events
         console.log(`Cursor event from ${sender.id}:`, event.type, event.position);
         // Track cursor positions for soccer physics

--- a/public/valence-viz.html
+++ b/public/valence-viz.html
@@ -1245,6 +1245,11 @@ input[type=range] { width: 100%; accent-color: rgba(255,255,255,0.45); cursor: p
         const n = data.count ?? 0;
         audienceN.textContent = n;
         setConnStatus(`connected · room: ${room} · ${n} participant${n !== 1 ? 's' : ''}`, 'ok');
+      } else if (data.type === 'userJoined') {
+        assignLiveSlot(data.userId);
+      } else if (data.type === 'userLeft') {
+        cursors.delete(data.userId);
+        freeLiveSlot(data.userId);
       } else if (data.type === 'move' || data.type === 'touch') {
         const { userId, x, y } = data.position;
         cursors.set(userId, { x, y });
@@ -1254,9 +1259,9 @@ input[type=range] { width: 100%; accent-color: rgba(255,255,255,0.45); cursor: p
         const { userId } = data.position;
         cursors.delete(userId);
         if (userId.startsWith('replay_')) {
-          freeLiveSlot(userId);  // playback cursor ended — fully release slot
+          freeLiveSlot(userId);
         }
-        // real users: keep slot alive, valence freezes at 0 (thumb lift)
+        // real users: thumb lift only — slot stays until userLeft
         audienceN.textContent = cursors.size;
       }
     };

--- a/public/valence-viz.html
+++ b/public/valence-viz.html
@@ -1252,7 +1252,11 @@ input[type=range] { width: 100%; accent-color: rgba(255,255,255,0.45); cursor: p
         audienceN.textContent = cursors.size;
       } else if (data.type === 'remove') {
         const { userId } = data.position;
-        cursors.delete(userId);  // thumb lift: keep slot, just freeze valence at 0
+        cursors.delete(userId);
+        if (userId.startsWith('replay_')) {
+          freeLiveSlot(userId);  // playback cursor ended — fully release slot
+        }
+        // real users: keep slot alive, valence freezes at 0 (thumb lift)
         audienceN.textContent = cursors.size;
       }
     };

--- a/public/valence-viz.html
+++ b/public/valence-viz.html
@@ -1261,7 +1261,7 @@ input[type=range] { width: 100%; accent-color: rgba(255,255,255,0.45); cursor: p
 
     ws.onclose = () => {
       wsConnected = false;
-      cursors.clear();
+      freeAllLiveSlots();
       if (btnConnect.classList.contains('disconnecting')) {
         setConnStatus('disconnected', '');
         btnConnect.textContent = 'connect';

--- a/public/valence-viz.html
+++ b/public/valence-viz.html
@@ -1205,10 +1205,10 @@ input[type=range] { width: 100%; accent-color: rgba(255,255,255,0.45); cursor: p
   });
 
   function wsUrl(room) {
-    const host = window.location.hostname === 'localhost'
-      ? 'localhost:1999'
+    const host = window.location.port === '1999'
+      ? `${window.location.hostname}:1999`
       : DEFAULT_HOST;
-    const proto = host.startsWith('localhost') ? 'ws' : 'wss';
+    const proto = window.location.port === '1999' ? 'ws' : 'wss';
     const userId = crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2);
     return `${proto}://${host}/parties/main/${encodeURIComponent(room)}?isAdmin=true&userId=${userId}`;
   }


### PR DESCRIPTION
## Summary

- Adds a **Playback** section to the V4 admin panel for loading and replaying previously recorded JSON files
- The admin loads a `.json` file (produced by the existing record/download feature), then clicks **Play** — the server broadcasts fake cursor events to all connected clients in real time
- Playback cursors appear as **purple dashed circles** (70% opacity) to distinguish them from real participants
- Supports both recording modes: **positions** (raw x/y replay) and **transitions** (cursor snapped to anchor region with deterministic per-user jitter so users don't pile up on the same pixel)
- Clicking **Stop** (or finishing naturally) immediately sends `remove` events for all active playback cursors

## How it works

- Admin client schedules all events client-side with a 50ms polling loop, sending `playbackCursorBroadcast` messages to the server
- Server broadcasts these to **all** clients (including sender), so the admin's own "Peek Canvas" tab also sees the playback
- Playback cursor user IDs use a `replay_` prefix; Canvas renders these with distinct purple/dashed style

## Test plan

- [ ] `npm run dev` — open `localhost:1999/#v4?admin=true` in two tabs
- [ ] In tab 1 (admin): record a short positions-mode session from a third browser at `localhost:1999/#v4`
- [ ] Download the JSON, then load it via "Load JSON file" button
- [ ] Click Play — confirm purple dashed cursors appear on tab 2 (Peek Canvas)
- [ ] Confirm real cursors from tab 3 appear normally alongside playback cursors
- [ ] Click Stop — confirm playback cursors vanish immediately
- [ ] Repeat with a transitions-mode recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)