### PR TITLE
feat: share QR button on reaction canvas (V2/V4/V5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- V2/V4/V5: share QR button — a small icon in the top-right corner of the reaction canvas opens a full-screen QR code modal showing the current page URL (with `forceView` param stripped), so participants can easily invite others
 - V4: vibe-coding activity — admin can push a GitHub username submission form to all participants from the Activities tab; participants are prompted to enter their GitHub username, which is validated against the public GitHub API (avatar + display name shown for confirmation); submissions appear live in a new Events tab in the V4 admin panel and can be downloaded as JSON
 - V4 admin: two new label presets — `genz` (Based / Whack / Mid) and `engagement` (Engaged / Disengaged / Baseline)
 - V4 admin: custom label history — the last 5 applied custom label sets are saved to localStorage and shown as chips below the custom inputs; clicking a chip restores those values, and × removes it from history

--- a/app/components/ReactionCanvasAppV2.tsx
+++ b/app/components/ReactionCanvasAppV2.tsx
@@ -7,6 +7,7 @@ import type { ReactionLabelSet } from "../voteLabels";
 import { DEFAULT_ANCHORS, reactionLabelStyle } from "../utils/voteRegion";
 import type { ReactionAnchors } from "../utils/voteRegion";
 import { getPersistentUserId } from "../utils/userId";
+import ShareQRButton from "./ShareQRButton";
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
 
@@ -206,6 +207,7 @@ export default function ReactionCanvasAppV2({ videoId: videoIdProp }: { videoId?
           {viewerCount > 0 && <> · <span className="v2-counter-num">{viewerCount}</span> watching</>}
         </div>
         <div className="debug-hint">{debug ? 'd: debug on' : 'd: debug'}</div>
+        <ShareQRButton />
         {touchPos && (
           <div
             className="v2-touch-indicator"

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -9,6 +9,7 @@ import type { ReactionAnchors } from "../utils/voteRegion";
 import { getReactionLabelSet } from "../voteLabels";
 import type { ReactionLabelSet } from "../voteLabels";
 import { getPersistentUserId } from "../utils/userId";
+import ShareQRButton from "./ShareQRButton";
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
 
@@ -120,6 +121,7 @@ export default function ReactionCanvasAppV4() {
         </div>
         <div className="debug-hint">{debug ? 'd: debug on' : 'd: debug'}</div>
         <div className={`v3-rec-badge${isRecording ? '' : ' v3-rec-badge--off'}`}>● REC</div>
+        <ShareQRButton />
         {touchPos && (
           <div
             className="v2-touch-indicator"

--- a/app/components/ReactionCanvasAppV5.tsx
+++ b/app/components/ReactionCanvasAppV5.tsx
@@ -11,6 +11,7 @@ import type { ReactionAnchors } from "../utils/voteRegion";
 import { insertEvent, fetchEvents, isSupabaseConfigured, testConnection } from "../lib/supabase";
 import type { ReactionEvent } from "../lib/supabase";
 import { getPersistentUserId } from "../utils/userId";
+import ShareQRButton from "./ShareQRButton";
 
 declare global {
   interface Window {
@@ -236,6 +237,7 @@ export default function ReactionCanvasAppV5() {
         {labels && <div className="reaction-label reaction-label-neutral" style={reactionLabelStyle(anchors.neutral)}>{labels.neutral}</div>}
         <div className={`v3-rec-badge v3-rec-badge--left${isSupabaseConfigured ? '' : ' v3-rec-badge--off'}`}>● REC</div>
         <div className="debug-hint">{debug ? 'd: debug on' : 'd: debug'}</div>
+        <ShareQRButton />
         {touchPos && (
           <div
             className="v5-touch-indicator"

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+
+function getShareUrl(): string {
+  const p = new URLSearchParams(window.location.search);
+  p.delete('forceView');
+  const qs = p.toString();
+  return `${window.location.origin}${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
+}
+
+export default function ShareQRButton() {
+  const [isOpen, setIsOpen] = useState(false);
+  const url = getShareUrl();
+
+  return (
+    <>
+      <button className="share-qr-btn" onClick={() => setIsOpen(true)} aria-label="Share link">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" /><rect x="3" y="14" width="7" height="7" />
+          <line x1="14" y1="17.5" x2="21" y2="17.5" /><line x1="17.5" y1="14" x2="17.5" y2="21" />
+        </svg>
+      </button>
+      {isOpen && (
+        <div className="share-qr-modal" onClick={() => setIsOpen(false)}>
+          <div className="share-qr-modal-card" onClick={e => e.stopPropagation()}>
+            <p className="share-qr-modal-title">Share this page</p>
+            <div className="v2-mobile-gate-qr">
+              <QRCodeSVG value={url} size={220} />
+            </div>
+            <p className="share-qr-modal-url">{url}</p>
+            <button className="share-qr-modal-close" onClick={() => setIsOpen(false)}>Close</button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/styles.css
+++ b/app/styles.css
@@ -1477,8 +1477,8 @@ body {
 /* Share QR Button */
 .share-qr-btn {
   position: absolute;
-  top: 12px;
-  left: 12px;
+  top: 44px;
+  left: 8px;
   z-index: 200;
   background: rgba(0, 0, 0, 0.35);
   border: none;

--- a/app/styles.css
+++ b/app/styles.css
@@ -1501,7 +1501,7 @@ body {
 .share-qr-modal {
   position: fixed;
   inset: 0;
-  z-index: 300;
+  z-index: 2000;
   background: rgba(0, 0, 0, 0.75);
   display: flex;
   align-items: center;

--- a/app/styles.css
+++ b/app/styles.css
@@ -882,7 +882,7 @@ body {
 .v2-presence-counter {
   position: absolute;
   top: 8px;
-  left: 8px;
+  left: 56px;
   z-index: 20;
   background: rgba(0, 0, 0, 0.45);
   color: #fff;
@@ -1062,6 +1062,7 @@ body {
 .v3-rec-badge--left {
   right: unset;
   left: 8px;
+  top: 100px;
 }
 
 /* V3: Admin panel container */
@@ -1179,13 +1180,14 @@ body {
 .github-corner {
   position: fixed;
   top: 0;
-  right: 0;
+  left: 0;
   z-index: 9999;
 }
 
 .github-corner svg {
   fill: #151513;
   color: #fff;
+  transform: scaleX(-1);
 }
 
 .github-corner:hover .octo-arm {
@@ -1477,7 +1479,7 @@ body {
 /* Share QR Button */
 .share-qr-btn {
   position: absolute;
-  top: 44px;
+  top: 58px;
   left: 8px;
   z-index: 200;
   background: rgba(0, 0, 0, 0.35);

--- a/app/styles.css
+++ b/app/styles.css
@@ -1474,6 +1474,82 @@ body {
   font-size: 15px;
   margin: 0 0 2px;
 }
+/* Share QR Button */
+.share-qr-btn {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 200;
+  background: rgba(0, 0, 0, 0.35);
+  border: none;
+  border-radius: 8px;
+  color: #fff;
+  cursor: pointer;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.6;
+}
+
+.share-qr-btn:hover {
+  opacity: 0.9;
+}
+
+.share-qr-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 300;
+  background: rgba(0, 0, 0, 0.75);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.share-qr-modal-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #1a1a1a;
+  border-radius: 16px;
+  padding: 32px 28px 24px;
+  max-width: 320px;
+  width: 90vw;
+  text-align: center;
+  gap: 16px;
+}
+
+.share-qr-modal-title {
+  color: #fff;
+  font-size: 18px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.share-qr-modal-url {
+  font-size: 11px;
+  color: #666;
+  word-break: break-all;
+  font-family: monospace;
+  margin: 0;
+}
+
+.share-qr-modal-close {
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  border-radius: 8px;
+  color: #aaa;
+  cursor: pointer;
+  font-size: 14px;
+  padding: 8px 24px;
+  margin-top: 4px;
+}
+
+.share-qr-modal-close:hover {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+}
+
 .github-modal-login {
   color: #888;
   font-size: 13px;


### PR DESCRIPTION
## Summary

- Adds a small share icon button to the top-left of the reaction canvas (V2, V4, V5) that opens a full-screen QR code modal showing the current page URL — so participants on mobile can easily invite others without leaving the canvas
- `forceView=mobile` is stripped from the share URL so new visitors get the correct experience
- Moves the GitHub corner from top-right to top-left (SVG mirrored via `scaleX(-1)`), and shuffles the presence counter, REC badge, and share button to avoid overlaps
- Modal z-index raised above reaction labels (1000) but below the GitHub corner (9999)

## Test plan

- [ ] Open `/#v4?forceView=mobile` — share icon appears top-left below the GitHub corner
- [ ] Tap icon → full-screen QR modal appears, reaction labels are behind the overlay, GitHub corner stays on top
- [ ] Tap outside card or Close → modal dismisses
- [ ] Inspect/scan QR URL — `forceView` param should be absent
- [ ] Repeat on `/#v2?room=<id>&forceView=mobile` and `/#v5?room=<id>&forceView=mobile`
- [ ] Confirm presence counter, REC badge, and share button don't overlap each other or the corner

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~120 words of PR description from ~60 words of human prompts across this session)