### PR TITLE
feat: Image Canvas interface mode

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: 18
           cache: "npm"
       - run: npm ci
-      - run: npx partykit delete --preview pr-${{ github.event.pull_request.number }} --yes
+      - run: npx partykit delete --preview pr-${{ github.event.pull_request.number }} --force
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- V4 admin: Image Canvas interface mode — admin selects "Image Canvas" in the Interfaces tab and uses the adjacent "config" link to set a public image URL; the image is broadcast to all participants as the canvas background (fitted with `object-fit: contain`); cursor positions are normalized to image-relative coordinates so reactions stay anchored to the same image content regardless of screen size
+- V4 admin: renamed "Canvas" interface option to "Reaction Canvas" in the Interfaces tab
 - V2/V4/V5: share QR button — a small icon in the top-right corner of the reaction canvas opens a full-screen QR code modal showing the current page URL (with `forceView` param stripped), so participants can easily invite others
 - V4: vibe-coding activity — admin can push a GitHub username submission form to all participants from the Activities tab; participants are prompted to enter their GitHub username, which is validated against the public GitHub API (avatar + display name shown for confirmation); submissions appear live in a new Events tab in the V4 admin panel and can be downloaded as JSON
 - V4 admin: two new label presets — `genz` (Based / Whack / Mid) and `engagement` (Engaged / Disengaged / Baseline)

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -5,6 +5,7 @@ import type { ReactionRegion, ReactionAnchors } from "../utils/voteRegion";
 import { REACTION_LABEL_PRESETS, getCustomLabelHistory, saveCustomLabelToHistory, removeCustomLabelFromHistory } from "../voteLabels";
 import type { ReactionLabelSet } from "../voteLabels";
 import Canvas from "./Canvas";
+import ImageConfigModal from "./ImageConfigModal";
 
 interface AdminPanelV4Props {
   room: string;
@@ -64,8 +65,10 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
   const [avatarStyle, setAvatarStyle] = useState<string | null>(null);
 
   // Activity state
-  const [activity, setActivity] = useState<'canvas' | 'soccer'>('canvas');
+  const [activity, setActivity] = useState<'canvas' | 'soccer' | 'image-canvas'>('canvas');
   const [soccerScore, setSoccerScore] = useState({ left: 0, right: 0 });
+  const [imageConfigOpen, setImageConfigOpen] = useState(false);
+  const [roomImageUrl, setRoomImageUrl] = useState('');
 
   // Events (GitHub submissions) state
   interface GithubSubmission {
@@ -167,6 +170,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
           if ('roomAnchors' in data) applyServerAnchors(data.roomAnchors);
           if ('roomAvatarStyle' in data) setAvatarStyle(data.roomAvatarStyle ?? null);
           if ('currentActivity' in data) setActivity(data.currentActivity ?? 'canvas');
+          if ('roomImageUrl' in data) setRoomImageUrl(data.roomImageUrl ?? '');
           if ('soccerScore' in data && data.soccerScore) setSoccerScore(data.soccerScore);
           if (data.userCap !== undefined) {
             setUserCap(data.userCap);
@@ -192,6 +196,11 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
 
         if (data.type === 'activityChanged') {
           setActivity(data.activity ?? 'canvas');
+          return;
+        }
+
+        if (data.type === 'imageUrlChanged') {
+          setRoomImageUrl(data.url ?? '');
           return;
         }
 
@@ -576,9 +585,14 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
     socket.send(JSON.stringify({ type: 'setRoomAvatarStyle', avatarStyle: style }));
   };
 
-  const sendActivity = (act: 'canvas' | 'soccer') => {
+  const sendActivity = (act: 'canvas' | 'soccer' | 'image-canvas') => {
     setActivity(act);
     socket.send(JSON.stringify({ type: 'setActivity', activity: act }));
+  };
+
+  const sendImageUrl = (url: string) => {
+    setRoomImageUrl(url);
+    socket.send(JSON.stringify({ type: 'setImageUrl', url }));
   };
 
   const resetSoccerScore = () => {
@@ -1121,7 +1135,8 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
           <p style={{ marginBottom: 12, fontWeight: 600 }}>Interfaces</p>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
             {([
-              { id: 'canvas', label: 'Canvas', desc: 'Standard reaction canvas' },
+              { id: 'canvas', label: 'Reaction Canvas', desc: 'Standard reaction canvas' },
+              { id: 'image-canvas', label: 'Image Canvas', desc: 'React over a shared background image' },
               { id: 'soccer', label: 'Soccer', desc: 'Top-down physics ball — kick with your cursor' },
             ] as const).map(({ id, label, desc }) => (
               <label key={id} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}>
@@ -1136,6 +1151,14 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
                 <div>
                   <span style={{ fontWeight: activity === id ? 600 : 400 }}>{label}</span>
                   <span style={{ color: '#888', fontSize: 13, marginLeft: 8 }}>{desc}</span>
+                  {id === 'image-canvas' && (
+                    <button
+                      className="image-canvas-config-link"
+                      onClick={e => { e.preventDefault(); setImageConfigOpen(true); }}
+                    >
+                      config
+                    </button>
+                  )}
                 </div>
               </label>
             ))}
@@ -1287,6 +1310,13 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
         </div>
       )}
       </div>}
+      {imageConfigOpen && (
+        <ImageConfigModal
+          currentUrl={roomImageUrl}
+          onSubmit={sendImageUrl}
+          onClose={() => setImageConfigOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -417,8 +417,8 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
       const dispH = imageNaturalSize.h * scale;
       const offX = (dimensions.width - dispW) / 2;
       const offY = (dimensions.height - dispH) / 2;
-      toScreenX = (n: number) => offX + (n / 100) * dispW;
-      toScreenY = (n: number) => offY + (n / 100) * dispH;
+      toScreenX = (n: number) => Math.max(0, Math.min(dimensions.width, offX + (n / 100) * dispW));
+      toScreenY = (n: number) => Math.max(0, Math.min(dimensions.height, offY + (n / 100) * dispH));
     }
 
     const cursorData = Array.from(cursors.entries()).map(([cursorUserId, cursor]) => ({

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -535,10 +535,13 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
       width={dimensions.width}
       height={dimensions.height}
       style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
         width: '100%',
         height: '100%',
-        zIndex: 1, // Lower z-index for rendering layer
-        pointerEvents: 'none' // Don't capture events, let TouchLayer handle them
+        zIndex: 1,
+        pointerEvents: 'none'
       }}
     />
   );

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -42,6 +42,7 @@ interface CanvasProps {
   onRoomAvatarStyleChange?: (style: string | null) => void;
   onActivityTriggered?: (activityName: string) => void;
   onRoomImageUrlChange?: (url: string) => void;
+  onActivityChange?: (activity: 'canvas' | 'soccer' | 'image-canvas') => void;
 }
 
 // Clip an infinite line (defined by two points) to the rectangle [0,w]×[0,h].
@@ -65,7 +66,7 @@ function clipLineToRect(
   return [px + tMin * dx, py + tMin * dy, px + tMax * dx, py + tMax * dy];
 }
 
-export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onRoomImageUrlChange, debug = false }: CanvasProps) {
+export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onRoomImageUrlChange, onActivityChange, debug = false }: CanvasProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [cursors, setCursors] = useState<Map<string, CursorPosition>>(new Map());
   const [anchors, setAnchors] = useState<ReactionAnchors>(DEFAULT_ANCHORS);
@@ -122,7 +123,11 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
             setAvatarStyle(data.roomAvatarStyle ?? null);
             onRoomAvatarStyleChange?.(data.roomAvatarStyle ?? null);
           }
-          if ('currentActivity' in data) setActivity(data.currentActivity ?? 'canvas');
+          if ('currentActivity' in data) {
+            const act = data.currentActivity ?? 'canvas';
+            setActivity(act);
+            onActivityChange?.(act);
+          }
           if ('roomImageUrl' in data) {
             const url = data.roomImageUrl ?? '';
             setImageUrl(url);
@@ -181,7 +186,9 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
         }
 
         if (data.type === 'activityChanged') {
-          setActivity(data.activity ?? 'canvas');
+          const act = data.activity ?? 'canvas';
+          setActivity(act);
+          onActivityChange?.(act);
           if (data.ball) setBallPos({ x: data.ball.x, y: data.ball.y });
           if (data.score) setSoccerScore(data.score);
           if (data.activity !== 'soccer') setBallPos(null);

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -41,6 +41,7 @@ interface CanvasProps {
   debug?: boolean;
   onRoomAvatarStyleChange?: (style: string | null) => void;
   onActivityTriggered?: (activityName: string) => void;
+  onRoomImageUrlChange?: (url: string) => void;
 }
 
 // Clip an infinite line (defined by two points) to the rectangle [0,w]×[0,h].
@@ -64,12 +65,14 @@ function clipLineToRect(
   return [px + tMin * dx, py + tMin * dy, px + tMax * dx, py + tMax * dy];
 }
 
-export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, debug = false }: CanvasProps) {
+export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onRoomImageUrlChange, debug = false }: CanvasProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [cursors, setCursors] = useState<Map<string, CursorPosition>>(new Map());
   const [anchors, setAnchors] = useState<ReactionAnchors>(DEFAULT_ANCHORS);
   const [avatarStyle, setAvatarStyle] = useState<string | null>(null);
-  const [activity, setActivity] = useState<'canvas' | 'soccer'>('canvas');
+  const [activity, setActivity] = useState<'canvas' | 'soccer' | 'image-canvas'>('canvas');
+  const [imageUrl, setImageUrl] = useState('');
+  const [imageNaturalSize, setImageNaturalSize] = useState<{ w: number; h: number } | null>(null);
   const [ballPos, setBallPos] = useState<{ x: number; y: number } | null>(null);
   const [soccerScore, setSoccerScore] = useState({ left: 0, right: 0 });
 
@@ -78,6 +81,14 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
     const simulatedCount = Array.from(cursors.keys()).filter(id => id.startsWith('replay_')).length;
     onSimulatedCursorCountChange?.(simulatedCount);
   }, [cursors.size]);
+
+  useEffect(() => {
+    if (!imageUrl) { setImageNaturalSize(null); return; }
+    const img = new Image();
+    img.onload = () => setImageNaturalSize({ w: img.naturalWidth, h: img.naturalHeight });
+    img.onerror = () => setImageNaturalSize(null);
+    img.src = imageUrl;
+  }, [imageUrl]);
 
   const [dimensions, setDimensions] = useState({
     width: window.innerWidth,
@@ -112,6 +123,11 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
             onRoomAvatarStyleChange?.(data.roomAvatarStyle ?? null);
           }
           if ('currentActivity' in data) setActivity(data.currentActivity ?? 'canvas');
+          if ('roomImageUrl' in data) {
+            const url = data.roomImageUrl ?? '';
+            setImageUrl(url);
+            onRoomImageUrlChange?.(url);
+          }
           if ('ballState' in data && data.ballState) setBallPos({ x: data.ballState.x, y: data.ballState.y });
           if ('soccerScore' in data && data.soccerScore) setSoccerScore(data.soccerScore);
           onConnectedAsViewer?.(data.isViewer ?? false, data.userCap ?? null);
@@ -154,6 +170,13 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
         if (data.type === 'roomAvatarStyleChanged') {
           setAvatarStyle(data.avatarStyle ?? null);
           onRoomAvatarStyleChange?.(data.avatarStyle ?? null);
+          return;
+        }
+
+        if (data.type === 'imageUrlChanged') {
+          const url = data.url ?? '';
+          setImageUrl(url);
+          onRoomImageUrlChange?.(url);
           return;
         }
 
@@ -259,14 +282,14 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
     // Clear previous content
     svg.selectAll("*").remove();
 
-    // Add background rectangle with default color
+    // Add background rectangle with default color (transparent in image-canvas mode)
     svg.append('rect')
       .attr('width', dimensions.width)
       .attr('height', dimensions.height)
-      .attr('fill', 'rgba(255, 255, 255, 0.1)'); // Default transparent white
+      .attr('fill', imageUrl ? 'transparent' : 'rgba(255, 255, 255, 0.1)');
 
-    // Apply current reaction state color if any
-    if (currentReactionState) {
+    // Apply current reaction state color if any (skip in image-canvas mode)
+    if (currentReactionState && !imageUrl) {
       updateBackgroundColor(currentReactionState);
     }
 
@@ -384,13 +407,26 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
 
     // Add cursor positions as colored dots - convert normalized coordinates to pixels
     if (hideCursors) return;
+
+    // When an image is active, map image-relative 0-100 coords to screen pixels
+    let toScreenX = (n: number) => (n / 100) * dimensions.width;
+    let toScreenY = (n: number) => (n / 100) * dimensions.height;
+    if (imageUrl && imageNaturalSize) {
+      const scale = Math.min(dimensions.width / imageNaturalSize.w, dimensions.height / imageNaturalSize.h);
+      const dispW = imageNaturalSize.w * scale;
+      const dispH = imageNaturalSize.h * scale;
+      const offX = (dimensions.width - dispW) / 2;
+      const offY = (dimensions.height - dispH) / 2;
+      toScreenX = (n: number) => offX + (n / 100) * dispW;
+      toScreenY = (n: number) => offY + (n / 100) * dispH;
+    }
+
     const cursorData = Array.from(cursors.entries()).map(([cursorUserId, cursor]) => ({
       cursorUserId,
-      x: (cursor.x / 100) * dimensions.width, // Convert from 0-100 to pixel coordinates
-      y: (cursor.y / 100) * dimensions.height, // Convert from 0-100 to pixel coordinates
+      x: toScreenX(cursor.x),
+      y: toScreenY(cursor.y),
       timestamp: cursor.timestamp,
       userId: cursor.userId,
-      // Calculate reaction state on client side for coloring
       reactionState: colorCursorsByVote ? computeReactionRegion(cursor.x, cursor.y, anchors) : null
     }));
 
@@ -475,7 +511,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
         .text((d: any) => d.cursorUserId.substring(0, 6));
     }
 
-  }, [cursors, dimensions, anchors, debug, hideCursors, avatarStyle, activity, ballPos, soccerScore]);
+  }, [cursors, dimensions, anchors, debug, hideCursors, avatarStyle, activity, ballPos, soccerScore, imageUrl, imageNaturalSize]);
 
   // Handle window resize
   useEffect(() => {

--- a/app/components/ImageConfigModal.tsx
+++ b/app/components/ImageConfigModal.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 
+const DEFAULT_IMAGE_URL = 'https://pbs.twimg.com/media/DY_tjS0WsAADhmT.jpg';
+
 interface ImageConfigModalProps {
   onSubmit: (url: string) => void;
   onClose: () => void;
@@ -7,7 +9,7 @@ interface ImageConfigModalProps {
 }
 
 export default function ImageConfigModal({ onSubmit, onClose, currentUrl }: ImageConfigModalProps) {
-  const [urlInput, setUrlInput] = useState(currentUrl ?? '');
+  const [urlInput, setUrlInput] = useState(currentUrl ?? DEFAULT_IMAGE_URL);
 
   const handleSubmit = () => {
     const url = urlInput.trim();
@@ -25,15 +27,39 @@ export default function ImageConfigModal({ onSubmit, onClose, currentUrl }: Imag
       <div className="github-modal">
         <p className="github-modal-title">Image Canvas</p>
         <p className="github-modal-body">Enter a public image URL to display as the canvas background. All participants will see the same image.</p>
-        <input
-          className="github-modal-input"
-          type="url"
-          value={urlInput}
-          onChange={e => setUrlInput(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter') handleSubmit(); }}
-          placeholder="https://example.com/image.jpg"
-          autoFocus
-        />
+        <div style={{ position: 'relative' }}>
+          <input
+            className="github-modal-input"
+            type="url"
+            value={urlInput}
+            onChange={e => setUrlInput(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') handleSubmit(); }}
+            placeholder="https://example.com/image.jpg"
+            style={{ paddingRight: urlInput ? 32 : undefined }}
+            autoFocus
+          />
+          {urlInput && (
+            <button
+              onClick={() => setUrlInput('')}
+              style={{
+                position: 'absolute',
+                right: 8,
+                top: '50%',
+                transform: 'translateY(-50%)',
+                background: 'none',
+                border: 'none',
+                color: '#888',
+                fontSize: 16,
+                cursor: 'pointer',
+                lineHeight: 1,
+                padding: '0 2px',
+              }}
+              aria-label="Clear"
+            >
+              ×
+            </button>
+          )}
+        </div>
         <button className="github-modal-btn-primary" onClick={handleSubmit} disabled={!urlInput.trim()}>
           Set image
         </button>

--- a/app/components/ImageConfigModal.tsx
+++ b/app/components/ImageConfigModal.tsx
@@ -9,11 +9,10 @@ interface ImageConfigModalProps {
 }
 
 export default function ImageConfigModal({ onSubmit, onClose, currentUrl }: ImageConfigModalProps) {
-  const [urlInput, setUrlInput] = useState(currentUrl ?? DEFAULT_IMAGE_URL);
+  const [urlInput, setUrlInput] = useState(currentUrl ?? '');
 
   const handleSubmit = () => {
-    const url = urlInput.trim();
-    if (url) onSubmit(url);
+    onSubmit(urlInput.trim() || DEFAULT_IMAGE_URL);
     onClose();
   };
 
@@ -27,45 +26,19 @@ export default function ImageConfigModal({ onSubmit, onClose, currentUrl }: Imag
       <div className="github-modal">
         <p className="github-modal-title">Image Canvas</p>
         <p className="github-modal-body">Enter a public image URL to display as the canvas background. All participants will see the same image.</p>
-        <div style={{ position: 'relative' }}>
-          <input
-            className="github-modal-input"
-            type="url"
-            value={urlInput}
-            onChange={e => setUrlInput(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter') handleSubmit(); }}
-            placeholder="https://example.com/image.jpg"
-            style={{ paddingRight: urlInput ? 32 : undefined }}
-            autoFocus
-          />
-          {urlInput && (
-            <button
-              onClick={() => setUrlInput('')}
-              style={{
-                position: 'absolute',
-                right: 8,
-                top: '50%',
-                transform: 'translateY(-50%)',
-                background: 'none',
-                border: 'none',
-                color: '#888',
-                fontSize: 16,
-                cursor: 'pointer',
-                lineHeight: 1,
-                padding: '0 2px',
-              }}
-              aria-label="Clear"
-            >
-              ×
-            </button>
-          )}
-        </div>
-        <button className="github-modal-btn-primary" onClick={handleSubmit} disabled={!urlInput.trim()}>
+        <input
+          className="github-modal-input"
+          type="url"
+          value={urlInput}
+          onChange={e => setUrlInput(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') handleSubmit(); }}
+          placeholder={DEFAULT_IMAGE_URL}
+          autoFocus
+        />
+        <button className="github-modal-btn-primary" onClick={handleSubmit}>
           Set image
         </button>
-        {currentUrl && (
-          <button className="github-modal-btn-dismiss" onClick={handleClear}>Clear image</button>
-        )}
+        <button className="github-modal-btn-dismiss" onClick={handleClear}>Clear image</button>
         <button className="github-modal-btn-dismiss" onClick={onClose}>Cancel</button>
       </div>
     </div>

--- a/app/components/ImageConfigModal.tsx
+++ b/app/components/ImageConfigModal.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+
+interface ImageConfigModalProps {
+  onSubmit: (url: string) => void;
+  onClose: () => void;
+  currentUrl?: string;
+}
+
+export default function ImageConfigModal({ onSubmit, onClose, currentUrl }: ImageConfigModalProps) {
+  const [urlInput, setUrlInput] = useState(currentUrl ?? '');
+
+  const handleSubmit = () => {
+    const url = urlInput.trim();
+    if (url) onSubmit(url);
+    onClose();
+  };
+
+  const handleClear = () => {
+    onSubmit('');
+    onClose();
+  };
+
+  return (
+    <div className="github-modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="github-modal">
+        <p className="github-modal-title">Image Canvas</p>
+        <p className="github-modal-body">Enter a public image URL to display as the canvas background. All participants will see the same image.</p>
+        <input
+          className="github-modal-input"
+          type="url"
+          value={urlInput}
+          onChange={e => setUrlInput(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') handleSubmit(); }}
+          placeholder="https://example.com/image.jpg"
+          autoFocus
+        />
+        <button className="github-modal-btn-primary" onClick={handleSubmit} disabled={!urlInput.trim()}>
+          Set image
+        </button>
+        {currentUrl && (
+          <button className="github-modal-btn-dismiss" onClick={handleClear}>Clear image</button>
+        )}
+        <button className="github-modal-btn-dismiss" onClick={onClose}>Cancel</button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/ImageConfigModal.tsx
+++ b/app/components/ImageConfigModal.tsx
@@ -1,6 +1,17 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 
 const DEFAULT_IMAGE_URL = 'https://pbs.twimg.com/media/DY_tjS0WsAADhmT.jpg';
+const HISTORY_KEY = 'imageUrlHistory';
+const MAX_HISTORY = 5;
+
+function getImageUrlHistory(): string[] {
+  try { return JSON.parse(localStorage.getItem(HISTORY_KEY) ?? '[]'); } catch { return []; }
+}
+
+function saveImageUrlToHistory(url: string): void {
+  const history = [url, ...getImageUrlHistory().filter(u => u !== url)].slice(0, MAX_HISTORY);
+  localStorage.setItem(HISTORY_KEY, JSON.stringify(history));
+}
 
 interface ImageConfigModalProps {
   onSubmit: (url: string) => void;
@@ -10,9 +21,25 @@ interface ImageConfigModalProps {
 
 export default function ImageConfigModal({ onSubmit, onClose, currentUrl }: ImageConfigModalProps) {
   const [urlInput, setUrlInput] = useState(currentUrl ?? '');
+  const [history] = useState<string[]>(getImageUrlHistory);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = history.filter(u =>
+    !urlInput || u.toLowerCase().includes(urlInput.toLowerCase())
+  );
+  const showDropdown = dropdownOpen && filtered.length > 0;
+
+  const select = (url: string) => {
+    setUrlInput(url);
+    setDropdownOpen(false);
+    inputRef.current?.blur();
+  };
 
   const handleSubmit = () => {
-    onSubmit(urlInput.trim() || DEFAULT_IMAGE_URL);
+    const url = urlInput.trim() || DEFAULT_IMAGE_URL;
+    saveImageUrlToHistory(url);
+    onSubmit(url);
     onClose();
   };
 
@@ -26,15 +53,67 @@ export default function ImageConfigModal({ onSubmit, onClose, currentUrl }: Imag
       <div className="github-modal">
         <p className="github-modal-title">Image Canvas</p>
         <p className="github-modal-body">Enter a public image URL to display as the canvas background. All participants will see the same image.</p>
-        <input
-          className="github-modal-input"
-          type="url"
-          value={urlInput}
-          onChange={e => setUrlInput(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter') handleSubmit(); }}
-          placeholder={DEFAULT_IMAGE_URL}
-          autoFocus
-        />
+        <div style={{ position: 'relative' }}>
+          <input
+            ref={inputRef}
+            className="github-modal-input"
+            type="url"
+            value={urlInput}
+            onChange={e => setUrlInput(e.target.value)}
+            onFocus={() => setDropdownOpen(true)}
+            onBlur={() => setTimeout(() => setDropdownOpen(false), 150)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') handleSubmit();
+              if (e.key === 'Escape') setDropdownOpen(false);
+            }}
+            placeholder={DEFAULT_IMAGE_URL}
+            autoFocus
+          />
+          {showDropdown && (
+            <div style={{
+              position: 'absolute',
+              top: '100%',
+              left: 0,
+              right: 0,
+              marginTop: 4,
+              background: '#111',
+              border: '1px solid #444',
+              borderRadius: 8,
+              boxShadow: '0 4px 16px rgba(0,0,0,0.5)',
+              zIndex: 10,
+              maxHeight: 200,
+              overflowY: 'auto',
+            }}>
+              {filtered.map(url => (
+                <button
+                  key={url}
+                  type="button"
+                  onMouseDown={e => { e.preventDefault(); select(url); }}
+                  style={{
+                    display: 'block',
+                    width: '100%',
+                    textAlign: 'left',
+                    padding: '8px 12px',
+                    background: 'none',
+                    border: 'none',
+                    color: '#ccc',
+                    fontSize: 12,
+                    fontFamily: 'monospace',
+                    cursor: 'pointer',
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    borderBottom: '1px solid #2a2a2a',
+                  }}
+                  onMouseEnter={e => (e.currentTarget.style.background = '#222')}
+                  onMouseLeave={e => (e.currentTarget.style.background = 'none')}
+                >
+                  {url}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
         <button className="github-modal-btn-primary" onClick={handleSubmit}>
           Set image
         </button>

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -66,6 +66,7 @@ export default function ReactionCanvasAppV4() {
   const [isRecording, setIsRecording] = useState(false);
   const [serverLabels, setServerLabels] = useState<ReactionLabelSet | null>(null);
   const [serverAnchors, setServerAnchors] = useState<ReactionAnchors | null>(null);
+  const [serverImageUrl, setServerImageUrl] = useState('');
   const [debug, setDebug] = useState(() => new URLSearchParams(window.location.search).get('debug') === '1');
   const reactionStateRef = useRef<ReactionState>(null);
   const [showGithubModal, setShowGithubModal] = useState(false);
@@ -102,9 +103,16 @@ export default function ReactionCanvasAppV4() {
   return (
     <div className="v2-app-container">
       <div className="v2-vote-canvas-container" style={{ flex: 1 }}>
-        {labels && <div className="reaction-label reaction-label-positive" style={reactionLabelStyle(anchors.positive)}>{labels.positive}</div>}
-        {labels && <div className="reaction-label reaction-label-negative" style={reactionLabelStyle(anchors.negative)}>{labels.negative}</div>}
-        {labels && <div className="reaction-label reaction-label-neutral" style={reactionLabelStyle(anchors.neutral)}>{labels.neutral}</div>}
+        {serverImageUrl && (
+          <img
+            src={serverImageUrl}
+            className="image-canvas-bg"
+            alt=""
+          />
+        )}
+        {labels && !serverImageUrl && <div className="reaction-label reaction-label-positive" style={reactionLabelStyle(anchors.positive)}>{labels.positive}</div>}
+        {labels && !serverImageUrl && <div className="reaction-label reaction-label-negative" style={reactionLabelStyle(anchors.negative)}>{labels.negative}</div>}
+        {labels && !serverImageUrl && <div className="reaction-label reaction-label-neutral" style={reactionLabelStyle(anchors.neutral)}>{labels.neutral}</div>}
         {isViewer && (
           <div className="viewer-mode-banner">
             This room is full — you are watching in view-only mode.
@@ -148,6 +156,7 @@ export default function ReactionCanvasAppV4() {
           onActivityTriggered={(activityName) => {
             if (activityName === 'githubUsername') setShowGithubModal(true);
           }}
+          onRoomImageUrlChange={setServerImageUrl}
           debug={debug}
         />
         {!isViewer && (
@@ -161,6 +170,7 @@ export default function ReactionCanvasAppV4() {
             onTouchPosition={setTouchPos}
             heightOffset={0}
             anchors={anchors}
+            imageUrl={serverImageUrl || undefined}
           />
         )}
         {showGithubModal && (

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -104,16 +104,16 @@ export default function ReactionCanvasAppV4() {
   return (
     <div className="v2-app-container">
       <div className="v2-vote-canvas-container" style={{ flex: 1 }}>
-        {serverImageUrl && (
+        {activity === 'image-canvas' && serverImageUrl && (
           <img
             src={serverImageUrl}
             className="image-canvas-bg"
             alt=""
           />
         )}
-        {labels && activity !== 'image-canvas' && <div className="reaction-label reaction-label-positive" style={reactionLabelStyle(anchors.positive)}>{labels.positive}</div>}
-        {labels && activity !== 'image-canvas' && <div className="reaction-label reaction-label-negative" style={reactionLabelStyle(anchors.negative)}>{labels.negative}</div>}
-        {labels && activity !== 'image-canvas' && <div className="reaction-label reaction-label-neutral" style={reactionLabelStyle(anchors.neutral)}>{labels.neutral}</div>}
+        {labels && activity === 'canvas' && <div className="reaction-label reaction-label-positive" style={reactionLabelStyle(anchors.positive)}>{labels.positive}</div>}
+        {labels && activity === 'canvas' && <div className="reaction-label reaction-label-negative" style={reactionLabelStyle(anchors.negative)}>{labels.negative}</div>}
+        {labels && activity === 'canvas' && <div className="reaction-label reaction-label-neutral" style={reactionLabelStyle(anchors.neutral)}>{labels.neutral}</div>}
         {isViewer && (
           <div className="viewer-mode-banner">
             This room is full — you are watching in view-only mode.

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -67,6 +67,7 @@ export default function ReactionCanvasAppV4() {
   const [serverLabels, setServerLabels] = useState<ReactionLabelSet | null>(null);
   const [serverAnchors, setServerAnchors] = useState<ReactionAnchors | null>(null);
   const [serverImageUrl, setServerImageUrl] = useState('');
+  const [activity, setActivity] = useState<'canvas' | 'soccer' | 'image-canvas'>('canvas');
   const [debug, setDebug] = useState(() => new URLSearchParams(window.location.search).get('debug') === '1');
   const reactionStateRef = useRef<ReactionState>(null);
   const [showGithubModal, setShowGithubModal] = useState(false);
@@ -110,9 +111,9 @@ export default function ReactionCanvasAppV4() {
             alt=""
           />
         )}
-        {labels && !serverImageUrl && <div className="reaction-label reaction-label-positive" style={reactionLabelStyle(anchors.positive)}>{labels.positive}</div>}
-        {labels && !serverImageUrl && <div className="reaction-label reaction-label-negative" style={reactionLabelStyle(anchors.negative)}>{labels.negative}</div>}
-        {labels && !serverImageUrl && <div className="reaction-label reaction-label-neutral" style={reactionLabelStyle(anchors.neutral)}>{labels.neutral}</div>}
+        {labels && activity !== 'image-canvas' && <div className="reaction-label reaction-label-positive" style={reactionLabelStyle(anchors.positive)}>{labels.positive}</div>}
+        {labels && activity !== 'image-canvas' && <div className="reaction-label reaction-label-negative" style={reactionLabelStyle(anchors.negative)}>{labels.negative}</div>}
+        {labels && activity !== 'image-canvas' && <div className="reaction-label reaction-label-neutral" style={reactionLabelStyle(anchors.neutral)}>{labels.neutral}</div>}
         {isViewer && (
           <div className="viewer-mode-banner">
             This room is full — you are watching in view-only mode.
@@ -157,6 +158,7 @@ export default function ReactionCanvasAppV4() {
             if (activityName === 'githubUsername') setShowGithubModal(true);
           }}
           onRoomImageUrlChange={setServerImageUrl}
+          onActivityChange={setActivity}
           debug={debug}
         />
         {!isViewer && (

--- a/app/components/TouchLayer.tsx
+++ b/app/components/TouchLayer.tsx
@@ -36,6 +36,7 @@ interface TouchLayerProps {
   getTimecode?: () => number; // Returns current video timecode to send on lift
   anchors?: ReactionAnchors;
   onCursorEvent?: (type: 'move' | 'touch' | 'remove', pos: { x: number; y: number }) => void;
+  imageUrl?: string; // When set, normalize coordinates relative to displayed image bounds
 }
 
 export default function TouchLayer({
@@ -50,6 +51,7 @@ export default function TouchLayer({
   getTimecode,
   anchors,
   onCursorEvent,
+  imageUrl,
 }: TouchLayerProps) {
   const layerRef = useRef<HTMLDivElement>(null);
   const [userReactionState, setUserReactionState] = useState<ReactionState>(null);
@@ -59,6 +61,15 @@ export default function TouchLayer({
   });
   const [isDragging, setIsDragging] = useState(false);
   const [isMouseOver, setIsMouseOver] = useState(false);
+  const [imageNaturalSize, setImageNaturalSize] = useState<{ w: number; h: number } | null>(null);
+
+  useEffect(() => {
+    if (!imageUrl) { setImageNaturalSize(null); return; }
+    const img = new Image();
+    img.onload = () => setImageNaturalSize({ w: img.naturalWidth, h: img.naturalHeight });
+    img.onerror = () => setImageNaturalSize(null);
+    img.src = imageUrl;
+  }, [imageUrl]);
   const lastTouchTimeRef = useRef(0); // Used to suppress synthesized mouse events after touch
   const currentReactionStateRef = useRef<ReactionState>(null);
   const lastPositionRef = useRef<CursorPosition | null>(null);
@@ -141,11 +152,25 @@ export default function TouchLayer({
       clientY = e.clientY;
     }
 
-    // Convert to normalized coordinates (0-100)
     const pixelX = clientX - rect.left;
     const pixelY = clientY - rect.top;
-    const normalizedX = (pixelX / dimensions.width) * 100;
-    const normalizedY = (pixelY / dimensions.height) * 100;
+
+    let normalizedX: number;
+    let normalizedY: number;
+
+    if (imageUrl && imageNaturalSize) {
+      // Normalize relative to displayed image bounds (object-fit: contain letterboxing)
+      const scale = Math.min(dimensions.width / imageNaturalSize.w, dimensions.height / imageNaturalSize.h);
+      const dispW = imageNaturalSize.w * scale;
+      const dispH = imageNaturalSize.h * scale;
+      const offX = (dimensions.width - dispW) / 2;
+      const offY = (dimensions.height - dispH) / 2;
+      normalizedX = Math.max(0, Math.min(100, ((pixelX - offX) / dispW) * 100));
+      normalizedY = Math.max(0, Math.min(100, ((pixelY - offY) / dispH) * 100));
+    } else {
+      normalizedX = (pixelX / dimensions.width) * 100;
+      normalizedY = (pixelY / dimensions.height) * 100;
+    }
 
     return {
       x: normalizedX,

--- a/app/components/TouchLayer.tsx
+++ b/app/components/TouchLayer.tsx
@@ -165,8 +165,8 @@ export default function TouchLayer({
       const dispH = imageNaturalSize.h * scale;
       const offX = (dimensions.width - dispW) / 2;
       const offY = (dimensions.height - dispH) / 2;
-      normalizedX = Math.max(0, Math.min(100, ((pixelX - offX) / dispW) * 100));
-      normalizedY = Math.max(0, Math.min(100, ((pixelY - offY) / dispH) * 100));
+      normalizedX = ((pixelX - offX) / dispW) * 100;
+      normalizedY = ((pixelY - offY) / dispH) * 100;
     } else {
       normalizedX = (pixelX / dimensions.width) * 100;
       normalizedY = (pixelY / dimensions.height) * 100;

--- a/app/styles.css
+++ b/app/styles.css
@@ -1557,3 +1557,28 @@ body {
   font-size: 13px;
   margin: 0;
 }
+
+.image-canvas-bg {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  z-index: 0;
+  pointer-events: none;
+}
+
+.image-canvas-config-link {
+  background: none;
+  border: none;
+  color: #6af;
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0 6px;
+  text-decoration: underline;
+  vertical-align: middle;
+}
+.image-canvas-config-link:hover {
+  color: #9cf;
+}

--- a/party/server.ts
+++ b/party/server.ts
@@ -103,7 +103,12 @@ interface SetRoomAvatarStyleEvent {
 
 interface SetActivityEvent {
   type: 'setActivity';
-  activity: 'canvas' | 'soccer';
+  activity: 'canvas' | 'soccer' | 'image-canvas';
+}
+
+interface SetImageUrlEvent {
+  type: 'setImageUrl';
+  url: string;
 }
 
 interface ResetSoccerScoreEvent {
@@ -145,7 +150,7 @@ interface Vote {
   timestamp: number;
 }
 
-type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent;
+type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent;
 
 // ===== SOCCER PHYSICS CONSTANTS =====
 const SOCCER_BALL_R = 2;      // % of canvas
@@ -171,7 +176,8 @@ export default class Server implements Party.Server {
   private roomLabels: { positive: string; negative: string; neutral: string } | null = { positive: 'Agree', negative: 'Disagree', neutral: 'Pass' };
   private roomAnchors: ReactionAnchors | null = null;
   private roomAvatarStyle: string | null = null;
-  private currentActivity: 'canvas' | 'soccer' = 'canvas';
+  private currentActivity: 'canvas' | 'soccer' | 'image-canvas' = 'canvas';
+  private roomImageUrl: string = '';
   private ballState = { x: 50, y: 50, vx: 2, vy: 1 };
   private soccerScore = { left: 0, right: 0 };
   private githubSubmissions: { username: string; displayName: string | null; avatarUrl: string | null; timestamp: number }[] = [];
@@ -267,6 +273,7 @@ export default class Server implements Party.Server {
       roomAnchors: this.roomAnchors,
       roomAvatarStyle: this.roomAvatarStyle,
       currentActivity: this.currentActivity,
+      roomImageUrl: this.roomImageUrl,
       ballState: this.currentActivity === 'soccer' ? this.ballState : null,
       soccerScore: this.soccerScore,
       isViewer,
@@ -378,6 +385,9 @@ export default class Server implements Party.Server {
           ball: this.currentActivity === 'soccer' ? this.ballState : null,
           score: this.soccerScore,
         }));
+      } else if (event.type === 'setImageUrl') {
+        this.roomImageUrl = event.url;
+        this.room.broadcast(JSON.stringify({ type: 'imageUrlChanged', url: this.roomImageUrl }));
       } else if (event.type === 'resetSoccerScore') {
         this.soccerScore = { left: 0, right: 0 };
         this.room.broadcast(JSON.stringify({ type: 'goalScored', score: this.soccerScore }));


### PR DESCRIPTION
Closes #17

## Summary

- Adds **Image Canvas** as a new interface mode in the V4 admin Interfaces tab, alongside the existing Reaction Canvas and Soccer options
- Admin selects "Image Canvas" and uses a **config link** beside the radio option to set a background image URL via a modal
- Image URL is broadcast to all participants in real time; displayed fitted with `object-fit: contain`
- **Cursor coordinates are image-relative** (not screen-relative), so reactions stay anchored to the same image region across different screen sizes and aspect ratios
- Cursors in the **letterbox area** are shown on receiving devices if they have room for it (unclamped image-relative coords), and only snap to the canvas edge if the receiver's letterbox is too small
- Reaction labels are hidden in Image Canvas and Soccer modes; background image only shown in Image Canvas mode
- Image URL history stored in localStorage with a **custom dropdown** (focus-open, filters as you type, 150ms blur delay)
- Also fixes the **preview cleanup workflow** (`--yes` → `--force` for `partykit delete`)

## Test plan

- [ ] Open `?admin=true#v4` → Interfaces tab → confirm "Canvas" is now "Reaction Canvas"
- [ ] Select "Image Canvas" → click "config" → modal opens with default URL pre-filled as placeholder
- [ ] Set an image → confirm it broadcasts and appears as background on participant view (`#v4`)
- [ ] Open two tabs at different window sizes → confirm cursors stay anchored to the same image position
- [ ] Touch in the letterbox area on one tab → confirm the other tab shows it in its letterbox (if space available) or at the canvas edge
- [ ] Clear image → confirm image-canvas mode stays active (no reaction labels reappear)
- [ ] Switch to Soccer → confirm no labels and no image background
- [ ] Reopen config modal → confirm recent URLs appear in the dropdown
- [ ] Merge a PR → confirm preview cleanup workflow now deletes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~150 words of PR description from ~280 words of human prompts across this session)