### PR TITLE
feat: mobile-friendly tab layout for V4 admin panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - V4 admin: mobile-friendly layout — replaced the two-column desktop layout with a single-column tab-based UI; "Record" tab consolidates recording controls, status, playback, and the events table; config tabs (Labels, Anchors, Avatars, Interface, Events, People) are now top-level tabs in a horizontally-scrollable tab bar; "Peek Canvas" is now a toggle button in the persistent header that opens a full-screen overlay rather than a tab
+- V4 admin: recorded events table is always visible in the Record tab, even before any events have been captured
+- V4 admin: JSON download is available while recording is in progress, not only after stopping
+- V4 admin: confirm dialog on the Clear button shows the current event count before discarding
 - V4 admin: Participants tab — lists all connected users grouped by their current valence zone (using the active label set for group headings); users with no active cursor appear under "Lurking"; flat list available via grouping dropdown; row layout includes a disabled action button placeholder for future per-user actions
 - V4 admin: Image Canvas interface mode — admin selects "Image Canvas" in the Interfaces tab and uses the adjacent "config" link to set a public image URL; the image is broadcast to all participants as the canvas background (fitted with `object-fit: contain`); cursor positions are normalized to image-relative coordinates so reactions stay anchored to the same image content regardless of screen size
 - V4 admin: renamed "Canvas" interface option to "Reaction Canvas" in the Interfaces tab
@@ -18,6 +21,7 @@ All notable changes to this project will be documented in this file.
 - Onboarding V2: per-element opacity sliders in the style grid (radial / trace / cursor / fill), replacing the single global opacity slider; trace and fill sliders dim alongside their other controls when in 2d time slice mode
 
 ### Fixed
+- V4 admin: fix vertical bounce when swiping the tab bar on iOS/Android — added `touch-action: pan-x` and `overscroll-behavior-x: contain` so the browser treats tab-bar swipes as horizontal-only
 - Index: fix Android scroll bug where top cards were unreachable — changed `justify-content: center` to `justify-content: flex-start` on `.index-app` to prevent inaccessible top overflow in flex scroll containers
 - Onboarding V2: fix black chord/dot outlines appearing on fill surface when radial/cursor opacity is 0 — chord and dot materials now have `depthWrite:false`, consistent with trace and fill materials
 - Onboarding V2: fix fill surface origin — fill now anchors to each chord's historically-correct root position (stored alongside tip in history) instead of always the global canvas centre; fixes parallel mode where each chord has a distinct root x-position, and correctly tracks the root through geometry transitions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
+- V4 admin: mobile-friendly layout — replaced the two-column desktop layout with a single-column tab-based UI; "Record" tab consolidates recording controls, status, playback, and the events table; config tabs (Labels, Anchors, Avatars, Interface, Events, People) are now top-level tabs in a horizontally-scrollable tab bar; "Peek Canvas" is now a toggle button in the persistent header that opens a full-screen overlay rather than a tab
 - V4 admin: Participants tab — lists all connected users grouped by their current valence zone (using the active label set for group headings); users with no active cursor appear under "Lurking"; flat list available via grouping dropdown; row layout includes a disabled action button placeholder for future per-user actions
 - V4 admin: Image Canvas interface mode — admin selects "Image Canvas" in the Interfaces tab and uses the adjacent "config" link to set a public image URL; the image is broadcast to all participants as the canvas background (fitted with `object-fit: contain`); cursor positions are normalized to image-relative coordinates so reactions stay anchored to the same image content regardless of screen size
 - V4 admin: renamed "Canvas" interface option to "Reaction Canvas" in the Interfaces tab

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -841,7 +841,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
                   ■ Stop Recording
                 </button>
               )}
-              <button className="v3-admin-btn" onClick={downloadEvents} disabled={isRecording || eventCount === 0}>
+              <button className="v3-admin-btn" onClick={downloadEvents} disabled={eventCount === 0}>
                 ↓ Download JSON
               </button>
               <button

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -846,7 +846,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
               </button>
               <button
                 className="v3-admin-btn v3-admin-btn--destructive"
-                onClick={clearEvents}
+                onClick={() => { if (confirm(`Clear all ${eventCount} recorded events?`)) clearEvents(); }}
                 disabled={eventCount === 0}
               >
                 ✕ Clear

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -47,22 +47,14 @@ function anchorToLocal(anchors: ReactionAnchors) {
   };
 }
 
-export default function AdminPanelV4({ room }: AdminPanelV4Props) {
-  const [mainTab, setMainTab] = useState<'admin' | 'peek'>('admin');
-  const tabBarRef = useRef<HTMLDivElement>(null);
-  const [tabBarHeight, setTabBarHeight] = useState(46);
+type AdminTab = 'record' | 'labels' | 'anchors' | 'avatars' | 'interfaces' | 'events' | 'participants';
 
-  useEffect(() => {
-    if (!tabBarRef.current) return;
-    const ro = new ResizeObserver(entries => {
-      setTabBarHeight(entries[0].contentRect.height);
-    });
-    ro.observe(tabBarRef.current);
-    return () => ro.disconnect();
-  }, []);
+export default function AdminPanelV4({ room }: AdminPanelV4Props) {
+  const [isPeeking, setIsPeeking] = useState(false);
+
   const [isRecording, setIsRecording] = useState(false);
   const [mode, setMode] = useState<RecordingMode>('positions');
-  const [configTab, setConfigTab] = useState<'labels' | 'anchors' | 'avatars' | 'interfaces' | 'events' | 'participants'>('labels');
+  const [activeTab, setActiveTab] = useState<AdminTab>('record');
   const [eventCount, setEventCount] = useState(0);
   const [serverRecording, setServerRecording] = useState(false);
   const [userCap, setUserCap] = useState<number | null>(null);
@@ -697,756 +689,794 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
     width: 64,
   };
 
+  const tabLabel = (tab: AdminTab): string => {
+    if (tab === 'events') return githubSubmissions.length > 0 ? `Events (${githubSubmissions.length})` : 'Events';
+    if (tab === 'participants') return connectedUsers.size > 0 ? `People (${connectedUsers.size})` : 'People';
+    if (tab === 'interfaces') return 'Interface';
+    if (tab === 'record') return 'Record';
+    return tab.charAt(0).toUpperCase() + tab.slice(1);
+  };
+
+  const ALL_TABS: AdminTab[] = ['record', 'labels', 'anchors', 'avatars', 'interfaces', 'events', 'participants'];
+
   return (
     <div
       className="v3-admin-panel"
       style={{ padding: 0, height: '100vh', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}
     >
-      {/* Top-level tab bar */}
-      <div ref={tabBarRef} style={{ display: 'flex', gap: 0, marginBottom: 0, borderBottom: '2px solid #444', flexShrink: 0 }}>
-        {(['admin', 'peek'] as const).map(tab => (
-          <button
-            key={tab}
-            onClick={() => setMainTab(tab)}
-            style={{
-              padding: '10px 24px',
-              background: mainTab === tab ? '#333' : 'transparent',
-              color: mainTab === tab ? '#eee' : '#888',
-              border: 'none',
-              borderBottom: mainTab === tab ? '2px solid #aaa' : '2px solid transparent',
-              marginBottom: -2,
-              cursor: 'pointer',
-              fontSize: 15,
-              fontWeight: mainTab === tab ? 600 : 400,
-            }}
-          >
-            {tab === 'admin' ? 'Admin' : 'Peek Canvas'}
-          </button>
-        ))}
+      {/* === PERSISTENT HEADER === */}
+      <div style={{ flexShrink: 0, borderBottom: '2px solid #444' }}>
+        {/* Title row */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 16px 8px' }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, minWidth: 0, overflow: 'hidden' }}>
+            <span style={{ fontWeight: 700, fontSize: 15, color: '#eee', flexShrink: 0 }}>V4 Admin</span>
+            <span style={{ color: '#555', fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {room}
+            </span>
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0, marginLeft: 12 }}>
+            {isRecording && (
+              <span style={{ fontSize: 11, fontWeight: 700, color: '#f55', letterSpacing: '0.05em' }}>● REC</span>
+            )}
+            {connectedUsers.size > 0 && (
+              <span style={{ fontSize: 12, color: '#666' }}>{connectedUsers.size} online</span>
+            )}
+            <button
+              onClick={() => setIsPeeking(p => !p)}
+              style={{
+                padding: '4px 10px',
+                background: isPeeking ? '#444' : 'transparent',
+                color: isPeeking ? '#eee' : '#777',
+                border: '1px solid #555',
+                borderRadius: 4,
+                cursor: 'pointer',
+                fontSize: 12,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              👁 Peek
+            </button>
+          </div>
+        </div>
+
+        {/* Tab bar — horizontally scrollable, no visible scrollbar */}
+        <div
+          className="admin-v4-tab-bar"
+          style={{ display: 'flex', overflowX: 'auto' }}
+        >
+          {ALL_TABS.map(tab => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              style={{
+                padding: '8px 16px',
+                background: activeTab === tab ? '#333' : 'transparent',
+                color: activeTab === tab ? '#eee' : '#888',
+                border: 'none',
+                borderBottom: activeTab === tab ? '2px solid #aaa' : '2px solid transparent',
+                marginBottom: -2,
+                cursor: 'pointer',
+                fontSize: 13,
+                fontWeight: activeTab === tab ? 600 : 400,
+                whiteSpace: 'nowrap',
+                flexShrink: 0,
+              }}
+            >
+              {tabLabel(tab)}
+            </button>
+          ))}
+        </div>
       </div>
 
-      {mainTab === 'peek' && (
-        <div style={{ flex: 1, overflow: 'hidden' }}>
-          <Canvas
-            room={room}
-            userId="admin-peek"
-            readOnly={true}
-            colorCursorsByVote={true}
-            debug={true}
-            heightOffset={tabBarHeight}
-          />
-        </div>
-      )}
+      {/* === TAB CONTENT === */}
+      <div style={{ flex: 1, overflow: 'auto', padding: '24px 16px' }}>
 
-      {mainTab === 'admin' && <div style={{ flex: 1, overflow: 'auto', padding: 32 }}>
-      <h1>Reaction Canvas V4 — Admin</h1>
-      <p style={{ marginTop: 8, color: '#aaa' }}>Room: <strong style={{ color: '#eee' }}>{room}</strong></p>
-
-      {/* Two-column layout: recording left, config right */}
-      <div style={{ display: 'flex', gap: 48, marginTop: 32, alignItems: 'flex-start' }}>
-
-        {/* Left: recording */}
-        <div style={{ flexShrink: 0 }}>
-          <div style={{ marginBottom: 24 }}>
-            <p style={{ marginBottom: 8, fontWeight: 600 }}>Participant cap:</p>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <input
-                type="number"
-                min={1}
-                value={capInput}
-                placeholder="No cap"
-                onChange={e => setCapInput(e.target.value)}
-                style={{ ...inputStyle, width: 88 }}
-              />
-              <button className="v3-admin-btn" style={{ padding: '4px 12px' }} onClick={sendUserCap}>
-                Apply
-              </button>
-              {userCap !== null && (
-                <button
-                  className="v3-admin-btn"
-                  style={{ padding: '4px 12px' }}
-                  onClick={() => { setCapInput(''); socket.send(JSON.stringify({ type: 'setUserCap', cap: null })); }}
-                >
-                  Remove cap
+        {/* RECORD tab */}
+        {activeTab === 'record' && (
+          <div>
+            <div style={{ marginBottom: 24 }}>
+              <p style={{ marginBottom: 8, fontWeight: 600 }}>Participant cap:</p>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <input
+                  type="number"
+                  min={1}
+                  value={capInput}
+                  placeholder="No cap"
+                  onChange={e => setCapInput(e.target.value)}
+                  style={{ ...inputStyle, width: 88 }}
+                />
+                <button className="v3-admin-btn" style={{ padding: '4px 12px' }} onClick={sendUserCap}>
+                  Apply
                 </button>
+                {userCap !== null && (
+                  <button
+                    className="v3-admin-btn"
+                    style={{ padding: '4px 12px' }}
+                    onClick={() => { setCapInput(''); socket.send(JSON.stringify({ type: 'setUserCap', cap: null })); }}
+                  >
+                    Remove cap
+                  </button>
+                )}
+              </div>
+              {userCap !== null && (
+                <p style={{ marginTop: 6, color: '#aaa', fontSize: 13 }}>
+                  {presenceCount} / {userCap} participants active
+                </p>
               )}
             </div>
-            {userCap !== null && (
-              <p style={{ marginTop: 6, color: '#aaa', fontSize: 13 }}>
-                {presenceCount} / {userCap} participants active
-              </p>
-            )}
-          </div>
-          <p style={{ marginBottom: 12, fontWeight: 600 }}>Recording mode:</p>
-          <label style={{ display: 'block', marginBottom: 8, cursor: isRecording ? 'not-allowed' : 'pointer' }}>
-            <input
-              type="radio"
-              name="mode"
-              value="transitions"
-              checked={mode === 'transitions'}
-              disabled={isRecording}
-              onChange={() => handleModeChange('transitions')}
-              style={{ marginRight: 8 }}
-            />
-            Transitions — log only when a cursor changes vote region
-          </label>
-          <label style={{ display: 'block', cursor: isRecording ? 'not-allowed' : 'pointer' }}>
-            <input
-              type="radio"
-              name="mode"
-              value="positions"
-              checked={mode === 'positions'}
-              disabled={isRecording}
-              onChange={() => handleModeChange('positions')}
-              style={{ marginRight: 8 }}
-            />
-            Raw positions — log every move/touch/remove event
-          </label>
 
-          <div style={{ marginTop: 24, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-            {!isRecording ? (
-              <button className="v3-admin-btn v3-admin-btn-record" onClick={startRecording}>
-                ● Start Recording
-              </button>
-            ) : (
-              <button className="v3-admin-btn v3-admin-btn-stop" onClick={stopRecording}>
-                ■ Stop Recording
-              </button>
-            )}
-            <button className="v3-admin-btn" onClick={downloadEvents} disabled={isRecording || eventCount === 0}>
-              ↓ Download JSON
-            </button>
-            <button
-              className="v3-admin-btn v3-admin-btn--destructive"
-              onClick={clearEvents}
-              disabled={eventCount === 0}
-            >
-              ✕ Clear
-            </button>
-          </div>
+            <p style={{ marginBottom: 12, fontWeight: 600 }}>Recording mode:</p>
+            <label style={{ display: 'block', marginBottom: 8, cursor: isRecording ? 'not-allowed' : 'pointer' }}>
+              <input
+                type="radio"
+                name="mode"
+                value="transitions"
+                checked={mode === 'transitions'}
+                disabled={isRecording}
+                onChange={() => handleModeChange('transitions')}
+                style={{ marginRight: 8 }}
+              />
+              Transitions — log only when a cursor changes vote region
+            </label>
+            <label style={{ display: 'block', cursor: isRecording ? 'not-allowed' : 'pointer' }}>
+              <input
+                type="radio"
+                name="mode"
+                value="positions"
+                checked={mode === 'positions'}
+                disabled={isRecording}
+                onChange={() => handleModeChange('positions')}
+                style={{ marginRight: 8 }}
+              />
+              Raw positions — log every move/touch/remove event
+            </label>
 
-          <div style={{ marginTop: 16, color: '#aaa' }}>
-            Status:{' '}
-            {isRecording
-              ? <span style={{ color: '#f55', fontWeight: 700 }}>RECORDING — {eventCount} events logged</span>
-              : eventCount > 0
-                ? <span style={{ color: '#aaa' }}>Stopped — {eventCount} events</span>
-                : <span>Not recording</span>
-            }
-          </div>
-
-          <div style={{ marginTop: 8, color: '#aaa', fontSize: 13 }}>
-            Server broadcast:{' '}
-            {serverRecording
-              ? <span style={{ color: '#f55' }}>REC active (participants see badge)</span>
-              : <span>inactive</span>
-            }
-          </div>
-
-          {/* Playback section */}
-          <div style={{ marginTop: 32, borderTop: '1px solid #444', paddingTop: 24 }}>
-            <p style={{ marginBottom: 12, fontWeight: 600 }}>Playback</p>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-              <label style={{ display: 'inline-block', cursor: 'pointer' }}>
-                <span className="v3-admin-btn" style={{ display: 'inline-block' }}>
-                  ↑ Load JSON file
-                </span>
-                <input
-                  type="file"
-                  accept="application/json,.json"
-                  onChange={handlePlaybackFile}
-                  style={{ display: 'none' }}
-                />
-              </label>
-              <a
-                href="https://drive.google.com/drive/folders/12ujr5MKjs2q0vzDViyG_1U-SEyVOJZO_"
-                target="_blank"
-                rel="noopener noreferrer"
-                style={{ color: '#69f', fontSize: 13 }}
-              >
-                Valence traces ↗
-              </a>
-            </div>
-            {playbackData && (() => {
-              const events = playbackData.events as Record<string, unknown>[];
-              const uniqueUsers = new Set(events.map(e => e.connectionId)).size;
-              return (
-                <div style={{ marginTop: 12, color: '#aaa', fontSize: 13 }}>
-                  <div style={{ color: '#eee', marginBottom: 2 }}>
-                    {events.length} events · {uniqueUsers} users
-                  </div>
-                  <div style={{ color: '#888' }}>Mode: {playbackData.mode} · Room: {playbackData.room}</div>
-                </div>
-              );
-            })()}
-
-            {/* Timeline scrubber — always visible */}
-            {(() => {
-              const sorted = sortedEventsRef.current;
-              const durationMs = sorted.length > 1
-                ? (sorted[sorted.length - 1].timestamp as number) - (sorted[0].timestamp as number)
-                : 0;
-              const clampedElapsed = Math.min(playbackElapsed, durationMs || 1);
-              const fmtTime = (ms: number) => {
-                const m = Math.floor(ms / 60000);
-                const s = Math.floor((ms % 60000) / 1000);
-                return `${m}:${String(s).padStart(2, '0')}`;
-              };
-              const hasData = !!playbackData && durationMs > 0;
-              return (
-                <div style={{ marginTop: 16, opacity: hasData ? 1 : 0.35 }}>
-                  <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color: '#888', marginBottom: 4 }}>
-                    <span>{fmtTime(hasData ? clampedElapsed : 0)}</span>
-                    <span>{fmtTime(hasData ? durationMs : 0)}</span>
-                  </div>
-                  <input
-                    type="range"
-                    min={0}
-                    max={hasData ? durationMs : 1}
-                    value={hasData ? clampedElapsed : 0}
-                    disabled={!hasData}
-                    onChange={e => seekPlayback(Number(e.target.value))}
-                    style={{ width: '100%', accentColor: 'hsl(270, 70%, 65%)', cursor: hasData ? 'pointer' : 'default' }}
-                  />
-                </div>
-              );
-            })()}
-
-            <div style={{ marginTop: 8, display: 'flex', gap: 8 }}>
-              {isPlaying ? (
-                <button className="v3-admin-btn" onClick={pausePlayback}>
-                  ⏸ Pause
+            <div style={{ marginTop: 24, display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              {!isRecording ? (
+                <button className="v3-admin-btn v3-admin-btn-record" onClick={startRecording}>
+                  ● Start Recording
                 </button>
               ) : (
-                <button
-                  className="v3-admin-btn v3-admin-btn-record"
-                  onClick={playPlayback}
-                  disabled={!playbackData}
-                >
-                  ▶ {isPaused ? 'Resume' : 'Play'}
+                <button className="v3-admin-btn v3-admin-btn-stop" onClick={stopRecording}>
+                  ■ Stop Recording
                 </button>
               )}
+              <button className="v3-admin-btn" onClick={downloadEvents} disabled={isRecording || eventCount === 0}>
+                ↓ Download JSON
+              </button>
               <button
-                className="v3-admin-btn v3-admin-btn-stop"
-                onClick={stopPlayback}
-                disabled={!isPlaying && !isPaused}
+                className="v3-admin-btn v3-admin-btn--destructive"
+                onClick={clearEvents}
+                disabled={eventCount === 0}
               >
-                ■ Stop
+                ✕ Clear
               </button>
             </div>
-            {isPlaying && (
-              <div style={{ marginTop: 8, color: '#f55', fontSize: 13, fontWeight: 600 }}>
-                PLAYING — playback cursors visible to all participants
+
+            <div style={{ marginTop: 16, color: '#aaa' }}>
+              Status:{' '}
+              {isRecording
+                ? <span style={{ color: '#f55', fontWeight: 700 }}>RECORDING — {eventCount} events logged</span>
+                : eventCount > 0
+                  ? <span style={{ color: '#aaa' }}>Stopped — {eventCount} events</span>
+                  : <span>Not recording</span>
+              }
+            </div>
+            <div style={{ marginTop: 8, color: '#aaa', fontSize: 13 }}>
+              Server broadcast:{' '}
+              {serverRecording
+                ? <span style={{ color: '#f55' }}>REC active (participants see badge)</span>
+                : <span>inactive</span>
+              }
+            </div>
+
+            {/* Playback section */}
+            <div style={{ marginTop: 32, borderTop: '1px solid #444', paddingTop: 24 }}>
+              <p style={{ marginBottom: 12, fontWeight: 600 }}>Playback</p>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                <label style={{ display: 'inline-block', cursor: 'pointer' }}>
+                  <span className="v3-admin-btn" style={{ display: 'inline-block' }}>
+                    ↑ Load JSON file
+                  </span>
+                  <input
+                    type="file"
+                    accept="application/json,.json"
+                    onChange={handlePlaybackFile}
+                    style={{ display: 'none' }}
+                  />
+                </label>
+                <a
+                  href="https://drive.google.com/drive/folders/12ujr5MKjs2q0vzDViyG_1U-SEyVOJZO_"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{ color: '#69f', fontSize: 13 }}
+                >
+                  Valence traces ↗
+                </a>
               </div>
-            )}
-            {isPaused && (
-              <div style={{ marginTop: 8, color: '#fa0', fontSize: 13, fontWeight: 600 }}>
-                PAUSED — cursors frozen on canvas
+              {playbackData && (() => {
+                const events = playbackData.events as Record<string, unknown>[];
+                const uniqueUsers = new Set(events.map(e => e.connectionId)).size;
+                return (
+                  <div style={{ marginTop: 12, color: '#aaa', fontSize: 13 }}>
+                    <div style={{ color: '#eee', marginBottom: 2 }}>
+                      {events.length} events · {uniqueUsers} users
+                    </div>
+                    <div style={{ color: '#888' }}>Mode: {playbackData.mode} · Room: {playbackData.room}</div>
+                  </div>
+                );
+              })()}
+
+              {/* Timeline scrubber — always visible */}
+              {(() => {
+                const sorted = sortedEventsRef.current;
+                const durationMs = sorted.length > 1
+                  ? (sorted[sorted.length - 1].timestamp as number) - (sorted[0].timestamp as number)
+                  : 0;
+                const clampedElapsed = Math.min(playbackElapsed, durationMs || 1);
+                const fmtTime = (ms: number) => {
+                  const m = Math.floor(ms / 60000);
+                  const s = Math.floor((ms % 60000) / 1000);
+                  return `${m}:${String(s).padStart(2, '0')}`;
+                };
+                const hasData = !!playbackData && durationMs > 0;
+                return (
+                  <div style={{ marginTop: 16, opacity: hasData ? 1 : 0.35 }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12, color: '#888', marginBottom: 4 }}>
+                      <span>{fmtTime(hasData ? clampedElapsed : 0)}</span>
+                      <span>{fmtTime(hasData ? durationMs : 0)}</span>
+                    </div>
+                    <input
+                      type="range"
+                      min={0}
+                      max={hasData ? durationMs : 1}
+                      value={hasData ? clampedElapsed : 0}
+                      disabled={!hasData}
+                      onChange={e => seekPlayback(Number(e.target.value))}
+                      style={{ width: '100%', accentColor: 'hsl(270, 70%, 65%)', cursor: hasData ? 'pointer' : 'default' }}
+                    />
+                  </div>
+                );
+              })()}
+
+              <div style={{ marginTop: 8, display: 'flex', gap: 8 }}>
+                {isPlaying ? (
+                  <button className="v3-admin-btn" onClick={pausePlayback}>
+                    ⏸ Pause
+                  </button>
+                ) : (
+                  <button
+                    className="v3-admin-btn v3-admin-btn-record"
+                    onClick={playPlayback}
+                    disabled={!playbackData}
+                  >
+                    ▶ {isPaused ? 'Resume' : 'Play'}
+                  </button>
+                )}
+                <button
+                  className="v3-admin-btn v3-admin-btn-stop"
+                  onClick={stopPlayback}
+                  disabled={!isPlaying && !isPaused}
+                >
+                  ■ Stop
+                </button>
+              </div>
+              {isPlaying && (
+                <div style={{ marginTop: 8, color: '#f55', fontSize: 13, fontWeight: 600 }}>
+                  PLAYING — playback cursors visible to all participants
+                </div>
+              )}
+              {isPaused && (
+                <div style={{ marginTop: 8, color: '#fa0', fontSize: 13, fontWeight: 600 }}>
+                  PAUSED — cursors frozen on canvas
+                </div>
+              )}
+            </div>
+
+            {/* Recorded events table */}
+            {displayEvents.length > 0 && (
+              <div style={{ marginTop: 40 }}>
+                <p style={{ fontWeight: 600, marginBottom: 8 }}>
+                  Recorded events
+                  {eventCount > MAX_TABLE_ROWS && (
+                    <span style={{ fontWeight: 400, color: '#888', fontSize: 13, marginLeft: 8 }}>
+                      (showing last {MAX_TABLE_ROWS} of {eventCount})
+                    </span>
+                  )}
+                </p>
+                <div style={{ overflowX: 'auto' }}>
+                  <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, fontFamily: 'monospace' }}>
+                    <thead>
+                      <tr style={{ background: '#222', color: '#aaa', textAlign: 'left' }}>
+                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>#</th>
+                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>time</th>
+                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>connectionId</th>
+                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>from</th>
+                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>to</th>
+                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>type</th>
+                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>x</th>
+                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>y</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {displayEvents.map((evt, i) => {
+                        const e = evt as Record<string, unknown>;
+                        const offset = eventCount - displayEvents.length;
+                        const ts = typeof e.timestamp === 'number'
+                          ? new Date(e.timestamp).toISOString().slice(11, 23)
+                          : '';
+                        return (
+                          <tr key={i} style={{ background: i % 2 === 0 ? '#1a1a1a' : '#111' }}>
+                            <td style={{ padding: '4px 10px', color: '#555' }}>{offset + i + 1}</td>
+                            <td style={{ padding: '4px 10px', color: '#888' }}>{ts}</td>
+                            <td style={{ padding: '4px 10px', color: '#ccc' }}>{String(e.connectionId ?? '')}</td>
+                            <td style={{ padding: '4px 10px', color: '#f99' }}>{e.from !== undefined ? String(e.from ?? 'null') : ''}</td>
+                            <td style={{ padding: '4px 10px', color: '#9f9' }}>{e.to !== undefined ? String(e.to ?? 'null') : ''}</td>
+                            <td style={{ padding: '4px 10px', color: '#99f' }}>{e.type !== undefined ? String(e.type) : ''}</td>
+                            <td style={{ padding: '4px 10px', color: '#aaa' }}>{e.x !== undefined ? String((e.x as number).toFixed(2)) : ''}</td>
+                            <td style={{ padding: '4px 10px', color: '#aaa' }}>{e.y !== undefined ? String((e.y as number).toFixed(2)) : ''}</td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
               </div>
             )}
           </div>
-        </div>
+        )}
 
-        {/* Right: tabbed config */}
-        <div style={{ flex: 1, borderLeft: '1px solid #444', paddingLeft: 48 }}>
-
-      {/* Tab bar */}
-      <div style={{ display: 'flex', gap: 0, marginBottom: 24, borderBottom: '2px solid #444' }}>
-        {(['labels', 'anchors', 'avatars', 'interfaces', 'events', 'participants'] as const).map(tab => (
-          <button
-            key={tab}
-            onClick={() => setConfigTab(tab)}
-            style={{
-              padding: '8px 20px',
-              background: configTab === tab ? '#333' : 'transparent',
-              color: configTab === tab ? '#eee' : '#888',
-              border: 'none',
-              borderBottom: configTab === tab ? '2px solid #aaa' : '2px solid transparent',
-              marginBottom: -2,
-              cursor: 'pointer',
-              fontSize: 14,
-              fontWeight: configTab === tab ? 600 : 400,
-              textTransform: 'capitalize',
-            }}
-          >
-            {tab === 'labels' ? 'Labels' : tab === 'anchors' ? 'Anchors' : tab === 'avatars' ? 'Avatars' : tab === 'interfaces' ? 'Interfaces' : tab === 'events' ? `Events${githubSubmissions.length > 0 ? ` (${githubSubmissions.length})` : ''}` : `Participants${connectedUsers.size > 0 ? ` (${connectedUsers.size})` : ''}`}
-          </button>
-        ))}
-      </div>
-
-      {configTab === 'labels' && (
-        <div>
-          <p style={{ marginBottom: 12, fontWeight: 600 }}>Reaction labels (shared for all participants):</p>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-            {Object.entries(REACTION_LABEL_PRESETS).map(([key, set]) => (
-              <label key={key} style={{ display: 'block', cursor: 'pointer' }}>
+        {/* LABELS tab */}
+        {activeTab === 'labels' && (
+          <div>
+            <p style={{ marginBottom: 12, fontWeight: 600 }}>Reaction labels (shared for all participants):</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              {Object.entries(REACTION_LABEL_PRESETS).map(([key, set]) => (
+                <label key={key} style={{ display: 'block', cursor: 'pointer' }}>
+                  <input
+                    type="radio"
+                    name="labelSelected"
+                    value={key}
+                    checked={labelSelected === key}
+                    onChange={() => selectPreset(key)}
+                    style={{ marginRight: 8 }}
+                  />
+                  {set.positive} / {set.negative} / {set.neutral}
+                  {set.hint && (
+                    <span style={{ color: '#888', fontSize: 12, marginLeft: 8 }}>
+                      — {set.hint}
+                      {set.hintLinkText && set.hintUrl && (
+                        <a href={set.hintUrl} target="_blank" rel="noopener noreferrer" style={{ color: '#69f' }}>{set.hintLinkText}</a>
+                      )}
+                    </span>
+                  )}
+                </label>
+              ))}
+              <label style={{ display: 'block', cursor: 'pointer' }}>
                 <input
                   type="radio"
                   name="labelSelected"
-                  value={key}
-                  checked={labelSelected === key}
-                  onChange={() => selectPreset(key)}
+                  value="custom"
+                  checked={labelSelected === 'custom'}
+                  onChange={() => setLabelSelected('custom')}
                   style={{ marginRight: 8 }}
                 />
-                {set.positive} / {set.negative} / {set.neutral}
-                {set.hint && (
-                  <span style={{ color: '#888', fontSize: 12, marginLeft: 8 }}>
-                    — {set.hint}
-                    {set.hintLinkText && set.hintUrl && (
-                      <a href={set.hintUrl} target="_blank" rel="noopener noreferrer" style={{ color: '#69f' }}>{set.hintLinkText}</a>
-                    )}
-                  </span>
-                )}
+                Custom
               </label>
-            ))}
-            <label style={{ display: 'block', cursor: 'pointer' }}>
-              <input
-                type="radio"
-                name="labelSelected"
-                value="custom"
-                checked={labelSelected === 'custom'}
-                onChange={() => setLabelSelected('custom')}
-                style={{ marginRight: 8 }}
-              />
-              Custom
-            </label>
-            {labelSelected === 'custom' && (
-              <div style={{ marginLeft: 24, display: 'flex', flexDirection: 'column', gap: 6 }}>
-                {([['Positive', customPositive, setCustomPositive], ['Negative', customNegative, setCustomNegative], ['Neutral', customNeutral, setCustomNeutral]] as const).map(([slot, val, setter]) => (
-                  <div key={slot} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                    <span style={{ width: 64, color: '#aaa', fontSize: 13 }}>{slot}</span>
-                    <input
-                      type="text"
-                      value={val}
-                      onChange={e => setter(e.target.value)}
-                      placeholder={`${slot} label`}
-                      style={{ background: '#333', border: '1px solid #555', color: '#eee', padding: '4px 8px', borderRadius: 4 }}
-                    />
-                  </div>
-                ))}
-                {customHistory.length > 0 && (
-                  <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 4 }}>
-                    {customHistory.map((entry, i) => (
-                      <div
-                        key={i}
-                        style={{ display: 'inline-flex', alignItems: 'center', gap: 4, background: '#2a2a2a', border: '1px solid #444', borderRadius: 4, padding: '3px 6px', fontSize: 12, color: '#aaa', cursor: 'pointer' }}
-                        onClick={() => { setCustomPositive(entry.positive); setCustomNegative(entry.negative); setCustomNeutral(entry.neutral); }}
-                      >
-                        <span>{entry.positive} / {entry.negative} / {entry.neutral}</span>
-                        <button
-                          onClick={e => { e.stopPropagation(); setCustomHistory(removeCustomLabelFromHistory(i)); }}
-                          style={{ background: 'none', border: 'none', color: '#666', cursor: 'pointer', padding: '0 2px', fontSize: 13, lineHeight: 1 }}
-                        >×</button>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
-            )}
-            <label style={{ display: 'block', cursor: 'pointer' }}>
-              <input
-                type="radio"
-                name="labelSelected"
-                value="none"
-                checked={labelSelected === 'none'}
-                onChange={() => setLabelSelected('none')}
-                style={{ marginRight: 8 }}
-              />
-              None (hide labels)
-            </label>
-          </div>
-          <button
-            className="v3-admin-btn"
-            style={{ marginTop: 16 }}
-            onClick={sendLabels}
-            disabled={labelSelected === 'custom' && (!customPositive || !customNegative || !customNeutral)}
-          >
-            Apply Labels
-          </button>
-        </div>
-      )}
-
-      {configTab === 'anchors' && (
-        <div>
-          <p style={{ marginBottom: 12, fontWeight: 600 }}>Coordinate system:</p>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 24 }}>
-            <label style={{ display: 'block', cursor: 'pointer' }}>
-              <input
-                type="radio"
-                name="coordSystem"
-                value="barycentric"
-                checked
-                readOnly
-                style={{ marginRight: 8 }}
-              />
-              Barycentric
-            </label>
-            <label style={{ display: 'block', color: '#666', cursor: 'not-allowed' }}>
-              <input
-                type="radio"
-                name="coordSystem"
-                value="linear"
-                disabled
-                style={{ marginRight: 8 }}
-              />
-              Linear <span style={{ fontSize: 12, color: '#555' }}>(coming soon)</span>
-            </label>
-          </div>
-
-          <p style={{ marginBottom: 4, fontWeight: 600 }}>Anchor positions (shared for all participants):</p>
-          <p style={{ marginBottom: 12, color: '#888', fontSize: 13 }}>Values are percentages (0–100) of the canvas width/height.</p>
-          <button
-            className="v3-admin-btn"
-            style={{ marginBottom: 16, padding: '6px 14px', fontSize: 13 }}
-            onClick={resetAnchors}
-          >
-            Reset to defaults
-          </button>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {([
-              ['Positive', positiveX, setPositiveX, positiveY, setPositiveY],
-              ['Negative', negativeX, setNegativeX, negativeY, setNegativeY],
-              ['Neutral',  neutralX,  setNeutralX,  neutralY,  setNeutralY],
-            ] as const).map(([label, xVal, xSetter, yVal, ySetter]) => (
-              <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                <span style={{ width: 72, color: '#aaa', fontSize: 13 }}>{label}</span>
-                <label style={{ fontSize: 13, color: '#888', marginRight: 4 }}>X</label>
+              {labelSelected === 'custom' && (
+                <div style={{ marginLeft: 24, display: 'flex', flexDirection: 'column', gap: 6 }}>
+                  {([['Positive', customPositive, setCustomPositive], ['Negative', customNegative, setCustomNegative], ['Neutral', customNeutral, setCustomNeutral]] as const).map(([slot, val, setter]) => (
+                    <div key={slot} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <span style={{ width: 64, color: '#aaa', fontSize: 13 }}>{slot}</span>
+                      <input
+                        type="text"
+                        value={val}
+                        onChange={e => setter(e.target.value)}
+                        placeholder={`${slot} label`}
+                        style={{ background: '#333', border: '1px solid #555', color: '#eee', padding: '4px 8px', borderRadius: 4 }}
+                      />
+                    </div>
+                  ))}
+                  {customHistory.length > 0 && (
+                    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 4 }}>
+                      {customHistory.map((entry, i) => (
+                        <div
+                          key={i}
+                          style={{ display: 'inline-flex', alignItems: 'center', gap: 4, background: '#2a2a2a', border: '1px solid #444', borderRadius: 4, padding: '3px 6px', fontSize: 12, color: '#aaa', cursor: 'pointer' }}
+                          onClick={() => { setCustomPositive(entry.positive); setCustomNegative(entry.negative); setCustomNeutral(entry.neutral); }}
+                        >
+                          <span>{entry.positive} / {entry.negative} / {entry.neutral}</span>
+                          <button
+                            onClick={e => { e.stopPropagation(); setCustomHistory(removeCustomLabelFromHistory(i)); }}
+                            style={{ background: 'none', border: 'none', color: '#666', cursor: 'pointer', padding: '0 2px', fontSize: 13, lineHeight: 1 }}
+                          >×</button>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+              <label style={{ display: 'block', cursor: 'pointer' }}>
                 <input
-                  type="number"
-                  min={0}
-                  max={100}
-                  value={xVal}
-                  onChange={e => xSetter(e.target.value)}
-                  style={inputStyle}
+                  type="radio"
+                  name="labelSelected"
+                  value="none"
+                  checked={labelSelected === 'none'}
+                  onChange={() => setLabelSelected('none')}
+                  style={{ marginRight: 8 }}
                 />
-                <label style={{ fontSize: 13, color: '#888', marginRight: 4 }}>Y</label>
-                <input
-                  type="number"
-                  min={0}
-                  max={100}
-                  value={yVal}
-                  onChange={e => ySetter(e.target.value)}
-                  style={inputStyle}
-                />
-              </div>
-            ))}
+                None (hide labels)
+              </label>
+            </div>
+            <button
+              className="v3-admin-btn"
+              style={{ marginTop: 16 }}
+              onClick={sendLabels}
+              disabled={labelSelected === 'custom' && (!customPositive || !customNegative || !customNeutral)}
+            >
+              Apply Labels
+            </button>
           </div>
-          <button
-            className="v3-admin-btn"
-            style={{ marginTop: 16 }}
-            onClick={sendAnchors}
-          >
-            Apply Anchors
-          </button>
-        </div>
-      )}
+        )}
 
-      {configTab === 'avatars' && (
-        <div>
-          <p style={{ marginBottom: 4, fontWeight: 600 }}>Avatar style (shown to all participants):</p>
-          <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>Avatars are generated from each user's ID using <a href="https://www.dicebear.com" target="_blank" rel="noopener noreferrer" style={{ color: '#69f' }}>DiceBear</a>.</p>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-            <label style={{ display: 'flex', alignItems: 'center', gap: 12, cursor: 'pointer' }}>
-              <input
-                type="radio"
-                name="avatarStyle"
-                value=""
-                checked={avatarStyle === null}
-                onChange={() => sendAvatarStyle(null)}
-                style={{ marginRight: 4 }}
-              />
-              <span style={{ color: '#aaa' }}>None (show colored dots)</span>
-            </label>
-            {[
-              { id: 'adventurer', label: 'Adventurer' },
-              { id: 'avataaars', label: 'Avataaars' },
-              { id: 'bottts', label: 'Bottts (Robots)' },
-              { id: 'fun-emoji', label: 'Fun Emoji' },
-              { id: 'identicon', label: 'Identicon' },
-              { id: 'lorelei', label: 'Lorelei' },
-              { id: 'micah', label: 'Micah' },
-              { id: 'open-peeps', label: 'Open Peeps' },
-              { id: 'pixel-art', label: 'Pixel Art' },
-              { id: 'thumbs', label: 'Thumbs' },
-            ].map(({ id, label }) => (
-              <label key={id} style={{ display: 'flex', alignItems: 'center', gap: 12, cursor: 'pointer' }}>
+        {/* ANCHORS tab */}
+        {activeTab === 'anchors' && (
+          <div>
+            <p style={{ marginBottom: 12, fontWeight: 600 }}>Coordinate system:</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginBottom: 24 }}>
+              <label style={{ display: 'block', cursor: 'pointer' }}>
+                <input
+                  type="radio"
+                  name="coordSystem"
+                  value="barycentric"
+                  checked
+                  readOnly
+                  style={{ marginRight: 8 }}
+                />
+                Barycentric
+              </label>
+              <label style={{ display: 'block', color: '#666', cursor: 'not-allowed' }}>
+                <input
+                  type="radio"
+                  name="coordSystem"
+                  value="linear"
+                  disabled
+                  style={{ marginRight: 8 }}
+                />
+                Linear <span style={{ fontSize: 12, color: '#555' }}>(coming soon)</span>
+              </label>
+            </div>
+
+            <p style={{ marginBottom: 4, fontWeight: 600 }}>Anchor positions (shared for all participants):</p>
+            <p style={{ marginBottom: 12, color: '#888', fontSize: 13 }}>Values are percentages (0–100) of the canvas width/height.</p>
+            <button
+              className="v3-admin-btn"
+              style={{ marginBottom: 16, padding: '6px 14px', fontSize: 13 }}
+              onClick={resetAnchors}
+            >
+              Reset to defaults
+            </button>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {([
+                ['Positive', positiveX, setPositiveX, positiveY, setPositiveY],
+                ['Negative', negativeX, setNegativeX, negativeY, setNegativeY],
+                ['Neutral',  neutralX,  setNeutralX,  neutralY,  setNeutralY],
+              ] as const).map(([label, xVal, xSetter, yVal, ySetter]) => (
+                <div key={label} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <span style={{ width: 72, color: '#aaa', fontSize: 13 }}>{label}</span>
+                  <label style={{ fontSize: 13, color: '#888', marginRight: 4 }}>X</label>
+                  <input
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={xVal}
+                    onChange={e => xSetter(e.target.value)}
+                    style={inputStyle}
+                  />
+                  <label style={{ fontSize: 13, color: '#888', marginRight: 4 }}>Y</label>
+                  <input
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={yVal}
+                    onChange={e => ySetter(e.target.value)}
+                    style={inputStyle}
+                  />
+                </div>
+              ))}
+            </div>
+            <button
+              className="v3-admin-btn"
+              style={{ marginTop: 16 }}
+              onClick={sendAnchors}
+            >
+              Apply Anchors
+            </button>
+          </div>
+        )}
+
+        {/* AVATARS tab */}
+        {activeTab === 'avatars' && (
+          <div>
+            <p style={{ marginBottom: 4, fontWeight: 600 }}>Avatar style (shown to all participants):</p>
+            <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>Avatars are generated from each user's ID using <a href="https://www.dicebear.com" target="_blank" rel="noopener noreferrer" style={{ color: '#69f' }}>DiceBear</a>.</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 12, cursor: 'pointer' }}>
                 <input
                   type="radio"
                   name="avatarStyle"
-                  value={id}
-                  checked={avatarStyle === id}
-                  onChange={() => sendAvatarStyle(id)}
+                  value=""
+                  checked={avatarStyle === null}
+                  onChange={() => sendAvatarStyle(null)}
                   style={{ marginRight: 4 }}
                 />
-                <img
-                  src={`https://api.dicebear.com/9.x/${id}/svg?seed=preview`}
-                  alt={label}
-                  width={36}
-                  height={36}
-                  style={{ borderRadius: '50%', border: '2px solid #555', background: '#222' }}
-                />
-                <span>{label}</span>
+                <span style={{ color: '#aaa' }}>None (show colored dots)</span>
               </label>
-            ))}
-          </div>
-        </div>
-      )}
-
-      {configTab === 'interfaces' && (
-        <div>
-          <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>All settings here are shared with all participants in real time.</p>
-          <p style={{ marginBottom: 12, fontWeight: 600 }}>Interfaces</p>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-            {([
-              { id: 'canvas', label: 'Reaction Canvas', desc: 'Standard reaction canvas' },
-              { id: 'image-canvas', label: 'Image Canvas', desc: 'React over a shared background image' },
-              { id: 'soccer', label: 'Soccer', desc: 'Top-down physics ball — kick with your cursor' },
-            ] as const).map(({ id, label, desc }) => (
-              <label key={id} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}>
-                <input
-                  type="radio"
-                  name="activity"
-                  value={id}
-                  checked={activity === id}
-                  onChange={() => sendActivity(id)}
-                  style={{ marginTop: 3 }}
-                />
-                <div>
-                  <span style={{ fontWeight: activity === id ? 600 : 400 }}>{label}</span>
-                  <span style={{ color: '#888', fontSize: 13, marginLeft: 8 }}>{desc}</span>
-                  {id === 'image-canvas' && (
-                    <button
-                      className="image-canvas-config-link"
-                      onClick={e => { e.preventDefault(); setImageConfigOpen(true); }}
-                    >
-                      config
-                    </button>
-                  )}
-                </div>
-              </label>
-            ))}
-          </div>
-
-          {activity === 'soccer' && (
-            <div style={{ marginTop: 24, borderTop: '1px solid #444', paddingTop: 20 }}>
-              <p style={{ marginBottom: 10, fontWeight: 600 }}>Soccer settings:</p>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 20, marginBottom: 12 }}>
-                <span style={{ color: '#aaa', fontSize: 15 }}>Score:</span>
-                <span style={{ fontFamily: 'monospace', fontSize: 22, fontWeight: 700, color: '#eee' }}>
-                  {soccerScore.left} – {soccerScore.right}
-                </span>
-              </div>
-              <button className="v3-admin-btn v3-admin-btn--destructive" onClick={resetSoccerScore}>
-                Reset Score
-              </button>
-            </div>
-          )}
-
-          <div style={{ marginTop: 32, borderTop: '1px solid #444', paddingTop: 20 }}>
-            <p style={{ marginBottom: 4, fontWeight: 600 }}>Popups</p>
-            <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>Push a one-time form to all participants. Submissions appear in the Events tab.</p>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-              <div style={{ background: '#222', border: '1px solid #444', borderRadius: 8, padding: '12px 14px' }}>
-                <p style={{ fontWeight: 600, margin: '0 0 2px' }}>Coder role</p>
-                <p style={{ color: '#888', fontSize: 13, margin: '0 0 10px' }}>Ask participants for their GitHub username to confirm they can contribute code.</p>
-                <button className="v3-admin-btn" onClick={triggerGithubActivity}>
-                  Push popup
-                </button>
-              </div>
+              {[
+                { id: 'adventurer', label: 'Adventurer' },
+                { id: 'avataaars', label: 'Avataaars' },
+                { id: 'bottts', label: 'Bottts (Robots)' },
+                { id: 'fun-emoji', label: 'Fun Emoji' },
+                { id: 'identicon', label: 'Identicon' },
+                { id: 'lorelei', label: 'Lorelei' },
+                { id: 'micah', label: 'Micah' },
+                { id: 'open-peeps', label: 'Open Peeps' },
+                { id: 'pixel-art', label: 'Pixel Art' },
+                { id: 'thumbs', label: 'Thumbs' },
+              ].map(({ id, label }) => (
+                <label key={id} style={{ display: 'flex', alignItems: 'center', gap: 12, cursor: 'pointer' }}>
+                  <input
+                    type="radio"
+                    name="avatarStyle"
+                    value={id}
+                    checked={avatarStyle === id}
+                    onChange={() => sendAvatarStyle(id)}
+                    style={{ marginRight: 4 }}
+                  />
+                  <img
+                    src={`https://api.dicebear.com/9.x/${id}/svg?seed=preview`}
+                    alt={label}
+                    width={36}
+                    height={36}
+                    style={{ borderRadius: '50%', border: '2px solid #555', background: '#222' }}
+                  />
+                  <span>{label}</span>
+                </label>
+              ))}
             </div>
           </div>
-        </div>
-      )}
+        )}
 
-      {configTab === 'events' && (
-        <div>
-          <div style={{ display: 'flex', gap: 8, marginBottom: 16, alignItems: 'center' }}>
-            <p style={{ fontWeight: 600, margin: 0 }}>GitHub username submissions</p>
-            <button
-              className="v3-admin-btn"
-              onClick={downloadGithubSubmissions}
-              disabled={githubSubmissions.length === 0}
-              style={{ marginLeft: 'auto' }}
-            >
-              ↓ Download JSON
-            </button>
-            <button
-              className="v3-admin-btn v3-admin-btn--destructive"
-              onClick={() => setGithubSubmissions([])}
-              disabled={githubSubmissions.length === 0}
-            >
-              ✕ Clear
-            </button>
-          </div>
-          {githubSubmissions.length === 0 ? (
-            <p style={{ color: '#666', fontSize: 13 }}>No submissions yet. Trigger the activity from the Interfaces tab.</p>
-          ) : (
-            <div style={{ overflowX: 'auto' }}>
-              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, fontFamily: 'monospace' }}>
-                <thead>
-                  <tr style={{ background: '#222', color: '#aaa', textAlign: 'left' }}>
-                    <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>#</th>
-                    <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>time</th>
-                    <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>avatar</th>
-                    <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>username</th>
-                    <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>display name</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {githubSubmissions.map((s, i) => (
-                    <tr key={i} style={{ background: i % 2 === 0 ? '#1a1a1a' : '#111' }}>
-                      <td style={{ padding: '4px 10px', color: '#555' }}>{i + 1}</td>
-                      <td style={{ padding: '4px 10px', color: '#888' }}>
-                        {new Date(s.timestamp).toISOString().slice(11, 19)}
-                      </td>
-                      <td style={{ padding: '4px 10px' }}>
-                        {s.avatarUrl && (
-                          <img src={s.avatarUrl} alt={s.username} width={24} height={24} style={{ borderRadius: '50%', verticalAlign: 'middle' }} />
-                        )}
-                      </td>
-                      <td style={{ padding: '4px 10px', color: '#9cf' }}>
-                        <a href={`https://github.com/${s.username}`} target="_blank" rel="noopener noreferrer" style={{ color: '#9cf' }}>
-                          @{s.username}
-                        </a>
-                      </td>
-                      <td style={{ padding: '4px 10px', color: '#ccc' }}>{s.displayName ?? ''}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          )}
-        </div>
-      )}
-
-      {configTab === 'participants' && (
-        <div>
-          <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', gap: 12 }}>
-            <label style={{ color: '#aaa', fontSize: 13 }}>Group by:</label>
-            <select
-              value={participantGrouping}
-              onChange={e => setParticipantGrouping(e.target.value as 'none' | 'valence')}
-              style={{ background: '#222', color: '#eee', border: '1px solid #555', padding: '4px 8px', borderRadius: 4 }}
-            >
-              <option value="valence">Valence Zone</option>
-              <option value="none">None</option>
-            </select>
-          </div>
-
-          {connectedUsers.size === 0 ? (
-            <p style={{ color: '#666', fontSize: 13 }}>No participants connected.</p>
-          ) : participantGrouping === 'none' ? (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-              {[...connectedUsers].map(userId => {
-                const cursor = liveCursors.get(userId);
-                const region = cursor ? computeReactionRegion(cursor.x, cursor.y, activeAnchors) : null;
-                return <ParticipantRow key={userId} userId={userId} region={region} labels={activeLabels} />;
-              })}
-            </div>
-          ) : (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
-              {(['positive', 'negative', 'neutral', null] as (ReactionRegion | null)[]).map(region => {
-                const groupKey = String(region);
-                const members = [...connectedUsers].filter(userId => {
-                  const cursor = liveCursors.get(userId);
-                  if (!cursor) return region === null;
-                  return computeReactionRegion(cursor.x, cursor.y, activeAnchors) === region;
-                });
-                const groupLabel = region === null ? 'Lurking' : activeLabels[region];
-                const collapsed = collapsedGroups.has(groupKey);
-                const toggleCollapse = () => setCollapsedGroups(prev => {
-                  const s = new Set(prev);
-                  s.has(groupKey) ? s.delete(groupKey) : s.add(groupKey);
-                  return s;
-                });
-                return (
-                  <div key={groupKey}>
-                    <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: collapsed ? 0 : 6, paddingRight: 10 }}>
-                      <button onClick={toggleCollapse} style={{ background: 'none', border: 'none', color: '#666', cursor: 'pointer', padding: 0, fontSize: 10, width: 12, textAlign: 'center', flexShrink: 0 }}>
-                        {collapsed ? '▶' : '▼'}
+        {/* INTERFACES tab */}
+        {activeTab === 'interfaces' && (
+          <div>
+            <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>All settings here are shared with all participants in real time.</p>
+            <p style={{ marginBottom: 12, fontWeight: 600 }}>Interfaces</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {([
+                { id: 'canvas', label: 'Reaction Canvas', desc: 'Standard reaction canvas' },
+                { id: 'image-canvas', label: 'Image Canvas', desc: 'React over a shared background image' },
+                { id: 'soccer', label: 'Soccer', desc: 'Top-down physics ball — kick with your cursor' },
+              ] as const).map(({ id, label, desc }) => (
+                <label key={id} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}>
+                  <input
+                    type="radio"
+                    name="activity"
+                    value={id}
+                    checked={activity === id}
+                    onChange={() => sendActivity(id)}
+                    style={{ marginTop: 3 }}
+                  />
+                  <div>
+                    <span style={{ fontWeight: activity === id ? 600 : 400 }}>{label}</span>
+                    <span style={{ color: '#888', fontSize: 13, marginLeft: 8 }}>{desc}</span>
+                    {id === 'image-canvas' && (
+                      <button
+                        className="image-canvas-config-link"
+                        onClick={e => { e.preventDefault(); setImageConfigOpen(true); }}
+                      >
+                        config
                       </button>
-                      <span style={{ fontSize: 12, fontWeight: 600, color: '#888', textTransform: 'uppercase', letterSpacing: '0.08em', flex: 1, cursor: 'pointer' }} onClick={toggleCollapse}>
-                        {groupLabel} ({members.length})
-                      </span>
-                      <button disabled style={{ opacity: 0.3, fontSize: 11, padding: '2px 8px', background: '#333', border: '1px solid #555', color: '#aaa', borderRadius: 3, cursor: 'not-allowed' }}>
-                        ···
-                      </button>
-                    </div>
-                    {!collapsed && (
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-                        {members.length === 0 ? (
-                          <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 10px' }}>
-                            <span style={{ width: 8, height: 8, flexShrink: 0 }} />
-                            <span style={{ fontFamily: 'monospace', fontSize: 12, color: '#444', fontStyle: 'italic', flex: 1 }}>empty</span>
-                            <button disabled style={{ opacity: 0, fontSize: 11, padding: '2px 8px', background: '#333', border: '1px solid #555', color: '#aaa', borderRadius: 3, cursor: 'not-allowed' }}>···</button>
-                          </div>
-                        ) : members.map(userId => (
-                          <ParticipantRow key={userId} userId={userId} region={region} labels={activeLabels} />
-                        ))}
-                      </div>
                     )}
                   </div>
-                );
-              })}
+                </label>
+              ))}
             </div>
-          )}
-        </div>
-      )}
 
-        </div>{/* end right column */}
-      </div>{/* end two-column row */}
-
-      {/* Events table */}
-      {displayEvents.length > 0 && (
-        <div style={{ marginTop: 40 }}>
-          <p style={{ fontWeight: 600, marginBottom: 8 }}>
-            Recorded events
-            {eventCount > MAX_TABLE_ROWS && (
-              <span style={{ fontWeight: 400, color: '#888', fontSize: 13, marginLeft: 8 }}>
-                (showing last {MAX_TABLE_ROWS} of {eventCount})
-              </span>
+            {activity === 'soccer' && (
+              <div style={{ marginTop: 24, borderTop: '1px solid #444', paddingTop: 20 }}>
+                <p style={{ marginBottom: 10, fontWeight: 600 }}>Soccer settings:</p>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 20, marginBottom: 12 }}>
+                  <span style={{ color: '#aaa', fontSize: 15 }}>Score:</span>
+                  <span style={{ fontFamily: 'monospace', fontSize: 22, fontWeight: 700, color: '#eee' }}>
+                    {soccerScore.left} – {soccerScore.right}
+                  </span>
+                </div>
+                <button className="v3-admin-btn v3-admin-btn--destructive" onClick={resetSoccerScore}>
+                  Reset Score
+                </button>
+              </div>
             )}
-          </p>
-          <div style={{ overflowX: 'auto' }}>
-            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, fontFamily: 'monospace' }}>
-              <thead>
-                <tr style={{ background: '#222', color: '#aaa', textAlign: 'left' }}>
-                  <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>#</th>
-                  <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>time</th>
-                  <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>connectionId</th>
-                  <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>from</th>
-                  <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>to</th>
-                  <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>type</th>
-                  <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>x</th>
-                  <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>y</th>
-                </tr>
-              </thead>
-              <tbody>
-                {displayEvents.map((evt, i) => {
-                  const e = evt as Record<string, unknown>;
-                  const offset = eventCount - displayEvents.length;
-                  const ts = typeof e.timestamp === 'number'
-                    ? new Date(e.timestamp).toISOString().slice(11, 23)
-                    : '';
-                  return (
-                    <tr key={i} style={{ background: i % 2 === 0 ? '#1a1a1a' : '#111' }}>
-                      <td style={{ padding: '4px 10px', color: '#555' }}>{offset + i + 1}</td>
-                      <td style={{ padding: '4px 10px', color: '#888' }}>{ts}</td>
-                      <td style={{ padding: '4px 10px', color: '#ccc' }}>{String(e.connectionId ?? '')}</td>
-                      <td style={{ padding: '4px 10px', color: '#f99' }}>{e.from !== undefined ? String(e.from ?? 'null') : ''}</td>
-                      <td style={{ padding: '4px 10px', color: '#9f9' }}>{e.to !== undefined ? String(e.to ?? 'null') : ''}</td>
-                      <td style={{ padding: '4px 10px', color: '#99f' }}>{e.type !== undefined ? String(e.type) : ''}</td>
-                      <td style={{ padding: '4px 10px', color: '#aaa' }}>{e.x !== undefined ? String((e.x as number).toFixed(2)) : ''}</td>
-                      <td style={{ padding: '4px 10px', color: '#aaa' }}>{e.y !== undefined ? String((e.y as number).toFixed(2)) : ''}</td>
+
+            <div style={{ marginTop: 32, borderTop: '1px solid #444', paddingTop: 20 }}>
+              <p style={{ marginBottom: 4, fontWeight: 600 }}>Popups</p>
+              <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>Push a one-time form to all participants. Submissions appear in the Events tab.</p>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+                <div style={{ background: '#222', border: '1px solid #444', borderRadius: 8, padding: '12px 14px' }}>
+                  <p style={{ fontWeight: 600, margin: '0 0 2px' }}>Coder role</p>
+                  <p style={{ color: '#888', fontSize: 13, margin: '0 0 10px' }}>Ask participants for their GitHub username to confirm they can contribute code.</p>
+                  <button className="v3-admin-btn" onClick={triggerGithubActivity}>
+                    Push popup
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* EVENTS tab */}
+        {activeTab === 'events' && (
+          <div>
+            <div style={{ display: 'flex', gap: 8, marginBottom: 16, alignItems: 'center' }}>
+              <p style={{ fontWeight: 600, margin: 0 }}>GitHub username submissions</p>
+              <button
+                className="v3-admin-btn"
+                onClick={downloadGithubSubmissions}
+                disabled={githubSubmissions.length === 0}
+                style={{ marginLeft: 'auto' }}
+              >
+                ↓ Download JSON
+              </button>
+              <button
+                className="v3-admin-btn v3-admin-btn--destructive"
+                onClick={() => setGithubSubmissions([])}
+                disabled={githubSubmissions.length === 0}
+              >
+                ✕ Clear
+              </button>
+            </div>
+            {githubSubmissions.length === 0 ? (
+              <p style={{ color: '#666', fontSize: 13 }}>No submissions yet. Trigger the activity from the Interface tab.</p>
+            ) : (
+              <div style={{ overflowX: 'auto' }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, fontFamily: 'monospace' }}>
+                  <thead>
+                    <tr style={{ background: '#222', color: '#aaa', textAlign: 'left' }}>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>#</th>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>time</th>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>avatar</th>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>username</th>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>display name</th>
                     </tr>
+                  </thead>
+                  <tbody>
+                    {githubSubmissions.map((s, i) => (
+                      <tr key={i} style={{ background: i % 2 === 0 ? '#1a1a1a' : '#111' }}>
+                        <td style={{ padding: '4px 10px', color: '#555' }}>{i + 1}</td>
+                        <td style={{ padding: '4px 10px', color: '#888' }}>
+                          {new Date(s.timestamp).toISOString().slice(11, 19)}
+                        </td>
+                        <td style={{ padding: '4px 10px' }}>
+                          {s.avatarUrl && (
+                            <img src={s.avatarUrl} alt={s.username} width={24} height={24} style={{ borderRadius: '50%', verticalAlign: 'middle' }} />
+                          )}
+                        </td>
+                        <td style={{ padding: '4px 10px', color: '#9cf' }}>
+                          <a href={`https://github.com/${s.username}`} target="_blank" rel="noopener noreferrer" style={{ color: '#9cf' }}>
+                            @{s.username}
+                          </a>
+                        </td>
+                        <td style={{ padding: '4px 10px', color: '#ccc' }}>{s.displayName ?? ''}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* PARTICIPANTS tab */}
+        {activeTab === 'participants' && (
+          <div>
+            <div style={{ marginBottom: 16, display: 'flex', alignItems: 'center', gap: 12 }}>
+              <label style={{ color: '#aaa', fontSize: 13 }}>Group by:</label>
+              <select
+                value={participantGrouping}
+                onChange={e => setParticipantGrouping(e.target.value as 'none' | 'valence')}
+                style={{ background: '#222', color: '#eee', border: '1px solid #555', padding: '4px 8px', borderRadius: 4 }}
+              >
+                <option value="valence">Valence Zone</option>
+                <option value="none">None</option>
+              </select>
+            </div>
+
+            {connectedUsers.size === 0 ? (
+              <p style={{ color: '#666', fontSize: 13 }}>No participants connected.</p>
+            ) : participantGrouping === 'none' ? (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                {[...connectedUsers].map(userId => {
+                  const cursor = liveCursors.get(userId);
+                  const region = cursor ? computeReactionRegion(cursor.x, cursor.y, activeAnchors) : null;
+                  return <ParticipantRow key={userId} userId={userId} region={region} labels={activeLabels} />;
+                })}
+              </div>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+                {(['positive', 'negative', 'neutral', null] as (ReactionRegion | null)[]).map(region => {
+                  const groupKey = String(region);
+                  const members = [...connectedUsers].filter(userId => {
+                    const cursor = liveCursors.get(userId);
+                    if (!cursor) return region === null;
+                    return computeReactionRegion(cursor.x, cursor.y, activeAnchors) === region;
+                  });
+                  const groupLabel = region === null ? 'Lurking' : activeLabels[region];
+                  const collapsed = collapsedGroups.has(groupKey);
+                  const toggleCollapse = () => setCollapsedGroups(prev => {
+                    const s = new Set(prev);
+                    s.has(groupKey) ? s.delete(groupKey) : s.add(groupKey);
+                    return s;
+                  });
+                  return (
+                    <div key={groupKey}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: collapsed ? 0 : 6, paddingRight: 10 }}>
+                        <button onClick={toggleCollapse} style={{ background: 'none', border: 'none', color: '#666', cursor: 'pointer', padding: 0, fontSize: 10, width: 12, textAlign: 'center', flexShrink: 0 }}>
+                          {collapsed ? '▶' : '▼'}
+                        </button>
+                        <span style={{ fontSize: 12, fontWeight: 600, color: '#888', textTransform: 'uppercase', letterSpacing: '0.08em', flex: 1, cursor: 'pointer' }} onClick={toggleCollapse}>
+                          {groupLabel} ({members.length})
+                        </span>
+                        <button disabled style={{ opacity: 0.3, fontSize: 11, padding: '2px 8px', background: '#333', border: '1px solid #555', color: '#aaa', borderRadius: 3, cursor: 'not-allowed' }}>
+                          ···
+                        </button>
+                      </div>
+                      {!collapsed && (
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                          {members.length === 0 ? (
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 10px' }}>
+                              <span style={{ width: 8, height: 8, flexShrink: 0 }} />
+                              <span style={{ fontFamily: 'monospace', fontSize: 12, color: '#444', fontStyle: 'italic', flex: 1 }}>empty</span>
+                              <button disabled style={{ opacity: 0, fontSize: 11, padding: '2px 8px', background: '#333', border: '1px solid #555', color: '#aaa', borderRadius: 3, cursor: 'not-allowed' }}>···</button>
+                            </div>
+                          ) : members.map(userId => (
+                            <ParticipantRow key={userId} userId={userId} region={region} labels={activeLabels} />
+                          ))}
+                        </div>
+                      )}
+                    </div>
                   );
                 })}
-              </tbody>
-            </table>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* === PEEK CANVAS OVERLAY === */}
+      {isPeeking && (
+        <div style={{ position: 'fixed', inset: 0, zIndex: 100, background: '#1a1a1a', display: 'flex', flexDirection: 'column' }}>
+          <div style={{ flexShrink: 0, padding: '8px 16px', borderBottom: '1px solid #444', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <span style={{ color: '#aaa', fontSize: 13, fontFamily: 'monospace' }}>Canvas Peek — {room}</span>
+            <button
+              onClick={() => setIsPeeking(false)}
+              style={{ background: 'none', border: '1px solid #555', color: '#aaa', padding: '5px 12px', borderRadius: 4, cursor: 'pointer', fontSize: 13 }}
+            >
+              ✕ Close
+            </button>
+          </div>
+          <div style={{ flex: 1, overflow: 'hidden', position: 'relative' }}>
+            <Canvas
+              room={room}
+              userId="admin-peek"
+              readOnly={true}
+              colorCursorsByVote={true}
+              debug={true}
+              heightOffset={46}
+            />
           </div>
         </div>
       )}
-      </div>}
+
       {imageConfigOpen && (
         <ImageConfigModal
           currentUrl={roomImageUrl}

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -974,55 +974,53 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
             </div>
 
             {/* Recorded events table */}
-            {displayEvents.length > 0 && (
-              <div style={{ marginTop: 40 }}>
-                <p style={{ fontWeight: 600, marginBottom: 8 }}>
-                  Recorded events
-                  {eventCount > MAX_TABLE_ROWS && (
-                    <span style={{ fontWeight: 400, color: '#888', fontSize: 13, marginLeft: 8 }}>
-                      (showing last {MAX_TABLE_ROWS} of {eventCount})
-                    </span>
-                  )}
-                </p>
-                <div style={{ overflowX: 'auto' }}>
-                  <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, fontFamily: 'monospace' }}>
-                    <thead>
-                      <tr style={{ background: '#222', color: '#aaa', textAlign: 'left' }}>
-                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>#</th>
-                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>time</th>
-                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>connectionId</th>
-                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>from</th>
-                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>to</th>
-                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>type</th>
-                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>x</th>
-                        <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>y</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {displayEvents.map((evt, i) => {
-                        const e = evt as Record<string, unknown>;
-                        const offset = eventCount - displayEvents.length;
-                        const ts = typeof e.timestamp === 'number'
-                          ? new Date(e.timestamp).toISOString().slice(11, 23)
-                          : '';
-                        return (
-                          <tr key={i} style={{ background: i % 2 === 0 ? '#1a1a1a' : '#111' }}>
-                            <td style={{ padding: '4px 10px', color: '#555' }}>{offset + i + 1}</td>
-                            <td style={{ padding: '4px 10px', color: '#888' }}>{ts}</td>
-                            <td style={{ padding: '4px 10px', color: '#ccc' }}>{String(e.connectionId ?? '')}</td>
-                            <td style={{ padding: '4px 10px', color: '#f99' }}>{e.from !== undefined ? String(e.from ?? 'null') : ''}</td>
-                            <td style={{ padding: '4px 10px', color: '#9f9' }}>{e.to !== undefined ? String(e.to ?? 'null') : ''}</td>
-                            <td style={{ padding: '4px 10px', color: '#99f' }}>{e.type !== undefined ? String(e.type) : ''}</td>
-                            <td style={{ padding: '4px 10px', color: '#aaa' }}>{e.x !== undefined ? String((e.x as number).toFixed(2)) : ''}</td>
-                            <td style={{ padding: '4px 10px', color: '#aaa' }}>{e.y !== undefined ? String((e.y as number).toFixed(2)) : ''}</td>
-                          </tr>
-                        );
-                      })}
-                    </tbody>
-                  </table>
-                </div>
+            <div style={{ marginTop: 40 }}>
+              <p style={{ fontWeight: 600, marginBottom: 8 }}>
+                Recorded events
+                {eventCount > MAX_TABLE_ROWS && (
+                  <span style={{ fontWeight: 400, color: '#888', fontSize: 13, marginLeft: 8 }}>
+                    (showing last {MAX_TABLE_ROWS} of {eventCount})
+                  </span>
+                )}
+              </p>
+              <div style={{ overflowX: 'auto' }}>
+                <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, fontFamily: 'monospace' }}>
+                  <thead>
+                    <tr style={{ background: '#222', color: '#aaa', textAlign: 'left' }}>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>#</th>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>time</th>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>connectionId</th>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>from</th>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>to</th>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>type</th>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>x</th>
+                      <th style={{ padding: '6px 10px', borderBottom: '1px solid #444' }}>y</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {displayEvents.map((evt, i) => {
+                      const e = evt as Record<string, unknown>;
+                      const offset = eventCount - displayEvents.length;
+                      const ts = typeof e.timestamp === 'number'
+                        ? new Date(e.timestamp).toISOString().slice(11, 23)
+                        : '';
+                      return (
+                        <tr key={i} style={{ background: i % 2 === 0 ? '#1a1a1a' : '#111' }}>
+                          <td style={{ padding: '4px 10px', color: '#555' }}>{offset + i + 1}</td>
+                          <td style={{ padding: '4px 10px', color: '#888' }}>{ts}</td>
+                          <td style={{ padding: '4px 10px', color: '#ccc' }}>{String(e.connectionId ?? '')}</td>
+                          <td style={{ padding: '4px 10px', color: '#f99' }}>{e.from !== undefined ? String(e.from ?? 'null') : ''}</td>
+                          <td style={{ padding: '4px 10px', color: '#9f9' }}>{e.to !== undefined ? String(e.to ?? 'null') : ''}</td>
+                          <td style={{ padding: '4px 10px', color: '#99f' }}>{e.type !== undefined ? String(e.type) : ''}</td>
+                          <td style={{ padding: '4px 10px', color: '#aaa' }}>{e.x !== undefined ? String((e.x as number).toFixed(2)) : ''}</td>
+                          <td style={{ padding: '4px 10px', color: '#aaa' }}>{e.y !== undefined ? String((e.y as number).toFixed(2)) : ''}</td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
               </div>
-            )}
+            </div>
           </div>
         )}
 

--- a/app/styles.css
+++ b/app/styles.css
@@ -1126,6 +1126,16 @@ body {
   cursor: not-allowed;
 }
 
+/* AdminPanelV4 mobile-friendly tab bar */
+.admin-v4-tab-bar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.admin-v4-tab-bar::-webkit-scrollbar {
+  display: none;
+}
+
 
 /* Responsive ghost cursors control */
 @media (max-width: 768px) {

--- a/app/styles.css
+++ b/app/styles.css
@@ -1130,6 +1130,8 @@ body {
 .admin-v4-tab-bar {
   scrollbar-width: none;
   -ms-overflow-style: none;
+  touch-action: pan-x;
+  overscroll-behavior-x: contain;
 }
 
 .admin-v4-tab-bar::-webkit-scrollbar {


### PR DESCRIPTION
## Summary

- Replaces two-column desktop layout with a single-column tab-based UI that works on mobile
- **Record** tab consolidates recording controls, playback, and the events table (previously the left column + bottom section)
- Config sections (Labels, Anchors, Avatars, Interface, Events, People) become top-level tabs in a horizontally-scrollable, scrollbar-hidden tab bar
- **Peek Canvas** is now a toggle button in the persistent header that opens a full-screen overlay, rather than a tab that replaced the whole UI
- Persistent header always shows: app name, room, live recording indicator (● REC), online count, and Peek toggle

## Test plan

- [x] Open `localhost:1999/#v4?admin=true&forceView=mobile` in browser devtools mobile viewport (e.g. iPhone 12)
- [x] Confirm all 7 tabs are reachable by swiping the tab bar
- [x] Confirm Record tab shows cap, recording mode, start/stop, playback, and events table
- [x] Confirm Peek toggle opens full-screen canvas overlay and Close button dismisses it
- [x] Confirm `pnpm tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~120 words of PR description from ~60 words of human prompts across this session)