### PR TITLE
feat: buzz participants on label/activity/image change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 22 (2026-04-20)
 
 ### Added
+- V4: participants now receive a haptic buzz + indicator flash when the emcee silently changes the reaction labels or switches the canvas activity (Reaction Canvas / Soccer / Image Canvas); does not fire on the emcee's device or on initial page load ([#54](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/54))
+
+### Added
 - V4: haptic indicator button beside the QR share button — flashes when a buzz signal arrives; tap to toggle haptics on/off; on devices without haptic support it stays in "off" state but still flashes to show the signal arrived
 - V4 People tab: emcee can now send a haptic buzz to individual participants, groups, or reaction regions — a confirmation modal shows the target before sending, and participants see a permission dialog before their device vibrates ([#34](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/34))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 22 (2026-04-20)
 
 ### Added
-- V4: participants now receive a haptic buzz + indicator flash when the emcee silently changes the reaction labels or switches the canvas activity (Reaction Canvas / Soccer / Image Canvas); does not fire on the emcee's device or on initial page load ([#54](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/54))
+- V4: participants now receive a haptic buzz + indicator flash when the emcee silently changes the reaction labels, switches the canvas activity (Reaction Canvas / Soccer / Image Canvas), or sets a new image in Image Canvas; does not fire on the emcee's device or on initial page load ([#54](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/54))
 
 ### Added
 - V4: haptic indicator button beside the QR share button — flashes when a buzz signal arrives; tap to toggle haptics on/off; on devices without haptic support it stays in "off" state but still flashes to show the signal arrived

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -47,6 +47,7 @@ interface CanvasProps {
   onRoomImageUrlChange?: (url: string) => void;
   onActivityChange?: (activity: 'canvas' | 'soccer' | 'image-canvas') => void;
   onSocialConfigChange?: (config: { default: string; twitter: string; bluesky: string; mastodon: string; instagram: string } | null) => void;
+  onConnected?: () => void;
 }
 
 // Clip an infinite line (defined by two points) to the rectangle [0,w]×[0,h].
@@ -70,7 +71,7 @@ function clipLineToRect(
   return [px + tMin * dx, py + tMin * dy, px + tMax * dx, py + tMax * dy];
 }
 
-export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onInterfacePushed, onPushedInterfacesCleared, onHapticPushed, onRoomImageUrlChange, onActivityChange, onSocialConfigChange, debug = false }: CanvasProps) {
+export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onInterfacePushed, onPushedInterfacesCleared, onHapticPushed, onRoomImageUrlChange, onActivityChange, onSocialConfigChange, onConnected, debug = false }: CanvasProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [cursors, setCursors] = useState<Map<string, CursorPosition>>(new Map());
   const [anchors, setAnchors] = useState<ReactionAnchors>(DEFAULT_ANCHORS);
@@ -142,6 +143,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
           if ('roomSocialConfig' in data) onSocialConfigChange?.(data.roomSocialConfig ?? null);
           onConnectedAsViewer?.(data.isViewer ?? false, data.userCap ?? null);
           onViewerCount?.(data.viewerCount ?? 0);
+          onConnected?.();
           return;
         }
 

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { QRCodeSVG } from "qrcode.react";
 import Canvas from "./Canvas";
 import TouchLayer from "./TouchLayer";
@@ -119,7 +119,28 @@ export default function ReactionCanvasAppV4() {
   const [hapticEnabled, setHapticEnabled] = useState(WebHaptics.isSupported);
   const [hapticFlashing, setHapticFlashing] = useState(false);
   const hapticFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasConnectedRef = useRef(false);
   const { trigger: triggerHaptic } = useWebHaptics();
+
+  // Derived early so useCallback deps below can reference it (must still be before any early return)
+  const isEmcee = unlockedInterfaces.includes('emcee');
+
+  const triggerBuzzForUpdate = useCallback(() => {
+    if (hapticFlashTimeoutRef.current) clearTimeout(hapticFlashTimeoutRef.current);
+    setHapticFlashing(true);
+    hapticFlashTimeoutRef.current = setTimeout(() => setHapticFlashing(false), 500);
+    if (hapticEnabled && WebHaptics.isSupported) triggerHaptic('nudge');
+  }, [hapticEnabled, triggerHaptic]);
+
+  const handleRoomLabelsChange = useCallback((labels: ReactionLabelSet | null) => {
+    if (hasConnectedRef.current && !isEmcee) triggerBuzzForUpdate();
+    setServerLabels(labels);
+  }, [isEmcee, triggerBuzzForUpdate]);
+
+  const handleActivityChange = useCallback((act: 'canvas' | 'soccer' | 'image-canvas') => {
+    if (hasConnectedRef.current && !isEmcee) triggerBuzzForUpdate();
+    setActivity(act);
+  }, [isEmcee, triggerBuzzForUpdate]);
 
   useEffect(() => {
     localStorage.setItem('v4-active-interface', activeInterface);
@@ -138,8 +159,6 @@ export default function ReactionCanvasAppV4() {
   const handleJoinRequest = () => {
     socketSendRef.current?.(JSON.stringify({ type: 'requestJoin' }));
   };
-
-  const isEmcee = unlockedInterfaces.includes('emcee');
 
   if (!isEmcee && !isTouchDevice() && !isMobileForced()) {
     return <MobileOnlyGate />;
@@ -225,7 +244,8 @@ export default function ReactionCanvasAppV4() {
             onActiveCursorCountChange={setActiveCursorCount}
             onSimulatedCursorCountChange={setSimulatedCursorCount}
             onRecordingStateChange={setIsRecording}
-            onRoomLabelsChange={setServerLabels}
+            onConnected={() => { hasConnectedRef.current = true; }}
+            onRoomLabelsChange={handleRoomLabelsChange}
             onRoomAnchorsChange={setServerAnchors}
             onViewerCount={setViewerCount}
             onConnectedAsViewer={(viewer, cap) => { setIsViewer(viewer); setUserCap(cap); }}
@@ -255,7 +275,7 @@ export default function ReactionCanvasAppV4() {
               });
             }}
             onRoomImageUrlChange={setServerImageUrl}
-            onActivityChange={setActivity}
+            onActivityChange={handleActivityChange}
             onSocialConfigChange={setServerSocialConfig}
             debug={debug}
           />

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -142,6 +142,11 @@ export default function ReactionCanvasAppV4() {
     setActivity(act);
   }, [isEmcee, triggerBuzzForUpdate]);
 
+  const handleRoomImageUrlChange = useCallback((url: string) => {
+    if (hasConnectedRef.current && !isEmcee) triggerBuzzForUpdate();
+    setServerImageUrl(url);
+  }, [isEmcee, triggerBuzzForUpdate]);
+
   useEffect(() => {
     localStorage.setItem('v4-active-interface', activeInterface);
   }, [activeInterface]);
@@ -274,7 +279,7 @@ export default function ReactionCanvasAppV4() {
                 return urlBased.includes(prev) ? prev : (urlBased.includes('emcee') ? 'emcee' : 'canvas');
               });
             }}
-            onRoomImageUrlChange={setServerImageUrl}
+            onRoomImageUrlChange={handleRoomImageUrlChange}
             onActivityChange={handleActivityChange}
             onSocialConfigChange={setServerSocialConfig}
             debug={debug}

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -129,8 +129,12 @@ export default function ReactionCanvasAppV4() {
     if (hapticFlashTimeoutRef.current) clearTimeout(hapticFlashTimeoutRef.current);
     setHapticFlashing(true);
     hapticFlashTimeoutRef.current = setTimeout(() => setHapticFlashing(false), 500);
-    if (hapticEnabled && WebHaptics.isSupported) triggerHaptic('nudge');
-  }, [hapticEnabled, triggerHaptic]);
+    if (hapticEnabled && WebHaptics.isSupported) {
+      triggerHaptic('nudge');
+    } else if (!WebHaptics.isSupported && !suppressHapticModal) {
+      setHapticPending(true);
+    }
+  }, [hapticEnabled, suppressHapticModal, triggerHaptic]);
 
   const handleRoomLabelsChange = useCallback((labels: ReactionLabelSet | null) => {
     if (hasConnectedRef.current && !isEmcee) triggerBuzzForUpdate();


### PR DESCRIPTION
Closes #54

## Summary

- Participants receive a haptic buzz + `HapticIndicatorButton` flash when the emcee silently changes: reaction labels, canvas activity (Reaction Canvas / Soccer / Image Canvas), or the image in Image Canvas
- Does not fire on the emcee's own device or on initial page load
- Respects the existing "show popup when buzz is sent" setting (modal shown on unsupported devices unless suppressed)

## Implementation

**`Canvas.tsx`** — added `onConnected?: () => void` prop, called at the end of the `connected` socket message handler so the parent can distinguish initial state from live updates.

**`ReactionCanvasAppV4.tsx`**:
- `hasConnectedRef` — starts false, set to true by `onConnected`; guards against buzzing on load
- `triggerBuzzForUpdate` — shared helper: flash + buzz (or modal if haptics unsupported and not suppressed); same logic as the existing `onHapticPushed` handler
- `handleRoomLabelsChange`, `handleActivityChange`, `handleRoomImageUrlChange` — wrap the former bare state setters; call `triggerBuzzForUpdate` when connected and not the emcee

## Test plan

- [ ] Open two tabs: emcee (`?interface=emcee`) and participant
- [ ] From emcee Labels tab, change labels → participant's haptic button flashes; device buzzes if supported
- [ ] From emcee Interfaces tab, switch activity → same flash/buzz
- [ ] From emcee Image Canvas tab, set a new image → same flash/buzz
- [ ] Reload participant tab → no buzz on initial load
- [ ] Emcee device: changing labels/activity/image → no buzz on emcee side
- [ ] On a device without haptic support with "show popup" checked: popup appears on label/activity/image change

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~150 words of PR description from ~60 words of human prompts across this session)