### PR TITLE
feat: haptic indicator button with toggle and unsupported-device dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 22 (2026-04-20)
 
 ### Added
+- V4: haptic indicator button beside the QR share button — flashes when a buzz signal arrives; tap to toggle haptics on/off; on devices without haptic support it stays in "off" state but still flashes to show the signal arrived
 - V4 People tab: emcee can now send a haptic buzz to individual participants, groups, or reaction regions — a confirmation modal shows the target before sending, and participants see a permission dialog before their device vibrates ([#34](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/34))
 
 ### Fixed

--- a/app/components/HapticIndicatorButton.tsx
+++ b/app/components/HapticIndicatorButton.tsx
@@ -5,9 +5,10 @@ interface Props {
   flashing: boolean;
   canVibrate: boolean;
   onToggle: () => void;
+  onShowInfo?: () => void;
 }
 
-export default function HapticIndicatorButton({ enabled, flashing, canVibrate, onToggle }: Props) {
+export default function HapticIndicatorButton({ enabled, flashing, canVibrate, onToggle, onShowInfo }: Props) {
   const classes = [
     'haptic-indicator-btn',
     flashing ? 'haptic-indicator-btn--flash' : '',
@@ -17,7 +18,7 @@ export default function HapticIndicatorButton({ enabled, flashing, canVibrate, o
   return (
     <button
       className={classes}
-      onClick={canVibrate ? onToggle : undefined}
+      onClick={canVibrate ? onToggle : onShowInfo}
       aria-label={enabled ? "Disable haptic feedback" : "Enable haptic feedback"}
     >
       {enabled ? <LuVibrate size={20} /> : <LuVibrateOff size={20} />}

--- a/app/components/HapticIndicatorButton.tsx
+++ b/app/components/HapticIndicatorButton.tsx
@@ -1,0 +1,45 @@
+interface Props {
+  enabled: boolean;
+  flashing: boolean;
+  canVibrate: boolean;
+  onToggle: () => void;
+}
+
+export default function HapticIndicatorButton({ enabled, flashing, canVibrate, onToggle }: Props) {
+  const classes = [
+    'haptic-indicator-btn',
+    flashing ? 'haptic-indicator-btn--flash' : '',
+    !enabled ? 'haptic-indicator-btn--off' : '',
+  ].filter(Boolean).join(' ');
+
+  return (
+    <button
+      className={classes}
+      onClick={canVibrate ? onToggle : undefined}
+      aria-label={enabled ? "Disable haptic feedback" : "Enable haptic feedback"}
+    >
+      {enabled ? (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+          <rect x="8" y="4" width="8" height="16" rx="1.5" />
+          <line x1="5" y1="8" x2="6.5" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="4" y1="12" x2="6.5" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="5" y1="16" x2="6.5" y2="16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="17.5" y1="8" x2="19" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="17.5" y1="12" x2="20" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="17.5" y1="16" x2="19" y2="16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </svg>
+      ) : (
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+          <rect x="8" y="4" width="8" height="16" rx="1.5" />
+          <line x1="5" y1="8" x2="6.5" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="4" y1="12" x2="6.5" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="5" y1="16" x2="6.5" y2="16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="17.5" y1="8" x2="19" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="17.5" y1="12" x2="20" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="17.5" y1="16" x2="19" y2="16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          <line x1="3" y1="21" x2="21" y2="3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+        </svg>
+      )}
+    </button>
+  );
+}

--- a/app/components/HapticIndicatorButton.tsx
+++ b/app/components/HapticIndicatorButton.tsx
@@ -1,3 +1,5 @@
+import { LuVibrate, LuVibrateOff } from "react-icons/lu";
+
 interface Props {
   enabled: boolean;
   flashing: boolean;
@@ -18,28 +20,7 @@ export default function HapticIndicatorButton({ enabled, flashing, canVibrate, o
       onClick={canVibrate ? onToggle : undefined}
       aria-label={enabled ? "Disable haptic feedback" : "Enable haptic feedback"}
     >
-      {enabled ? (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-          <rect x="8" y="4" width="8" height="16" rx="1.5" />
-          <line x1="5" y1="8" x2="6.5" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="4" y1="12" x2="6.5" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="5" y1="16" x2="6.5" y2="16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="17.5" y1="8" x2="19" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="17.5" y1="12" x2="20" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="17.5" y1="16" x2="19" y2="16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-        </svg>
-      ) : (
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-          <rect x="8" y="4" width="8" height="16" rx="1.5" />
-          <line x1="5" y1="8" x2="6.5" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="4" y1="12" x2="6.5" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="5" y1="16" x2="6.5" y2="16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="17.5" y1="8" x2="19" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="17.5" y1="12" x2="20" y2="12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="17.5" y1="16" x2="19" y2="16" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-          <line x1="3" y1="21" x2="21" y2="3" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
-        </svg>
-      )}
+      {enabled ? <LuVibrate size={20} /> : <LuVibrateOff size={20} />}
     </button>
   );
 }

--- a/app/components/HapticPushModal.tsx
+++ b/app/components/HapticPushModal.tsx
@@ -1,16 +1,34 @@
+import { useState } from "react";
+
 interface HapticPushModalProps {
   onDismiss: () => void;
+  onSuppress: () => void;
 }
 
-export default function HapticPushModal({ onDismiss }: HapticPushModalProps) {
+export default function HapticPushModal({ onDismiss, onSuppress }: HapticPushModalProps) {
+  const [suppress, setSuppress] = useState(false);
+
+  const handleOk = () => {
+    if (suppress) onSuppress();
+    onDismiss();
+  };
+
   return (
-    <div className="github-modal-overlay" onClick={onDismiss}>
+    <div className="github-modal-overlay" onClick={handleOk}>
       <div className="github-modal" onClick={e => e.stopPropagation()}>
-        <div className="github-modal-title">Attention request</div>
+        <div className="github-modal-title">Haptic feedback unavailable</div>
         <div className="github-modal-body">
-          The facilitator sent a test buzz, but your device doesn't support haptic feedback via web apps.
+          Your device doesn't support haptic feedback via web apps.
         </div>
-        <button className="github-modal-btn-dismiss" onClick={onDismiss}>OK</button>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: '#888', cursor: 'pointer' }}>
+          <input
+            type="checkbox"
+            checked={suppress}
+            onChange={e => setSuppress(e.target.checked)}
+          />
+          Don't show again this session
+        </label>
+        <button className="github-modal-btn-dismiss" onClick={handleOk}>OK</button>
       </div>
     </div>
   );

--- a/app/components/HapticPushModal.tsx
+++ b/app/components/HapticPushModal.tsx
@@ -2,14 +2,15 @@ import { useState } from "react";
 
 interface HapticPushModalProps {
   onDismiss: () => void;
-  onSuppress: () => void;
+  suppressed: boolean;
+  onSuppressChange: (suppress: boolean) => void;
 }
 
-export default function HapticPushModal({ onDismiss, onSuppress }: HapticPushModalProps) {
-  const [suppress, setSuppress] = useState(false);
+export default function HapticPushModal({ onDismiss, suppressed, onSuppressChange }: HapticPushModalProps) {
+  const [suppress, setSuppress] = useState(suppressed);
 
   const handleOk = () => {
-    if (suppress) onSuppress();
+    onSuppressChange(suppress);
     onDismiss();
   };
 

--- a/app/components/HapticPushModal.tsx
+++ b/app/components/HapticPushModal.tsx
@@ -19,15 +19,15 @@ export default function HapticPushModal({ onDismiss, suppressed, onSuppressChang
       <div className="github-modal" onClick={e => e.stopPropagation()}>
         <div className="github-modal-title">Haptic feedback unavailable</div>
         <div className="github-modal-body">
-          Your device doesn't support haptic feedback via web apps.
+          Your device doesn't support haptic feedback via web apps. You can watch the vibration icon for a visual cue instead.
         </div>
         <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: '#888', cursor: 'pointer' }}>
           <input
             type="checkbox"
-            checked={suppress}
-            onChange={e => setSuppress(e.target.checked)}
+            checked={!suppress}
+            onChange={e => setSuppress(!e.target.checked)}
           />
-          Don't show again this session
+          Show this popup when a buzz is sent
         </label>
         <button className="github-modal-btn-dismiss" onClick={handleOk}>OK</button>
       </div>

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -207,6 +207,7 @@ export default function ReactionCanvasAppV4() {
             flashing={hapticFlashing}
             canVibrate={WebHaptics.isSupported}
             onToggle={() => { if (WebHaptics.isSupported) setHapticEnabled(prev => !prev); }}
+            onShowInfo={() => setHapticPending(true)}
           />
           {touchPos && (
             <div
@@ -310,7 +311,8 @@ export default function ReactionCanvasAppV4() {
           {hapticPending && (
             <HapticPushModal
               onDismiss={() => setHapticPending(false)}
-              onSuppress={() => setSuppressHapticModal(true)}
+              suppressed={suppressHapticModal}
+              onSuppressChange={setSuppressHapticModal}
             />
           )}
         </div>

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -115,6 +115,7 @@ export default function ReactionCanvasAppV4() {
   const [showGithubModal, setShowGithubModal] = useState(false);
   const [pushedInterface, setPushedInterface] = useState<string | null>(null);
   const [hapticPending, setHapticPending] = useState(false);
+  const [suppressHapticModal, setSuppressHapticModal] = useState(false);
   const [hapticEnabled, setHapticEnabled] = useState(WebHaptics.isSupported);
   const [hapticFlashing, setHapticFlashing] = useState(false);
   const hapticFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -240,7 +241,7 @@ export default function ReactionCanvasAppV4() {
               hapticFlashTimeoutRef.current = setTimeout(() => setHapticFlashing(false), 500);
               if (hapticEnabled && WebHaptics.isSupported) {
                 triggerHaptic('nudge');
-              } else if (!WebHaptics.isSupported) {
+              } else if (!WebHaptics.isSupported && !suppressHapticModal) {
                 setHapticPending(true);
               }
             }}
@@ -309,6 +310,7 @@ export default function ReactionCanvasAppV4() {
           {hapticPending && (
             <HapticPushModal
               onDismiss={() => setHapticPending(false)}
+              onSuppress={() => setSuppressHapticModal(true)}
             />
           )}
         </div>

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -17,6 +17,7 @@ import { getReactionLabelSet } from "../voteLabels";
 import type { ReactionLabelSet } from "../voteLabels";
 import { getPersistentUserId } from "../utils/userId";
 import ShareQRButton from "./ShareQRButton";
+import HapticIndicatorButton from "./HapticIndicatorButton";
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
 
@@ -114,6 +115,9 @@ export default function ReactionCanvasAppV4() {
   const [showGithubModal, setShowGithubModal] = useState(false);
   const [pushedInterface, setPushedInterface] = useState<string | null>(null);
   const [hapticPending, setHapticPending] = useState(false);
+  const [hapticEnabled, setHapticEnabled] = useState(WebHaptics.isSupported);
+  const [hapticFlashing, setHapticFlashing] = useState(false);
+  const hapticFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { trigger: triggerHaptic } = useWebHaptics();
 
   useEffect(() => {
@@ -197,6 +201,12 @@ export default function ReactionCanvasAppV4() {
           <div className="debug-hint">{debug ? 'd: debug on' : 'd: debug'}</div>
           <div className={`v3-rec-badge${isRecording ? '' : ' v3-rec-badge--off'}`}>● REC</div>
           <ShareQRButton />
+          <HapticIndicatorButton
+            enabled={hapticEnabled}
+            flashing={hapticFlashing}
+            canVibrate={WebHaptics.isSupported}
+            onToggle={() => { if (WebHaptics.isSupported) setHapticEnabled(prev => !prev); }}
+          />
           {touchPos && (
             <div
               className="v2-touch-indicator"
@@ -225,9 +235,12 @@ export default function ReactionCanvasAppV4() {
             }}
             onInterfacePushed={(name) => setPushedInterface(name)}
             onHapticPushed={() => {
-              if (WebHaptics.isSupported) {
+              if (hapticFlashTimeoutRef.current) clearTimeout(hapticFlashTimeoutRef.current);
+              setHapticFlashing(true);
+              hapticFlashTimeoutRef.current = setTimeout(() => setHapticFlashing(false), 500);
+              if (hapticEnabled && WebHaptics.isSupported) {
                 triggerHaptic('nudge');
-              } else {
+              } else if (!WebHaptics.isSupported) {
                 setHapticPending(true);
               }
             }}

--- a/app/styles.css
+++ b/app/styles.css
@@ -1518,7 +1518,7 @@ body {
   background: transparent;
   border: none;
   border-radius: 8px;
-  color: rgba(255, 255, 255, 0.35);
+  color: rgba(0, 0, 0, 0.3);
   cursor: pointer;
   padding: 8px;
   display: flex;
@@ -1527,13 +1527,13 @@ body {
   transition: color 0.15s ease;
 }
 
-.haptic-indicator-btn--flash {
-  color: rgba(255, 255, 255, 0.85);
+.haptic-indicator-btn--off {
+  color: rgba(0, 0, 0, 0.15);
+  cursor: default;
 }
 
-.haptic-indicator-btn--off {
-  color: rgba(255, 255, 255, 0.2);
-  cursor: default;
+.haptic-indicator-btn--flash {
+  color: rgba(0, 0, 0, 0.75);
 }
 
 .share-qr-modal {

--- a/app/styles.css
+++ b/app/styles.css
@@ -1510,6 +1510,32 @@ body {
   opacity: 0.9;
 }
 
+.haptic-indicator-btn {
+  position: absolute;
+  top: 96px;
+  left: 8px;
+  z-index: 200;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.35);
+  cursor: pointer;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s ease;
+}
+
+.haptic-indicator-btn--flash {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.haptic-indicator-btn--off {
+  color: rgba(255, 255, 255, 0.2);
+  cursor: default;
+}
+
 .share-qr-modal {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary

Follow-on to #34 — adds participant-side visibility into haptic buzz events.

- New `HapticIndicatorButton` beside the QR share button: a vibration icon (light gray) that flashes darker when a buzz signal arrives, regardless of device support
- Tapping toggles haptics on/off on supported devices
- On unsupported devices, tapping opens an info dialog explaining the limitation and pointing to the visual indicator as an alternative
- `HapticPushModal` updated: generalized message, checkbox to opt-in/out of popups per session, seeds from current suppress state so users can change their preference at any time

## Test plan

- [ ] On a supported device: verify icon flashes on buzz; tap to toggle off, verify next buzz flashes but doesn't vibrate
- [ ] On an unsupported device (or desktop): icon shows in "off" state; flashes on buzz; tapping opens the info dialog; checkbox correctly opts in/out of future popups
- [ ] Suppress popups, then tap icon → dialog re-opens with checkbox unchecked; check it → future buzzes show dialog again

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~120 words of PR description from ~160 words of human prompts across this session)