### PR TITLE
feat(v4): vibe-coding activity — GitHub username submission flow (MVP)

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -28,9 +28,26 @@ jobs:
           script: |
             const num = context.payload.pull_request.number;
             const url = `https://pr-${num}.polislike-partykit-reaction-canvas.patcon.partykit.dev`;
-            github.rest.issues.createComment({
+            const marker = '<!-- preview-url -->';
+            const body = `${marker}\nPreview deployed: ${url}`;
+            const { data: comments } = await github.rest.issues.listComments({
               issue_number: num,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `Preview deployed: ${url}`,
             });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: num,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- V4: vibe-coding activity — admin can push a GitHub username submission form to all participants from the Activities tab; participants are prompted to enter their GitHub username, which is validated against the public GitHub API (avatar + display name shown for confirmation); submissions appear live in a new Events tab in the V4 admin panel and can be downloaded as JSON
 - V4 admin: two new label presets — `genz` (Based / Whack / Mid) and `engagement` (Engaged / Disengaged / Baseline)
 - V4 admin: custom label history — the last 5 applied custom label sets are saved to localStorage and shown as chips below the custom inputs; clicking a chip restores those values, and × removes it from history
 - Onboarding V2: WebSocket connection panel — room input, connect/disconnect button, and live status; connected participants each appear as an additional blue (#4285F4) chord on top of simulated ones, with trace and fill surfaces; cursor color follows group/valence style setting; chord entry/exit animations run even when paused; cursor dot continues updating from live WS data while paused; group palette reordered so blue appears last (index 6) to keep live-user blue visually distinct

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -46,7 +46,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
   }, []);
   const [isRecording, setIsRecording] = useState(false);
   const [mode, setMode] = useState<RecordingMode>('positions');
-  const [configTab, setConfigTab] = useState<'labels' | 'anchors' | 'avatars' | 'activities' | 'events'>('labels');
+  const [configTab, setConfigTab] = useState<'labels' | 'anchors' | 'avatars' | 'interfaces' | 'events'>('labels');
   const [eventCount, setEventCount] = useState(0);
   const [serverRecording, setServerRecording] = useState(false);
   const [userCap, setUserCap] = useState<number | null>(null);
@@ -875,7 +875,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
 
       {/* Tab bar */}
       <div style={{ display: 'flex', gap: 0, marginBottom: 24, borderBottom: '2px solid #444' }}>
-        {(['labels', 'anchors', 'avatars', 'activities', 'events'] as const).map(tab => (
+        {(['labels', 'anchors', 'avatars', 'interfaces', 'events'] as const).map(tab => (
           <button
             key={tab}
             onClick={() => setConfigTab(tab)}
@@ -892,7 +892,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
               textTransform: 'capitalize',
             }}
           >
-            {tab === 'labels' ? 'Labels' : tab === 'anchors' ? 'Anchors' : tab === 'avatars' ? 'Avatars' : tab === 'activities' ? 'Activities' : `Events${githubSubmissions.length > 0 ? ` (${githubSubmissions.length})` : ''}`}
+            {tab === 'labels' ? 'Labels' : tab === 'anchors' ? 'Anchors' : tab === 'avatars' ? 'Avatars' : tab === 'interfaces' ? 'Interfaces' : `Events${githubSubmissions.length > 0 ? ` (${githubSubmissions.length})` : ''}`}
           </button>
         ))}
       </div>
@@ -1115,7 +1115,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
         </div>
       )}
 
-      {configTab === 'activities' && (
+      {configTab === 'interfaces' && (
         <div>
           <p style={{ marginBottom: 12, fontWeight: 600 }}>Activity (shared for all participants):</p>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
@@ -1186,7 +1186,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
             </button>
           </div>
           {githubSubmissions.length === 0 ? (
-            <p style={{ color: '#666', fontSize: 13 }}>No submissions yet. Trigger the activity from the Activities tab.</p>
+            <p style={{ color: '#666', fontSize: 13 }}>No submissions yet. Trigger the activity from the Interfaces tab.</p>
           ) : (
             <div style={{ overflowX: 'auto' }}>
               <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, fontFamily: 'monospace' }}>

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -46,7 +46,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
   }, []);
   const [isRecording, setIsRecording] = useState(false);
   const [mode, setMode] = useState<RecordingMode>('positions');
-  const [configTab, setConfigTab] = useState<'labels' | 'anchors' | 'avatars' | 'activities'>('labels');
+  const [configTab, setConfigTab] = useState<'labels' | 'anchors' | 'avatars' | 'activities' | 'events'>('labels');
   const [eventCount, setEventCount] = useState(0);
   const [serverRecording, setServerRecording] = useState(false);
   const [userCap, setUserCap] = useState<number | null>(null);
@@ -66,6 +66,15 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
   // Activity state
   const [activity, setActivity] = useState<'canvas' | 'soccer'>('canvas');
   const [soccerScore, setSoccerScore] = useState({ left: 0, right: 0 });
+
+  // Events (GitHub submissions) state
+  interface GithubSubmission {
+    username: string;
+    displayName: string | null;
+    avatarUrl: string | null;
+    timestamp: number;
+  }
+  const [githubSubmissions, setGithubSubmissions] = useState<GithubSubmission[]>([]);
 
   // Anchor config state (local editing)
   const defaults = anchorToLocal(DEFAULT_ANCHORS);
@@ -194,6 +203,16 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
         if (data.type === 'userCapChanged') {
           setUserCap(data.cap);
           setCapInput(data.cap !== null ? String(data.cap) : '');
+          return;
+        }
+
+        if (data.type === 'githubUsernameSubmitted') {
+          setGithubSubmissions(prev => [...prev, {
+            username: data.username,
+            displayName: data.displayName ?? null,
+            avatarUrl: data.avatarUrl ?? null,
+            timestamp: data.timestamp,
+          }]);
           return;
         }
 
@@ -566,6 +585,20 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
     socket.send(JSON.stringify({ type: 'resetSoccerScore' }));
   };
 
+  const triggerGithubActivity = () => {
+    socket.send(JSON.stringify({ type: 'triggerActivity', activityName: 'githubUsername' }));
+  };
+
+  const downloadGithubSubmissions = () => {
+    const blob = new Blob([JSON.stringify(githubSubmissions, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `github-submissions-${room}-${new Date().toISOString().replace(/[:.]/g, '-')}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
   const selectPreset = (key: string) => {
     setLabelSelected(key);
     if (key !== 'custom' && key !== 'none') {
@@ -842,7 +875,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
 
       {/* Tab bar */}
       <div style={{ display: 'flex', gap: 0, marginBottom: 24, borderBottom: '2px solid #444' }}>
-        {(['labels', 'anchors', 'avatars', 'activities'] as const).map(tab => (
+        {(['labels', 'anchors', 'avatars', 'activities', 'events'] as const).map(tab => (
           <button
             key={tab}
             onClick={() => setConfigTab(tab)}
@@ -859,7 +892,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
               textTransform: 'capitalize',
             }}
           >
-            {tab === 'labels' ? 'Labels' : tab === 'anchors' ? 'Anchors' : tab === 'avatars' ? 'Avatars' : 'Activities'}
+            {tab === 'labels' ? 'Labels' : tab === 'anchors' ? 'Anchors' : tab === 'avatars' ? 'Avatars' : tab === 'activities' ? 'Activities' : `Events${githubSubmissions.length > 0 ? ` (${githubSubmissions.length})` : ''}`}
           </button>
         ))}
       </div>
@@ -1119,6 +1152,75 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
               <button className="v3-admin-btn v3-admin-btn--destructive" onClick={resetSoccerScore}>
                 Reset Score
               </button>
+            </div>
+          )}
+
+          <div style={{ marginTop: 32, borderTop: '1px solid #444', paddingTop: 20 }}>
+            <p style={{ marginBottom: 4, fontWeight: 600 }}>Vibe coding check-in:</p>
+            <p style={{ marginBottom: 12, color: '#888', fontSize: 13 }}>Push a GitHub username form to all participants. Submissions appear in the Events tab.</p>
+            <button className="v3-admin-btn" onClick={triggerGithubActivity}>
+              Push GitHub login form
+            </button>
+          </div>
+        </div>
+      )}
+
+      {configTab === 'events' && (
+        <div>
+          <div style={{ display: 'flex', gap: 8, marginBottom: 16, alignItems: 'center' }}>
+            <p style={{ fontWeight: 600, margin: 0 }}>GitHub username submissions</p>
+            <button
+              className="v3-admin-btn"
+              onClick={downloadGithubSubmissions}
+              disabled={githubSubmissions.length === 0}
+              style={{ marginLeft: 'auto' }}
+            >
+              ↓ Download JSON
+            </button>
+            <button
+              className="v3-admin-btn v3-admin-btn--destructive"
+              onClick={() => setGithubSubmissions([])}
+              disabled={githubSubmissions.length === 0}
+            >
+              ✕ Clear
+            </button>
+          </div>
+          {githubSubmissions.length === 0 ? (
+            <p style={{ color: '#666', fontSize: 13 }}>No submissions yet. Trigger the activity from the Activities tab.</p>
+          ) : (
+            <div style={{ overflowX: 'auto' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, fontFamily: 'monospace' }}>
+                <thead>
+                  <tr style={{ background: '#222', color: '#aaa', textAlign: 'left' }}>
+                    <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>#</th>
+                    <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>time</th>
+                    <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>avatar</th>
+                    <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>username</th>
+                    <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>display name</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {githubSubmissions.map((s, i) => (
+                    <tr key={i} style={{ background: i % 2 === 0 ? '#1a1a1a' : '#111' }}>
+                      <td style={{ padding: '4px 10px', color: '#555' }}>{i + 1}</td>
+                      <td style={{ padding: '4px 10px', color: '#888' }}>
+                        {new Date(s.timestamp).toISOString().slice(11, 19)}
+                      </td>
+                      <td style={{ padding: '4px 10px' }}>
+                        {s.avatarUrl && (
+                          <img src={s.avatarUrl} alt={s.username} width={24} height={24} style={{ borderRadius: '50%', verticalAlign: 'middle' }} />
+                        )}
+                      </td>
+                      <td style={{ padding: '4px 10px', color: '#9cf' }}>
+                        <a href={`https://github.com/${s.username}`} target="_blank" rel="noopener noreferrer" style={{ color: '#9cf' }}>
+                          @{s.username}
+                        </a>
+                      </td>
+                      <td style={{ padding: '4px 10px', color: '#ccc' }}>{s.displayName ?? ''}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           )}
         </div>

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -1117,7 +1117,8 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
 
       {configTab === 'interfaces' && (
         <div>
-          <p style={{ marginBottom: 12, fontWeight: 600 }}>Activity (shared for all participants):</p>
+          <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>All settings here are shared with all participants in real time.</p>
+          <p style={{ marginBottom: 12, fontWeight: 600 }}>Interfaces:</p>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {([
               { id: 'canvas', label: 'Canvas', desc: 'Standard reaction canvas' },

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -1156,11 +1156,17 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
           )}
 
           <div style={{ marginTop: 32, borderTop: '1px solid #444', paddingTop: 20 }}>
-            <p style={{ marginBottom: 4, fontWeight: 600 }}>Vibe coding check-in:</p>
-            <p style={{ marginBottom: 12, color: '#888', fontSize: 13 }}>Push a GitHub username form to all participants. Submissions appear in the Events tab.</p>
-            <button className="v3-admin-btn" onClick={triggerGithubActivity}>
-              Push GitHub login form
-            </button>
+            <p style={{ marginBottom: 4, fontWeight: 600 }}>Popups</p>
+            <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>Push a one-time form to all participants. Submissions appear in the Events tab.</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <div style={{ background: '#222', border: '1px solid #444', borderRadius: 8, padding: '12px 14px' }}>
+                <p style={{ fontWeight: 600, margin: '0 0 2px' }}>Coder role</p>
+                <p style={{ color: '#888', fontSize: 13, margin: '0 0 10px' }}>Ask participants for their GitHub username to confirm they can contribute code.</p>
+                <button className="v3-admin-btn" onClick={triggerGithubActivity}>
+                  Push popup
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       )}

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -1118,7 +1118,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
       {configTab === 'interfaces' && (
         <div>
           <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>All settings here are shared with all participants in real time.</p>
-          <p style={{ marginBottom: 12, fontWeight: 600 }}>Interfaces:</p>
+          <p style={{ marginBottom: 12, fontWeight: 600 }}>Interfaces</p>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {([
               { id: 'canvas', label: 'Canvas', desc: 'Standard reaction canvas' },

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -40,6 +40,7 @@ interface CanvasProps {
   onSocketReady?: (send: (msg: string) => void) => void;
   debug?: boolean;
   onRoomAvatarStyleChange?: (style: string | null) => void;
+  onActivityTriggered?: (activityName: string) => void;
 }
 
 // Clip an infinite line (defined by two points) to the rectangle [0,w]×[0,h].
@@ -63,7 +64,7 @@ function clipLineToRect(
   return [px + tMin * dx, py + tMin * dy, px + tMax * dx, py + tMax * dy];
 }
 
-export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, debug = false }: CanvasProps) {
+export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, debug = false }: CanvasProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [cursors, setCursors] = useState<Map<string, CursorPosition>>(new Map());
   const [anchors, setAnchors] = useState<ReactionAnchors>(DEFAULT_ANCHORS);
@@ -161,6 +162,11 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
           if (data.ball) setBallPos({ x: data.ball.x, y: data.ball.y });
           if (data.score) setSoccerScore(data.score);
           if (data.activity !== 'soccer') setBallPos(null);
+          return;
+        }
+
+        if (data.type === 'activityTriggered') {
+          onActivityTriggered?.(data.activityName);
           return;
         }
 

--- a/app/components/GithubUsernameModal.tsx
+++ b/app/components/GithubUsernameModal.tsx
@@ -55,10 +55,10 @@ export default function GithubUsernameModal({ onSubmit, onDismiss }: GithubUsern
       <div className="github-modal">
         {step === 'prompt' && (
           <>
-            <p className="github-modal-title">Vibe coding check-in</p>
-            <p className="github-modal-body">The facilitator wants to know who's here.</p>
+            <p className="github-modal-title">Seeking [vibe] coders</p>
+            <p className="github-modal-body">Do you have your laptop? Willing to help improve the system running this event?</p>
             <button className="github-modal-btn-primary" onClick={() => setStep('input')}>
-              Log in with GitHub
+              Share your GitHub handle
             </button>
             <button className="github-modal-btn-dismiss" onClick={onDismiss}>Not now</button>
           </>

--- a/app/components/GithubUsernameModal.tsx
+++ b/app/components/GithubUsernameModal.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+
+interface GithubUser {
+  login: string;
+  name: string | null;
+  avatar_url: string;
+}
+
+interface GithubUsernameModalProps {
+  onSubmit: (username: string, displayName: string | null, avatarUrl: string | null) => void;
+  onDismiss: () => void;
+}
+
+export default function GithubUsernameModal({ onSubmit, onDismiss }: GithubUsernameModalProps) {
+  const [step, setStep] = useState<'prompt' | 'input' | 'confirm' | 'done'>('prompt');
+  const [usernameInput, setUsernameInput] = useState('');
+  const [resolvedUser, setResolvedUser] = useState<GithubUser | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const lookupUsername = async () => {
+    const username = usernameInput.trim();
+    if (!username) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`https://api.github.com/users/${encodeURIComponent(username)}`);
+      if (res.status === 404) {
+        setError('GitHub user not found. Check the username and try again.');
+        setLoading(false);
+        return;
+      }
+      if (!res.ok) {
+        setError('Could not reach GitHub. Try again.');
+        setLoading(false);
+        return;
+      }
+      const data: GithubUser = await res.json();
+      setResolvedUser(data);
+      setStep('confirm');
+    } catch {
+      setError('Network error. Try again.');
+    }
+    setLoading(false);
+  };
+
+  const handleConfirm = () => {
+    if (!resolvedUser) return;
+    onSubmit(resolvedUser.login, resolvedUser.name, resolvedUser.avatar_url);
+    setStep('done');
+  };
+
+  return (
+    <div className="github-modal-overlay" onClick={e => { if (e.target === e.currentTarget) onDismiss(); }}>
+      <div className="github-modal">
+        {step === 'prompt' && (
+          <>
+            <p className="github-modal-title">Vibe coding check-in</p>
+            <p className="github-modal-body">The facilitator wants to know who's here.</p>
+            <button className="github-modal-btn-primary" onClick={() => setStep('input')}>
+              Log in with GitHub
+            </button>
+            <button className="github-modal-btn-dismiss" onClick={onDismiss}>Not now</button>
+          </>
+        )}
+
+        {step === 'input' && (
+          <>
+            <p className="github-modal-title">Enter your GitHub username</p>
+            <input
+              className="github-modal-input"
+              type="text"
+              value={usernameInput}
+              onChange={e => { setUsernameInput(e.target.value); setError(null); }}
+              onKeyDown={e => { if (e.key === 'Enter') lookupUsername(); }}
+              placeholder="username"
+              autoFocus
+              autoCapitalize="none"
+              autoCorrect="off"
+            />
+            {error && <p className="github-modal-error">{error}</p>}
+            <button
+              className="github-modal-btn-primary"
+              onClick={lookupUsername}
+              disabled={loading || !usernameInput.trim()}
+            >
+              {loading ? 'Checking…' : 'Verify'}
+            </button>
+            <button className="github-modal-btn-dismiss" onClick={() => setStep('prompt')}>Back</button>
+          </>
+        )}
+
+        {step === 'confirm' && resolvedUser && (
+          <>
+            <p className="github-modal-title">Is this you?</p>
+            <div className="github-modal-user-card">
+              <img
+                src={resolvedUser.avatar_url}
+                alt={resolvedUser.login}
+                className="github-modal-avatar"
+              />
+              <div>
+                <p className="github-modal-display-name">{resolvedUser.name || resolvedUser.login}</p>
+                <p className="github-modal-login">@{resolvedUser.login}</p>
+              </div>
+            </div>
+            <button className="github-modal-btn-primary" onClick={handleConfirm}>
+              Yes, that's me
+            </button>
+            <button className="github-modal-btn-dismiss" onClick={() => { setStep('input'); setResolvedUser(null); }}>
+              Not me
+            </button>
+          </>
+        )}
+
+        {step === 'done' && (
+          <>
+            <p className="github-modal-title">Thanks!</p>
+            <p className="github-modal-body">Your GitHub username has been shared with the facilitator.</p>
+            <button className="github-modal-btn-primary" onClick={onDismiss}>Close</button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/GithubUsernameModal.tsx
+++ b/app/components/GithubUsernameModal.tsx
@@ -116,7 +116,7 @@ export default function GithubUsernameModal({ onSubmit, onDismiss }: GithubUsern
         {step === 'done' && (
           <>
             <p className="github-modal-title">Thanks!</p>
-            <p className="github-modal-body">Your GitHub username has been shared with the facilitator.</p>
+            <p className="github-modal-body">Your GitHub username has been shared with the emcee.</p>
             <button className="github-modal-btn-primary" onClick={onDismiss}>Close</button>
           </>
         )}

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -3,6 +3,7 @@ import { QRCodeSVG } from "qrcode.react";
 import Canvas from "./Canvas";
 import TouchLayer from "./TouchLayer";
 import AdminPanelV4 from "./AdminPanelV4";
+import GithubUsernameModal from "./GithubUsernameModal";
 import { DEFAULT_ANCHORS, reactionLabelStyle } from "../utils/voteRegion";
 import type { ReactionAnchors } from "../utils/voteRegion";
 import { getReactionLabelSet } from "../voteLabels";
@@ -66,6 +67,7 @@ export default function ReactionCanvasAppV4() {
   const [serverAnchors, setServerAnchors] = useState<ReactionAnchors | null>(null);
   const [debug, setDebug] = useState(() => new URLSearchParams(window.location.search).get('debug') === '1');
   const reactionStateRef = useRef<ReactionState>(null);
+  const [showGithubModal, setShowGithubModal] = useState(false);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -141,6 +143,9 @@ export default function ReactionCanvasAppV4() {
           onUserCapChanged={setUserCap}
           onJoinApproved={() => setIsViewer(false)}
           onSocketReady={(send) => { socketSendRef.current = send; }}
+          onActivityTriggered={(activityName) => {
+            if (activityName === 'githubUsername') setShowGithubModal(true);
+          }}
           debug={debug}
         />
         {!isViewer && (
@@ -154,6 +159,20 @@ export default function ReactionCanvasAppV4() {
             onTouchPosition={setTouchPos}
             heightOffset={0}
             anchors={anchors}
+          />
+        )}
+        {showGithubModal && (
+          <GithubUsernameModal
+            onSubmit={(username, displayName, avatarUrl) => {
+              socketSendRef.current?.(JSON.stringify({
+                type: 'submitGithubUsername',
+                username,
+                displayName,
+                avatarUrl,
+                timestamp: Date.now(),
+              }));
+            }}
+            onDismiss={() => setShowGithubModal(false)}
           />
         )}
       </div>

--- a/app/styles.css
+++ b/app/styles.css
@@ -1369,3 +1369,113 @@ body {
 .vviz-tcol-flex .vviz-tcol-lbl { padding: 0; border: none; margin-bottom: 2px; }
 .vviz-tcol-flex input[type=range] { width: 100%; accent-color: rgba(255,255,255,0.45); cursor: pointer; }
 .vviz-row-particle { display: flex; align-items: stretch; border: 0.5px solid rgba(255,255,255,0.12); border-radius: 5px; overflow: hidden; }
+
+/* GitHub username modal */
+.github-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.72);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+.github-modal {
+  background: #1a1a1a;
+  border: 1px solid #444;
+  border-radius: 12px;
+  padding: 28px 24px;
+  width: 100%;
+  max-width: 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  color: #eee;
+}
+.github-modal-title {
+  font-size: 18px;
+  font-weight: 700;
+  margin: 0;
+}
+.github-modal-body {
+  font-size: 14px;
+  color: #aaa;
+  margin: 0;
+}
+.github-modal-input {
+  background: #333;
+  border: 1px solid #555;
+  color: #eee;
+  padding: 10px 12px;
+  border-radius: 6px;
+  font-size: 16px;
+  width: 100%;
+  box-sizing: border-box;
+}
+.github-modal-input:focus {
+  outline: none;
+  border-color: #888;
+}
+.github-modal-error {
+  color: #f77;
+  font-size: 13px;
+  margin: 0;
+}
+.github-modal-btn-primary {
+  background: #2a5cba;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 12px 16px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  width: 100%;
+}
+.github-modal-btn-primary:hover:not(:disabled) {
+  background: #3a6ccf;
+}
+.github-modal-btn-primary:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+.github-modal-btn-dismiss {
+  background: none;
+  border: none;
+  color: #888;
+  font-size: 13px;
+  cursor: pointer;
+  padding: 4px 0;
+  text-align: center;
+  width: 100%;
+}
+.github-modal-btn-dismiss:hover {
+  color: #ccc;
+}
+.github-modal-user-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  background: #222;
+  border: 1px solid #444;
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+.github-modal-avatar {
+  width: 52px;
+  height: 52px;
+  border-radius: 50%;
+  border: 2px solid #555;
+  flex-shrink: 0;
+}
+.github-modal-display-name {
+  font-weight: 600;
+  font-size: 15px;
+  margin: 0 0 2px;
+}
+.github-modal-login {
+  color: #888;
+  font-size: 13px;
+  margin: 0;
+}

--- a/party/server.ts
+++ b/party/server.ts
@@ -115,6 +115,19 @@ interface SetUserCapEvent {
   cap: number | null;
 }
 
+interface TriggerActivityEvent {
+  type: 'triggerActivity';
+  activityName: 'githubUsername';
+}
+
+interface SubmitGithubUsernameEvent {
+  type: 'submitGithubUsername';
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  timestamp: number;
+}
+
 interface RequestJoinEvent {
   type: 'requestJoin';
 }
@@ -132,7 +145,7 @@ interface Vote {
   timestamp: number;
 }
 
-type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent;
+type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent;
 
 // ===== SOCCER PHYSICS CONSTANTS =====
 const SOCCER_BALL_R = 2;      // % of canvas
@@ -161,6 +174,7 @@ export default class Server implements Party.Server {
   private currentActivity: 'canvas' | 'soccer' = 'canvas';
   private ballState = { x: 50, y: 50, vx: 2, vy: 1 };
   private soccerScore = { left: 0, right: 0 };
+  private githubSubmissions: { username: string; displayName: string | null; avatarUrl: string | null; timestamp: number }[] = [];
   private soccerInterval?: NodeJS.Timeout;
   private cursorPositions = new Map<string, { x: number; y: number }>();
 
@@ -371,6 +385,18 @@ export default class Server implements Party.Server {
         if (!this.adminConnectionIds.has(sender.id)) return;
         this.userCap = event.cap;
         this.room.broadcast(JSON.stringify({ type: 'userCapChanged', cap: this.userCap }));
+      } else if (event.type === 'triggerActivity') {
+        this.room.broadcast(JSON.stringify({ type: 'activityTriggered', activityName: event.activityName }));
+      } else if (event.type === 'submitGithubUsername') {
+        const submission = {
+          username: event.username,
+          displayName: event.displayName,
+          avatarUrl: event.avatarUrl,
+          timestamp: event.timestamp || Date.now(),
+        };
+        this.githubSubmissions.push(submission);
+        // Broadcast to admins so they see it live
+        this.room.broadcast(JSON.stringify({ type: 'githubUsernameSubmitted', ...submission }));
       } else if (event.type === 'requestJoin') {
         if (!this.viewerConnectionIds.has(sender.id)) return;
         if (this.userCap !== null && this.participantCount() >= this.userCap) {
@@ -913,6 +939,19 @@ export default class Server implements Party.Server {
       this.votes = [];
       console.log(`[VOTE] All votes cleared successfully`);
       return new Response(JSON.stringify({ success: true, message: "All votes cleared" }), {
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    if (request.method === "GET" && url.pathname.endsWith("/github-submissions")) {
+      return new Response(JSON.stringify(this.githubSubmissions), {
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    if (request.method === "DELETE" && url.pathname.endsWith("/github-submissions")) {
+      this.githubSubmissions = [];
+      return new Response(JSON.stringify({ success: true }), {
         headers: { "Content-Type": "application/json" }
       });
     }


### PR DESCRIPTION
MVP implementation of #16.

## What's in here

- **Interfaces tab** in V4 admin (renamed from Activities) with a shared note at the top
- **Popups section** under Interfaces — extensible card-per-popup layout, with the first card being "Coder role"
- **Coder role popup**: admin clicks "Push popup" → all participants see a modal overlay titled "Seeking [vibe] coders" asking if they have a laptop and want to help; they can share their GitHub handle (validated against the public GitHub API — avatar + display name shown for confirmation) or dismiss
- **Events tab** in V4 admin shows submitted handles live (with avatar, username, display name, timestamp), count badge on tab, download as JSON, clear
- **CI fix**: preview URL comment is now posted once per PR and updated in place on re-runs, instead of creating a new comment each time

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~100 words of PR description from ~200 words of human prompts across this session)