### PR TITLE
fix: generateUUID() fallback for non-secure-context LAN dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. Releases cu
 - V4 People tab: emcee can now send a haptic buzz to individual participants, groups, or reaction regions — a confirmation modal shows the target before sending, and participants see a permission dialog before their device vibrates ([#34](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/34))
 
 ### Fixed
+- V4 Moments: snapping a moment over a LAN IP (e.g. `192.168.x.x`) threw a silent `TypeError` because `crypto.randomUUID()` is only available in secure contexts (HTTPS + `localhost`) — fixed by extracting a `generateUUID()` utility in `app/utils/userId.ts` with a Math.random fallback; `ValenceViz` had the same bare call and is also fixed
 - V4 People tab: the emcee's own connection now shows "(you)" next to their user ID so they can identify themselves before pushing interfaces ([#45](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/45))
 - V4: image-canvas coordinate remapping no longer leaks into the regular reaction canvas — `Canvas` now gates the image-relative cursor math on `activity === 'image-canvas'`, and `TouchLayer` is only given `imageUrl` when that activity is active ([#37](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/37))
 

--- a/app/components/AdminPanelV4/hooks/useParticipants.ts
+++ b/app/components/AdminPanelV4/hooks/useParticipants.ts
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import { generateUUID } from "../../../utils/userId";
 import { computeReactionRegion } from "../../../utils/voteRegion";
 import type { ReactionAnchors } from "../../../utils/voteRegion";
 import type { MomentSnapshot, PushTarget } from "../types";
@@ -58,7 +59,7 @@ export function useParticipants(socket: PartySocket, room: string, activeAnchors
       regions[userId] = cursor ? computeReactionRegion(cursor.x, cursor.y, activeAnchorsRef.current) : null;
     }
     const newMoment: MomentSnapshot = {
-      id: crypto.randomUUID(),
+      id: generateUUID(),
       label: momentLabelInput.trim() || `Moment ${moments.length + 1}`,
       timestamp: Date.now(),
       regions,

--- a/app/components/ValenceViz.tsx
+++ b/app/components/ValenceViz.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
+import { generateUUID } from "../utils/userId";
 
 const CAM_MODES = ['static', 'lerp', 'exp', 'spring', 'quat'];
 
@@ -800,7 +801,7 @@ export default function ValenceViz() {
       setWsConnected(false);
       const host=window.location.port==='1999'?`${window.location.hostname}:1999`:window.location.hostname;
       const proto=window.location.port==='1999'?'ws':'wss';
-      const userId=crypto.randomUUID();
+      const userId=generateUUID();
       ws=new WebSocket(`${proto}://${host}/parties/main/${encodeURIComponent(room)}?isAdmin=true&userId=${userId}`);
       ws.onopen=()=>{
         wsConnectedLocal=true;

--- a/app/utils/userId.ts
+++ b/app/utils/userId.ts
@@ -1,13 +1,22 @@
 const STORAGE_KEY = 'polis_user_id';
 
-export function getPersistentUserId(): string {
-  const existing = localStorage.getItem(STORAGE_KEY);
-  if (existing) return existing;
-  const id = crypto.randomUUID?.() ??
+// crypto.randomUUID() is only available in secure contexts (HTTPS + localhost).
+// http://192.168.x.x and other LAN IPs are NOT secure contexts, so calling it
+// directly throws — silently breaking any feature that generates IDs at runtime
+// (e.g. snapping Moments over the local network). The fallback below matches the
+// UUID v4 format and is safe everywhere.
+export function generateUUID(): string {
+  return crypto.randomUUID?.() ??
     'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, c => {
       const r = Math.random() * 16 | 0;
       return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
     });
+}
+
+export function getPersistentUserId(): string {
+  const existing = localStorage.getItem(STORAGE_KEY);
+  if (existing) return existing;
+  const id = generateUUID();
   localStorage.setItem(STORAGE_KEY, id);
   return id;
 }


### PR DESCRIPTION
## Summary

- `crypto.randomUUID()` is only available in secure contexts (HTTPS + `localhost`) — calling it bare on `http://192.168.x.x` throws a silent `TypeError`
- This broke Moments snapping and ValenceViz WebSocket identity when accessing the dev server via a LAN IP
- Extracts `generateUUID()` in `app/utils/userId.ts` with a Math.random fallback and a comment explaining the trap; replaces both bare call sites

## Test plan

- [x] Start dev server (`pnpm run dev`) and open the app via your **LAN IP** (e.g. `http://192.168.x.x:1999#v4?interface=emcee`) on a second device or the same machine
- [x] Open the **Moments tab** in the emcee panel — the "Now" card should show connected participants
- [x] Click **Snap Moment** — confirm a new moment appears in the list (previously this threw silently and nothing happened)
- [x] Snap a second moment with a label — confirm it saves correctly and the label persists
- [x] Open `ValenceViz` over the LAN IP — confirm it connects to the WebSocket without console errors
- [x] Smoke-test the same flows on `localhost:1999` and the deployed HTTPS URL to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~90 words of PR description from ~60 words of human prompts across this session)