### PR TITLE
fix: preview deployments connect to production PartyKit server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,11 +13,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: "npm"
-      - run: npm ci
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
       - run: npm run deploy -- --with-vars
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,7 +21,7 @@ jobs:
           node-version: 18
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
-      - run: npm run deploy -- --with-vars
+      - run: pnpm run deploy -- --with-vars
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,4 +22,3 @@ jobs:
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon
-          PARTYKIT_HOST: polislike-partykit-reaction-canvas.patcon.partykit.dev

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   delete-preview:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -15,7 +17,7 @@ jobs:
           node-version: 18
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
-      - run: npx partykit delete --preview pr-${{ github.event.pull_request.number }} --force
+      - run: pnpm exec partykit delete --preview pr-${{ github.event.pull_request.number }} --force
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon

--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -9,11 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: "npm"
-      - run: npm ci
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
       - run: npx partykit delete --preview pr-${{ github.event.pull_request.number }} --force
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   deploy-preview:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       pull-requests: write
     steps:
@@ -19,7 +21,7 @@ jobs:
           node-version: 18
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
-      - run: npm run cachebust && npx partykit deploy --preview pr-${{ github.event.pull_request.number }} --with-vars
+      - run: pnpm run cachebust && pnpm exec partykit deploy --preview pr-${{ github.event.pull_request.number }} --with-vars
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,11 +13,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: "npm"
-      - run: npm ci
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
       - run: npm run cachebust && npx partykit deploy --preview pr-${{ github.event.pull_request.number }} --with-vars
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -22,7 +22,6 @@ jobs:
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon
-          PARTYKIT_HOST: pr-${{ github.event.pull_request.number }}.polislike-partykit-reaction-canvas.patcon.partykit.dev
       - uses: actions/github-script@v7
         with:
           script: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file. Releases cu
 - V4 admin: confirm dialog on the Clear button shows the current event count before discarding ([`d579f85`](https://github.com/patcon/polislike-partykit-reaction-canvas/commit/d579f85))
 
 ### Fixed
+- All versions: preview deployments now connect to their own isolated PartyKit server instead of production — replaced the hardcoded `process.env.PARTYKIT_HOST` build-time define with `window.location.hostname` so each environment (local dev, staging, PR preview, production) automatically uses its own server
 - V4 admin: fix vertical bounce when swiping the tab bar on iOS/Android — added `touch-action: pan-x` and `overscroll-behavior-x: contain` so the browser treats tab-bar swipes as horizontal-only ([`d579f85`](https://github.com/patcon/polislike-partykit-reaction-canvas/commit/d579f85))
 
 ## Week 21 (2026-04-13)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,15 +13,15 @@ A real-time collaborative voting canvas built on PartyKit (WebSockets) and React
 ## Dev commands
 
 ```bash
-npm run dev          # PartyKit dev server (frontend + server) on port 1999
-npm run storybook    # Storybook on localhost:6006
-npm run deploy       # Deploy to PartyKit — see rules below
-npm run deploy:staging  # Deploy to staging preview environment
-npm run cachebust    # Production build with cache-busting
-npx vitest           # Run Storybook-based tests via Playwright/Chromium (headless)
+pnpm run dev          # PartyKit dev server (frontend + server) on port 1999
+pnpm run storybook    # Storybook on localhost:6006
+pnpm run deploy       # Deploy to PartyKit — see rules below
+pnpm run deploy:staging  # Deploy to staging preview environment
+pnpm run cachebust    # Production build with cache-busting
+pnpm vitest           # Run Storybook-based tests via Playwright/Chromium (headless)
 ```
 
-`npm run dev` runs both the frontend and `party/server.ts` locally on port 1999. The app is accessible at `localhost:1999` or any local network IP on port 1999 (e.g. `10.x.x.x:1999`). The WebSocket host is detected by port — if you're on port 1999, sockets connect to the local server; otherwise they connect to the deployed server.
+`pnpm run dev` runs both the frontend and `party/server.ts` locally on port 1999. The app is accessible at `localhost:1999` or any local network IP on port 1999 (e.g. `10.x.x.x:1999`). The WebSocket host is detected by port — if you're on port 1999, sockets connect to the local server; otherwise they connect to the deployed server.
 
 ### PartyKit CLI notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,10 @@ npx vitest           # Run Storybook-based tests via Playwright/Chromium (headle
 
 `npm run dev` runs both the frontend and `party/server.ts` locally on port 1999. The app is accessible at `localhost:1999` or any local network IP on port 1999 (e.g. `10.x.x.x:1999`). The WebSocket host is detected by port — if you're on port 1999, sockets connect to the local server; otherwise they connect to the deployed server.
 
+### PartyKit CLI notes
+
+Use `--force` (not `--yes`) to skip confirmation prompts — e.g. `npx partykit delete --preview stg --force`. `--yes` is not a valid partykit option and will error.
+
 ### Deploy rules
 
 > **Never deploy uncommitted changes.** Always commit `party/server.ts` (and any other changed files) before running `npm run deploy`.

--- a/app/components/AdminPanel.tsx
+++ b/app/components/AdminPanel.tsx
@@ -26,7 +26,7 @@ export default function AdminPanel({ room }: AdminPanelProps) {
   const [ghostCursorsEnabled, setGhostCursorsEnabled] = useState(false);
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : process.env.PARTYKIT_HOST,
+    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : window.location.hostname,
     room: room,
     query: { isAdmin: 'true' },
     onMessage(evt) {

--- a/app/components/AdminPanelV4.tsx
+++ b/app/components/AdminPanelV4.tsx
@@ -174,7 +174,7 @@ export default function AdminPanelV4({ room }: AdminPanelV4Props) {
   // Keep refs in sync with state so the socket handler can access current values
   // without stale closures
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : process.env.PARTYKIT_HOST,
+    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : window.location.hostname,
     room,
     query: { isAdmin: 'true' },
     onMessage(evt) {

--- a/app/components/AdminPanelV5.tsx
+++ b/app/components/AdminPanelV5.tsx
@@ -106,7 +106,7 @@ export default function AdminPanelV5({ room }: AdminPanelV5Props) {
   };
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : process.env.PARTYKIT_HOST,
+    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : window.location.hostname,
     room,
     query: { isAdmin: 'true' },
     onMessage(evt) {

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -98,7 +98,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   });
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : process.env.PARTYKIT_HOST,
+    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : window.location.hostname,
     room: room,
     query: readOnly ? { isAdmin: 'true' } : { userId },
     onMessage(evt) {

--- a/app/components/SimpleReactionCanvasAppV1.tsx
+++ b/app/components/SimpleReactionCanvasAppV1.tsx
@@ -52,7 +52,7 @@ export default function SimpleReactionCanvasAppV1() {
   }, []);
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : process.env.PARTYKIT_HOST,
+    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : window.location.hostname,
     room: room,
     onMessage(evt) {
       try {

--- a/app/components/TouchLayer.tsx
+++ b/app/components/TouchLayer.tsx
@@ -75,7 +75,7 @@ export default function TouchLayer({
   const lastPositionRef = useRef<CursorPosition | null>(null);
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : process.env.PARTYKIT_HOST,
+    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : window.location.hostname,
     room: room,
     query: { userId },
     onMessage(evt) {

--- a/app/components/ValenceViz.tsx
+++ b/app/components/ValenceViz.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 
 const CAM_MODES = ['static', 'lerp', 'exp', 'spring', 'quat'];
-const DEFAULT_HOST = 'polislike-partykit-reaction-canvas.patcon.partykit.dev';
 
 interface SceneActions {
   togglePlay: () => void;
@@ -799,7 +798,7 @@ export default function ValenceViz() {
       if (wsReconnectTimer) clearTimeout(wsReconnectTimer);
       setWsStatusText('connecting…'); setWsStatusCls('connecting');
       setWsConnected(false);
-      const host=window.location.port==='1999'?`${window.location.hostname}:1999`:DEFAULT_HOST;
+      const host=window.location.port==='1999'?`${window.location.hostname}:1999`:window.location.hostname;
       const proto=window.location.port==='1999'?'ws':'wss';
       const userId=crypto.randomUUID();
       ws=new WebSocket(`${proto}://${host}/parties/main/${encodeURIComponent(room)}?isAdmin=true&userId=${userId}`);

--- a/docs/supabase.md
+++ b/docs/supabase.md
@@ -47,13 +47,12 @@ Edit the `serve.build.define` section with your actual values:
 
 ```json
 "define": {
-  "process.env.PARTYKIT_HOST": "'polislike-partykit-reaction-canvas.patcon.partykit.dev'",
   "process.env.PARTYKIT_SUPABASE_URL": "\"https://your-project.supabase.co\"",
   "process.env.PARTYKIT_SUPABASE_ANON_KEY": "\"eyJ...your-anon-key...\""
 }
 ```
 
-These values are bundled into the client-side JavaScript at build time — both for `npm run dev` and `npm run deploy`. The anon key is safe to commit since it only grants access to the `reaction_events` table and RLS is intentionally permissive.
+These values are bundled into the client-side JavaScript at build time — both for `pnpm run dev` and `pnpm run deploy`. The anon key is safe to commit since it only grants access to the `reaction_events` table and RLS is intentionally permissive.
 
 > **Note:** `npx partykit env add` does **not** work for this — PartyKit cloud env vars are only available to server-side code (`party/server.ts`), not to the client-side esbuild `define` step. Credentials must be embedded directly in `partykit.json`.
 >

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "qrcode.react": "^4.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.6.0",
         "simplex-noise": "^4.0.3",
         "three": "^0.183.2"
       },
@@ -4670,6 +4671,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
+      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "partykit dev --live",
     "deploy": "npm run cachebust && partykit deploy",
-    "deploy:staging": "npm run cachebust && PARTYKIT_HOST=staging.polislike-partykit-reaction-canvas.patcon.partykit.dev partykit deploy --preview staging --with-vars",
+    "deploy:staging": "npm run cachebust && partykit deploy --preview staging --with-vars",
     "cachebust": "node scripts/build-with-cachebust.js",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "polislike-partykit-reaction-canvas",
   "version": "0.0.0",
   "private": true,
+  "packageManager": "pnpm@10.18.0",
   "scripts": {
     "dev": "partykit dev --live",
     "deploy": "npm run cachebust && partykit deploy",

--- a/partykit.example.json
+++ b/partykit.example.json
@@ -8,7 +8,6 @@
     "build": {
       "entry": "app/client.tsx",
       "define": {
-        "process.env.PARTYKIT_HOST": "'your-project-name.your-username.partykit.dev'",
         "process.env.PARTYKIT_SUPABASE_URL": "\"https://your-project.supabase.co\"",
         "process.env.PARTYKIT_SUPABASE_ANON_KEY": "\"your-supabase-anon-key\""
       }

--- a/partykit.json
+++ b/partykit.json
@@ -8,7 +8,6 @@
     "build": {
       "entry": "app/client.tsx",
       "define": {
-        "process.env.PARTYKIT_HOST": "'polislike-partykit-reaction-canvas.patcon.partykit.dev'",
         "process.env.PARTYKIT_SUPABASE_URL": "\"https://cufrmdhkoabpwilwztym.supabase.co\"",
         "process.env.PARTYKIT_SUPABASE_ANON_KEY": "\"sb_publishable_HoNA1ULIi6X_bW9-4UJOMQ_zUuNogkJ\""
       }


### PR DESCRIPTION
## Summary

- Removes the hardcoded `process.env.PARTYKIT_HOST` build-time `define` from `partykit.json` that was embedding the production host into every client bundle
- Replaces it with `window.location.hostname` across all 7 components that establish WebSocket connections — since PartyKit serves both static assets and the WS server from the same hostname, this always resolves correctly for local dev, staging, previews, and production
- Removes now-redundant `PARTYKIT_HOST` env vars from CI workflows and `deploy:staging` script

## Root cause

`partykit.json`'s esbuild `define` performs a *build-time* string substitution, replacing `process.env.PARTYKIT_HOST` with the literal production hostname in every bundle. The preview workflow passed `PARTYKIT_HOST` via `--with-vars`, but that flag only injects env vars into the server worker — it does not override `define` values for the client build. So all preview bundles connected to production.

## Test plan

- [ ] Merge this PR and verify the PR preview URL (`pr-N.polislike-partykit-reaction-canvas.patcon.partykit.dev`) connects to its own isolated server (check DevTools Network for WS host)
- [ ] Confirm `localhost:1999` still connects to local server (port-based detection unchanged)
- [ ] Run `deploy:staging` and verify staging URL connects to the staging server

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~130 words of PR description from ~60 words of human prompts across this session)