### PR TITLE
feat: restructure Interface tab as table with Solo/Commons/Patch columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 22 (2026-04-20)
 
 ### Added
+- V4 Interface tab: restructured as a table with Solo / Commons / Patch columns — Social Sharing promoted to a first-class radio row alongside Reaction Canvas, Image Canvas, and Soccer; Commons column is a placeholder for the future front-of-room screen ([#55](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/55))
+- V4 Interface tab: Patch column with QR share button on the Social Sharing row — opens a dialog with `?interface=social` URL so participants can add the interface voluntarily without it being pushed; other rows show a greyed-out icon ([#55](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/55))
+- V4 People tab: "Send popup…" added to `···` action menus on participant rows and group/region headers — opens a confirmation modal before dispatching the coder-role GitHub username popup ([#55](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/55))
+- V4: Social Sharing is now a broadcast canvas activity — when the emcee selects it from the Interface tab all participants' personal screens switch to the social sharing UI; selecting any other mode restores their canvas ([#55](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/55))
+
+### Changed
+- Refactor: extracted shared `ActivityMode` type to `app/types.ts` replacing 12 inline union literals across server and client
+- V4 Interface tab: coder-role popup trigger moved from Interface tab to the People tab "Send popup…" menu item
+
+### Added
 - V4: participants now receive a haptic buzz + indicator flash when the emcee silently changes the reaction labels, switches the canvas activity (Reaction Canvas / Soccer / Image Canvas), or sets a new image in Image Canvas; does not fire on the emcee's device or on initial page load ([#54](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/54))
 
 ### Added

--- a/app/components/AdminPanelV4/ParticipantRow.tsx
+++ b/app/components/AdminPanelV4/ParticipantRow.tsx
@@ -11,9 +11,10 @@ interface ParticipantRowProps {
   onMenuToggle: () => void;
   onOfferInterface: () => void;
   onSendHaptic: () => void;
+  onSendPopup: () => void;
 }
 
-export default function ParticipantRow({ userId, region, labels, online, isSelf, isMenuOpen, onMenuToggle, onOfferInterface, onSendHaptic }: ParticipantRowProps) {
+export default function ParticipantRow({ userId, region, labels, online, isSelf, isMenuOpen, onMenuToggle, onOfferInterface, onSendHaptic, onSendPopup }: ParticipantRowProps) {
   const regionColor = region === 'positive' ? '#4a4' : region === 'negative' ? '#a44' : region === 'neutral' ? '#aa4' : '#555';
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 10px', background: '#1a1a1a', borderRadius: 4, opacity: online ? 1 : 0.4 }}>
@@ -40,6 +41,13 @@ export default function ParticipantRow({ userId, region, labels, online, isSelf,
               style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 12px', background: 'none', border: 'none', color: '#ddd', fontSize: 13, cursor: 'pointer' }}
             >
               Send buzz…
+            </button>
+            <button
+              onPointerDown={e => e.stopPropagation()}
+              onClick={() => { onSendPopup(); }}
+              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 12px', background: 'none', border: 'none', color: '#ddd', fontSize: 13, cursor: 'pointer' }}
+            >
+              Send popup…
             </button>
           </div>
         )}

--- a/app/components/AdminPanelV4/SendPopupModal.tsx
+++ b/app/components/AdminPanelV4/SendPopupModal.tsx
@@ -1,0 +1,53 @@
+import type { ReactionLabelSet } from "../../voteLabels";
+import type { PushTarget } from "./types";
+
+interface SendPopupModalProps {
+  pushTarget: PushTarget;
+  activeLabels: ReactionLabelSet;
+  onSend: () => void;
+  onClose: () => void;
+}
+
+export default function SendPopupModal({ pushTarget, activeLabels, onSend, onClose }: SendPopupModalProps) {
+  const targetDescription =
+    pushTarget.kind === 'user'
+      ? <span style={{ color: '#ccc', fontFamily: 'monospace' }}>{pushTarget.userId}</span>
+      : pushTarget.kind === 'users'
+        ? <span style={{ color: '#ccc' }}>{pushTarget.label} ({pushTarget.userIds.length})</span>
+        : <span style={{ color: '#ccc' }}>{pushTarget.region === null ? 'Lurking' : activeLabels[pushTarget.region]} group</span>;
+
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+      onPointerDown={onClose}
+    >
+      <div
+        style={{ background: '#1e1e1e', border: '1px solid #444', borderRadius: 10, padding: '20px 20px 16px', width: 280, display: 'flex', flexDirection: 'column', gap: 12 }}
+        onPointerDown={e => e.stopPropagation()}
+      >
+        <div style={{ fontSize: 13, color: '#888' }}>
+          Send popup to {targetDescription}
+        </div>
+        <div style={{ background: '#252525', border: '1px solid #333', borderRadius: 6, padding: '10px 12px' }}>
+          <p style={{ fontWeight: 600, margin: '0 0 2px', fontSize: 13, color: '#ddd' }}>Coder role</p>
+          <p style={{ color: '#666', fontSize: 12, margin: 0 }}>Asks for their GitHub username to confirm they can contribute code.</p>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            onClick={onSend}
+            autoFocus
+            style={{ flex: 1, padding: '8px', background: '#2a5cba', color: '#fff', border: 'none', borderRadius: 6, fontSize: 13, cursor: 'pointer' }}
+          >
+            Send
+          </button>
+          <button
+            onClick={onClose}
+            style={{ padding: '8px 14px', background: 'none', border: '1px solid #444', color: '#888', borderRadius: 6, fontSize: 13, cursor: 'pointer' }}
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/AdminPanelV4/hooks/useRoomConfig.ts
+++ b/app/components/AdminPanelV4/hooks/useRoomConfig.ts
@@ -1,10 +1,10 @@
 import { useState } from "react";
-import type { SocialConfig } from "../../../types";
+import type { ActivityMode, SocialConfig } from "../../../types";
 import type PartySocket from "partysocket";
 
 export function useRoomConfig(socket: PartySocket) {
   const [avatarStyle, setAvatarStyle]         = useState<string | null>(null);
-  const [activity, setActivity]               = useState<'canvas' | 'soccer' | 'image-canvas'>('canvas');
+  const [activity, setActivity]               = useState<ActivityMode>('canvas');
   const [soccerScore, setSoccerScore]         = useState({ left: 0, right: 0 });
   const [imageConfigOpen, setImageConfigOpen] = useState(false);
   const [roomImageUrl, setRoomImageUrl]       = useState('');
@@ -18,7 +18,7 @@ export function useRoomConfig(socket: PartySocket) {
     socket.send(JSON.stringify({ type: 'setRoomAvatarStyle', avatarStyle: style }));
   };
 
-  const sendActivity = (act: 'canvas' | 'soccer' | 'image-canvas') => {
+  const sendActivity = (act: ActivityMode) => {
     setActivity(act);
     socket.send(JSON.stringify({ type: 'setActivity', activity: act }));
   };
@@ -45,7 +45,7 @@ export function useRoomConfig(socket: PartySocket) {
 
   const applyConnected = (data: Record<string, unknown>) => {
     if ('roomAvatarStyle' in data) setAvatarStyle((data.roomAvatarStyle as string | null) ?? null);
-    if ('currentActivity' in data) setActivity((data.currentActivity as 'canvas' | 'soccer' | 'image-canvas') ?? 'canvas');
+    if ('currentActivity' in data) setActivity((data.currentActivity as ActivityMode) ?? 'canvas');
     if ('roomImageUrl' in data) setRoomImageUrl((data.roomImageUrl as string) ?? '');
     if ('roomSocialConfig' in data) setRoomSocialConfig((data.roomSocialConfig as SocialConfig | null) ?? null);
     if ('soccerScore' in data && data.soccerScore) setSoccerScore(data.soccerScore as { left: number; right: number });
@@ -59,7 +59,7 @@ export function useRoomConfig(socket: PartySocket) {
     if (data.type === 'roomAvatarStyleChanged') {
       setAvatarStyle((data.avatarStyle as string | null) ?? null);
     } else if (data.type === 'activityChanged') {
-      setActivity((data.activity as 'canvas' | 'soccer' | 'image-canvas') ?? 'canvas');
+      setActivity((data.activity as ActivityMode) ?? 'canvas');
     } else if (data.type === 'imageUrlChanged') {
       setRoomImageUrl((data.url as string) ?? '');
     } else if (data.type === 'socialConfigChanged') {

--- a/app/components/AdminPanelV4/index.tsx
+++ b/app/components/AdminPanelV4/index.tsx
@@ -10,6 +10,7 @@ import { usePlayback } from "./hooks/usePlayback";
 import { useParticipants } from "./hooks/useParticipants";
 import OfferInterfaceModal from "./OfferInterfaceModal";
 import HapticConfirmModal from "./HapticConfirmModal";
+import SendPopupModal from "./SendPopupModal";
 import RecordTab from "./tabs/RecordTab";
 import LabelsTab from "./tabs/LabelsTab";
 import AnchorsTab from "./tabs/AnchorsTab";
@@ -34,6 +35,7 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
   const [presenceCount, setPresenceCount]     = useState<number>(0);
   const [githubSubmissions, setGithubSubmissions] = useState<GithubSubmission[]>([]);
   const [pendingHapticTarget, setPendingHapticTarget] = useState<PushTarget | null>(null);
+  const [pendingPopupTarget, setPendingPopupTarget]   = useState<PushTarget | null>(null);
 
   // Ref-based dispatch so all hooks see the same handler regardless of creation order
   const dispatchRef = useRef<(data: Record<string, unknown>) => void>(() => {});
@@ -235,7 +237,6 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
             resetSoccerScore={roomConfig.resetSoccerScore}
             setImageConfigOpen={roomConfig.setImageConfigOpen}
             setSocialConfigOpen={roomConfig.setSocialConfigOpen}
-            triggerGithubActivity={triggerGithubActivity}
             onClearRoleAssignments={() => socket.send(JSON.stringify({ type: 'clearPushedInterfaces' }))}
           />
         )}
@@ -266,6 +267,7 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
             setPushTarget={participants.setPushTarget}
             setPendingInterfaceName={participants.setPendingInterfaceName}
             onSendHaptic={setPendingHapticTarget}
+            onSendPopup={setPendingPopupTarget}
             interfaceAcceptances={participants.interfaceAcceptances}
             activeLabels={labels.activeLabels}
             activeAnchors={anchors.activeAnchors}
@@ -320,6 +322,17 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
           activeLabels={labels.activeLabels}
           onSend={msg => socket.send(JSON.stringify(msg))}
           onClose={() => { participants.setPushTarget(null); participants.setPendingInterfaceName('social'); }}
+        />
+      )}
+      {pendingPopupTarget && (
+        <SendPopupModal
+          pushTarget={pendingPopupTarget}
+          activeLabels={labels.activeLabels}
+          onSend={() => {
+            triggerGithubActivity();
+            setPendingPopupTarget(null);
+          }}
+          onClose={() => setPendingPopupTarget(null)}
         />
       )}
       {roomConfig.imageConfigOpen && (

--- a/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
+++ b/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
@@ -1,59 +1,120 @@
-import type { SocialConfig } from "../../../types";
+import { useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import type { ActivityMode } from "../../../types";
 
 interface InterfacesTabProps {
-  activity: 'canvas' | 'soccer' | 'image-canvas';
+  activity: ActivityMode;
   soccerScore: { left: number; right: number };
-  sendActivity: (act: 'canvas' | 'soccer' | 'image-canvas') => void;
+  sendActivity: (act: ActivityMode) => void;
   resetSoccerScore: () => void;
   setImageConfigOpen: (v: boolean) => void;
   setSocialConfigOpen: (v: boolean) => void;
-  triggerGithubActivity: () => void;
   onClearRoleAssignments: () => void;
 }
+
+const QR_ICON = (
+  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" /><rect x="3" y="14" width="7" height="7" />
+    <line x1="14" y1="17.5" x2="21" y2="17.5" /><line x1="17.5" y1="14" x2="17.5" y2="21" />
+  </svg>
+);
+
+function getPatchUrl(interfaceName: string): string {
+  const p = new URLSearchParams(window.location.search);
+  p.delete('forceView');
+  p.delete('admin');
+  p.set('interface', interfaceName);
+  const qs = p.toString();
+  return `${window.location.origin}${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
+}
+
+const ROWS: { id: ActivityMode; label: string; desc: string; patchable: boolean }[] = [
+  { id: 'canvas',       label: 'Reaction Canvas', desc: 'Standard reaction canvas',                       patchable: false },
+  { id: 'image-canvas', label: 'Image Canvas',    desc: 'React over a shared background image',           patchable: false },
+  { id: 'soccer',       label: 'Soccer',          desc: 'Top-down physics ball — kick with your cursor',  patchable: false },
+  { id: 'social',       label: 'Social Sharing',  desc: 'Bluesky · Twitter / X · Mastodon',              patchable: true  },
+];
 
 export default function InterfacesTab({
   activity, soccerScore,
   sendActivity, resetSoccerScore,
   setImageConfigOpen, setSocialConfigOpen,
-  triggerGithubActivity, onClearRoleAssignments,
+  onClearRoleAssignments,
 }: InterfacesTabProps) {
+  const [patchDialogOpen, setPatchDialogOpen] = useState(false);
+  const patchUrl = getPatchUrl('social');
+
   return (
     <div>
       <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>All settings here are shared with all participants in real time.</p>
-      <p style={{ marginBottom: 12, fontWeight: 600 }}>Interfaces</p>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-        {([
-          { id: 'canvas', label: 'Reaction Canvas', desc: 'Standard reaction canvas' },
-          { id: 'image-canvas', label: 'Image Canvas', desc: 'React over a shared background image' },
-          { id: 'soccer', label: 'Soccer', desc: 'Top-down physics ball — kick with your cursor' },
-        ] as const).map(({ id, label, desc }) => (
-          <label key={id} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}>
-            <input
-              type="radio"
-              name="activity"
-              value={id}
-              checked={activity === id}
-              onChange={() => sendActivity(id)}
-              style={{ marginTop: 3 }}
-            />
-            <div>
-              <span style={{ fontWeight: activity === id ? 600 : 400 }}>{label}</span>
-              <span style={{ color: '#888', fontSize: 13, marginLeft: 8 }}>{desc}</span>
-              {id === 'image-canvas' && (
-                <button
-                  className="image-canvas-config-link"
-                  onClick={e => { e.preventDefault(); setImageConfigOpen(true); }}
-                >
-                  config
-                </button>
-              )}
-            </div>
-          </label>
-        ))}
-      </div>
 
+      {/* ── Interface table ── */}
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left', color: '#666', fontWeight: 500, padding: '0 8px 8px 0', fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em' }}>Interface</th>
+            <th style={{ color: '#666', fontWeight: 500, padding: '0 8px 8px', fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em', width: 48, textAlign: 'center' }}>Solo</th>
+            <th style={{ color: '#444', fontWeight: 500, padding: '0 8px 8px', fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em', width: 64, textAlign: 'center' }}>Commons</th>
+            <th style={{ color: '#666', fontWeight: 500, padding: '0 0 8px 8px', fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em', width: 48, textAlign: 'center' }}>Patch</th>
+          </tr>
+        </thead>
+        <tbody>
+          {ROWS.map(({ id, label, desc, patchable }) => {
+            const isActive = activity === id;
+            return (
+              <tr key={id} style={{ borderTop: '1px solid #2a2a2a' }}>
+                {/* Description */}
+                <td style={{ padding: '10px 8px 10px 0' }}>
+                  <label style={{ cursor: 'pointer', display: 'block' }} htmlFor={`activity-${id}`}>
+                    <span style={{ fontWeight: isActive ? 600 : 400, color: isActive ? '#eee' : '#bbb' }}>{label}</span>
+                    <span style={{ color: '#666', marginLeft: 8 }}>{desc}</span>
+                    {id === 'image-canvas' && (
+                      <button className="image-canvas-config-link" onClick={e => { e.preventDefault(); setImageConfigOpen(true); }}>config</button>
+                    )}
+                    {id === 'social' && (
+                      <button className="image-canvas-config-link" onClick={e => { e.preventDefault(); setSocialConfigOpen(true); }}>config</button>
+                    )}
+                  </label>
+                </td>
+                {/* Solo */}
+                <td style={{ textAlign: 'center', padding: '10px 8px' }}>
+                  <input
+                    id={`activity-${id}`}
+                    type="radio"
+                    name="activity"
+                    value={id}
+                    checked={isActive}
+                    onChange={() => sendActivity(id)}
+                  />
+                </td>
+                {/* Commons — placeholder */}
+                <td style={{ textAlign: 'center', padding: '10px 8px', color: '#3a3a3a' }}>—</td>
+                {/* Patch */}
+                <td style={{ textAlign: 'center', padding: '10px 0 10px 8px' }}>
+                  {patchable ? (
+                    <button
+                      onClick={() => setPatchDialogOpen(true)}
+                      style={{ background: 'none', border: 'none', color: '#888', cursor: 'pointer', padding: 4, lineHeight: 0 }}
+                      title="Share patch URL"
+                      aria-label="Share social interface URL"
+                    >
+                      {QR_ICON}
+                    </button>
+                  ) : (
+                    <span style={{ color: '#333', display: 'inline-block', lineHeight: 0, padding: 4 }} aria-hidden="true">
+                      {QR_ICON}
+                    </span>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      {/* Soccer score — shown when soccer is active */}
       {activity === 'soccer' && (
-        <div style={{ marginTop: 24, borderTop: '1px solid #444', paddingTop: 20 }}>
+        <div style={{ marginTop: 20, borderTop: '1px solid #444', paddingTop: 16 }}>
           <p style={{ marginBottom: 10, fontWeight: 600 }}>Soccer settings:</p>
           <div style={{ display: 'flex', alignItems: 'center', gap: 20, marginBottom: 12 }}>
             <span style={{ color: '#aaa', fontSize: 15 }}>Score:</span>
@@ -61,50 +122,30 @@ export default function InterfacesTab({
               {soccerScore.left} – {soccerScore.right}
             </span>
           </div>
-          <button className="v3-admin-btn v3-admin-btn--destructive" onClick={resetSoccerScore}>
-            Reset Score
-          </button>
+          <button className="v3-admin-btn v3-admin-btn--destructive" onClick={resetSoccerScore}>Reset Score</button>
         </div>
       )}
 
-      <div style={{ marginTop: 32, borderTop: '1px solid #444', paddingTop: 20 }}>
-        <p style={{ marginBottom: 12, fontWeight: 600 }}>Social sharing</p>
-        <p style={{ marginBottom: 12, color: '#888', fontSize: 13 }}>Configure prefilled text for participant share buttons. Participants with <code>?interface=social</code> see a button per platform.</p>
-        <div style={{ background: '#222', border: '1px solid #444', borderRadius: 8, padding: '12px 14px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <div>
-            <p style={{ fontWeight: 600, margin: '0 0 2px' }}>Social butterfly</p>
-            <p style={{ color: '#888', fontSize: 13, margin: 0 }}>Bluesky · Twitter / X · Mastodon</p>
-          </div>
-          <button
-            className="image-canvas-config-link"
-            onClick={e => { e.preventDefault(); setSocialConfigOpen(true); }}
-          >
-            config
-          </button>
-        </div>
-      </div>
-
+      {/* Role assignments */}
       <div style={{ marginTop: 32, borderTop: '1px solid #444', paddingTop: 20 }}>
         <p style={{ marginBottom: 4, fontWeight: 600 }}>Role assignments</p>
-        <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>Push interface invitations to participants from the Participants tab. Use this to revoke all pushed roles.</p>
-        <button className="v3-admin-btn v3-admin-btn--destructive" onClick={onClearRoleAssignments}>
-          Clear all role assignments
-        </button>
+        <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>Push interface invitations to participants from the People tab. Use this to revoke all pushed roles.</p>
+        <button className="v3-admin-btn v3-admin-btn--destructive" onClick={onClearRoleAssignments}>Clear all role assignments</button>
       </div>
 
-      <div style={{ marginTop: 32, borderTop: '1px solid #444', paddingTop: 20 }}>
-        <p style={{ marginBottom: 4, fontWeight: 600 }}>Popups</p>
-        <p style={{ marginBottom: 16, color: '#888', fontSize: 13 }}>Push a one-time form to all participants. Submissions appear in the Events tab.</p>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-          <div style={{ background: '#222', border: '1px solid #444', borderRadius: 8, padding: '12px 14px' }}>
-            <p style={{ fontWeight: 600, margin: '0 0 2px' }}>Coder role</p>
-            <p style={{ color: '#888', fontSize: 13, margin: '0 0 10px' }}>Ask participants for their GitHub username to confirm they can contribute code.</p>
-            <button className="v3-admin-btn" onClick={triggerGithubActivity}>
-              Push popup
-            </button>
+      {/* Patch dialog — social sharing URL */}
+      {patchDialogOpen && (
+        <div className="share-qr-modal" onClick={() => setPatchDialogOpen(false)}>
+          <div className="share-qr-modal-card" onClick={e => e.stopPropagation()}>
+            <p className="share-qr-modal-title">Social Sharing — add without push</p>
+            <div className="v2-mobile-gate-qr">
+              <QRCodeSVG value={patchUrl} size={220} />
+            </div>
+            <p className="share-qr-modal-url">{patchUrl}</p>
+            <button className="share-qr-modal-close" onClick={() => setPatchDialogOpen(false)}>Close</button>
           </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/app/components/AdminPanelV4/tabs/ParticipantsTab.tsx
+++ b/app/components/AdminPanelV4/tabs/ParticipantsTab.tsx
@@ -25,6 +25,7 @@ interface ParticipantsTabProps {
   setPushTarget: (v: PushTarget | null) => void;
   setPendingInterfaceName: (v: string) => void;
   onSendHaptic: (target: PushTarget) => void;
+  onSendPopup: (target: PushTarget) => void;
   interfaceAcceptances: { userId: string; interfaceName: string }[];
   activeLabels: ReactionLabelSet;
   activeAnchors: ReactionAnchors;
@@ -39,7 +40,7 @@ function ParticipantsTabInner({
   collapsedGroups, setCollapsedGroups,
   openMenuUserId, setOpenMenuUserId,
   openMenuGroupKey, setOpenMenuGroupKey,
-  setPushTarget, setPendingInterfaceName, onSendHaptic,
+  setPushTarget, setPendingInterfaceName, onSendHaptic, onSendPopup,
   interfaceAcceptances, activeLabels, activeAnchors, room, selfUserId,
 }: ParticipantsTabProps) {
   const offerInterface = (target: PushTarget) => {
@@ -106,6 +107,7 @@ function ParticipantsTabInner({
                 onMenuToggle={() => setOpenMenuUserId(prev => prev === userId ? null : userId)}
                 onOfferInterface={() => { setOpenMenuUserId(null); offerInterface({ kind: 'user', userId }); }}
                 onSendHaptic={() => { setOpenMenuUserId(null); onSendHaptic({ kind: 'user', userId }); }}
+                onSendPopup={() => { setOpenMenuUserId(null); onSendPopup({ kind: 'user', userId }); }}
               />
             );
           })}
@@ -153,6 +155,13 @@ function ParticipantsTabInner({
                             >
                               Send buzz…
                             </button>
+                            <button
+                              onPointerDown={e => e.stopPropagation()}
+                              onClick={() => { setOpenMenuGroupKey(null); onSendPopup({ kind: 'users', userIds: members, label: groupLabel }); }}
+                              style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 12px', background: 'none', border: 'none', color: '#ddd', fontSize: 13, cursor: 'pointer' }}
+                            >
+                              Send popup…
+                            </button>
                           </div>
                         )}
                       </div>
@@ -178,6 +187,7 @@ function ParticipantsTabInner({
                               onMenuToggle={() => setOpenMenuUserId(prev => prev === userId ? null : userId)}
                               onOfferInterface={() => { setOpenMenuUserId(null); offerInterface({ kind: 'user', userId }); }}
                               onSendHaptic={() => { setOpenMenuUserId(null); onSendHaptic({ kind: 'user', userId }); }}
+                              onSendPopup={() => { setOpenMenuUserId(null); onSendPopup({ kind: 'user', userId }); }}
                             />
                           );
                         })}
@@ -233,6 +243,13 @@ function ParticipantsTabInner({
                         >
                           Send buzz…
                         </button>
+                        <button
+                          onPointerDown={e => e.stopPropagation()}
+                          onClick={() => { setOpenMenuGroupKey(null); onSendPopup({ kind: 'region', region }); }}
+                          style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 12px', background: 'none', border: 'none', color: '#ddd', fontSize: 13, cursor: 'pointer' }}
+                        >
+                          Send popup…
+                        </button>
                       </div>
                     )}
                   </div>
@@ -258,10 +275,11 @@ function ParticipantsTabInner({
                         onMenuToggle={() => setOpenMenuUserId(prev => prev === userId ? null : userId)}
                         onOfferInterface={() => { setOpenMenuUserId(null); offerInterface({ kind: 'user', userId }); }}
                         onSendHaptic={() => { setOpenMenuUserId(null); onSendHaptic({ kind: 'user', userId }); }}
+                        onSendPopup={() => { setOpenMenuUserId(null); onSendPopup({ kind: 'user', userId }); }}
                       />
                     ))}
                     {region === null && offlineMembers.map(userId => (
-                      <ParticipantRow key={userId} userId={userId} region={null} labels={activeLabels} online={false} isSelf={userId === selfUserId} isMenuOpen={false} onMenuToggle={() => {}} onOfferInterface={() => {}} onSendHaptic={() => {}} />
+                      <ParticipantRow key={userId} userId={userId} region={null} labels={activeLabels} online={false} isSelf={userId === selfUserId} isMenuOpen={false} onMenuToggle={() => {}} onOfferInterface={() => {}} onSendHaptic={() => {}} onSendPopup={() => {}} />
                     ))}
                   </div>
                 )}

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -3,6 +3,7 @@ import usePartySocket from "partysocket/react";
 import * as d3 from "d3";
 import { computeReactionRegion, DEFAULT_ANCHORS } from "../utils/voteRegion";
 import type { ReactionAnchors } from "../utils/voteRegion";
+import type { ActivityMode } from "../types";
 
 interface CursorPosition {
   x: number; // Normalized coordinates (0-100)
@@ -45,7 +46,7 @@ interface CanvasProps {
   onPushedInterfacesCleared?: () => void;
   onHapticPushed?: () => void;
   onRoomImageUrlChange?: (url: string) => void;
-  onActivityChange?: (activity: 'canvas' | 'soccer' | 'image-canvas') => void;
+  onActivityChange?: (activity: ActivityMode) => void;
   onSocialConfigChange?: (config: { default: string; twitter: string; bluesky: string; mastodon: string; instagram: string } | null) => void;
   onConnected?: () => void;
 }
@@ -76,7 +77,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   const [cursors, setCursors] = useState<Map<string, CursorPosition>>(new Map());
   const [anchors, setAnchors] = useState<ReactionAnchors>(DEFAULT_ANCHORS);
   const [avatarStyle, setAvatarStyle] = useState<string | null>(null);
-  const [activity, setActivity] = useState<'canvas' | 'soccer' | 'image-canvas'>('canvas');
+  const [activity, setActivity] = useState<ActivityMode>('canvas');
   const [imageUrl, setImageUrl] = useState('');
   const [imageNaturalSize, setImageNaturalSize] = useState<{ w: number; h: number } | null>(null);
   const [ballPos, setBallPos] = useState<{ x: number; y: number } | null>(null);

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -5,7 +5,7 @@ import TouchLayer from "./TouchLayer";
 import AdminPanelV4 from "./AdminPanelV4";
 import InterfaceChipBar from "./InterfaceChipBar";
 import SocialPanel from "./SocialPanel";
-import type { SocialConfig } from "../types";
+import type { ActivityMode, SocialConfig } from "../types";
 import GithubUsernameModal from "./GithubUsernameModal";
 import InterfacePushModal from "./InterfacePushModal";
 import HapticPushModal from "./HapticPushModal";
@@ -109,7 +109,7 @@ export default function ReactionCanvasAppV4() {
   const [serverAnchors, setServerAnchors] = useState<ReactionAnchors | null>(null);
   const [serverImageUrl, setServerImageUrl] = useState('');
   const [serverSocialConfig, setServerSocialConfig] = useState<SocialConfig | null>(null);
-  const [activity, setActivity] = useState<'canvas' | 'soccer' | 'image-canvas'>('canvas');
+  const [activity, setActivity] = useState<ActivityMode>('canvas');
   const [debug, setDebug] = useState(() => new URLSearchParams(window.location.search).get('debug') === '1');
   const reactionStateRef = useRef<ReactionState>(null);
   const [showGithubModal, setShowGithubModal] = useState(false);
@@ -141,7 +141,7 @@ export default function ReactionCanvasAppV4() {
     setServerLabels(labels);
   }, [isEmcee, triggerBuzzForUpdate]);
 
-  const handleActivityChange = useCallback((act: 'canvas' | 'soccer' | 'image-canvas') => {
+  const handleActivityChange = useCallback((act: ActivityMode) => {
     if (hasConnectedRef.current && !isEmcee) triggerBuzzForUpdate();
     setActivity(act);
   }, [isEmcee, triggerBuzzForUpdate]);
@@ -203,6 +203,7 @@ export default function ReactionCanvasAppV4() {
       ) : null}
       {/* Canvas is always mounted to keep the WebSocket alive for all interfaces */}
       <div className="v2-vote-canvas-container" style={{ flex: 1, display: activeInterface === 'canvas' ? undefined : 'none' }}>
+          {activity === 'social' && <SocialPanel socialConfig={serverSocialConfig} />}
           {activity === 'image-canvas' && serverImageUrl && (
             <img
               src={serverImageUrl}
@@ -288,7 +289,7 @@ export default function ReactionCanvasAppV4() {
             onSocialConfigChange={setServerSocialConfig}
             debug={debug}
           />
-          {!isViewer && (
+          {!isViewer && activity !== 'social' && (
             <TouchLayer
               room={room}
               userId={userId}

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -201,9 +201,14 @@ export default function ReactionCanvasAppV4() {
       ) : activeInterface === 'social' ? (
         <SocialPanel socialConfig={serverSocialConfig} />
       ) : null}
+      {/* When activity is 'social', show SocialPanel as a flex sibling (fills the
+          remaining height below the chip bar, same as the chip-based case).
+          Canvas container is hidden but stays mounted to keep the socket alive. */}
+      {activeInterface === 'canvas' && activity === 'social' && (
+        <SocialPanel socialConfig={serverSocialConfig} />
+      )}
       {/* Canvas is always mounted to keep the WebSocket alive for all interfaces */}
-      <div className="v2-vote-canvas-container" style={{ flex: 1, display: activeInterface === 'canvas' ? undefined : 'none' }}>
-          {activity === 'social' && <SocialPanel socialConfig={serverSocialConfig} />}
+      <div className="v2-vote-canvas-container" style={{ flex: 1, display: (activeInterface === 'canvas' && activity !== 'social') ? undefined : 'none' }}>
           {activity === 'image-canvas' && serverImageUrl && (
             <img
               src={serverImageUrl}

--- a/app/types.ts
+++ b/app/types.ts
@@ -28,6 +28,8 @@ export interface Statement {
   text: string;
 }
 
+export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social';
+
 export interface SocialConfig {
   default: string;
   twitter: string;

--- a/party/server.ts
+++ b/party/server.ts
@@ -1,4 +1,5 @@
 import type * as Party from "partykit/server";
+import type { ActivityMode } from "../app/types";
 // Ghost cursor imports (for demo purposes - can be easily removed)
 import { createNoise2D } from 'simplex-noise';
 
@@ -103,7 +104,7 @@ interface SetRoomAvatarStyleEvent {
 
 interface SetActivityEvent {
   type: 'setActivity';
-  activity: 'canvas' | 'soccer' | 'image-canvas';
+  activity: ActivityMode;
 }
 
 interface SetImageUrlEvent {
@@ -233,7 +234,7 @@ export default class Server implements Party.Server {
   private roomLabels: { positive: string; negative: string; neutral: string } | null = { positive: 'Agree', negative: 'Disagree', neutral: 'Pass' };
   private roomAnchors: ReactionAnchors | null = null;
   private roomAvatarStyle: string | null = null;
-  private currentActivity: 'canvas' | 'soccer' | 'image-canvas' = 'canvas';
+  private currentActivity: ActivityMode = 'canvas';
   private roomImageUrl: string = '';
   private roomSocialConfig: { default: string; twitter: string; bluesky: string; mastodon: string } | null = null;
   private ballState = { x: 50, y: 50, vx: 2, vy: 1 };


### PR DESCRIPTION
Closes #55

## Summary

- **Interface tab → table**: four rows (Reaction Canvas, Image Canvas, Soccer, Social Sharing) with Solo, Commons (placeholder), and Patch columns. All rows are radios under Solo. Config links stay inline.
- **Social Sharing as broadcast activity**: selecting it from the emcee's Interface tab pushes everyone's personal screen to the social sharing UI; chip bar stays visible, canvas socket stays alive underneath
- **Patch column**: Social Sharing row has an active QR/share button that opens a `?interface=social` URL dialog so participants can add the interface voluntarily; other rows show a greyed-out icon
- **"Send popup…" in People tab**: new menu item in all `···` menus (individual, group, region) opens a confirmation modal before dispatching the coder-role popup; coder popup section removed from Interface tab
- **Refactor**: extracted shared `ActivityMode` type to `app/types.ts`, replacing 12 inline union literals

## Test plan

- [ ] Interface tab renders as a 4-row table; Solo radios work for all modes including Social Sharing
- [ ] Selecting Social Sharing in emcee → second tab at `?forceView=mobile` shows SocialPanel filling height below chip bar; chip bar remains; REC/QR hidden
- [ ] Switching back to Reaction Canvas restores the canvas on the second tab
- [ ] Soccer score section appears below table when Soccer is selected
- [ ] Patch QR button on Social Sharing row opens dialog with `?interface=social` URL; other row icons are non-interactive
- [ ] `···` menu on a participant row shows "Send popup…"; confirming sends the GitHub username popup; Events tab receives the submission
- [ ] Interface tab no longer has a Popups section
- [ ] Existing chip-based `?interface=social` push from People tab still works
- [ ] `pnpm tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~130 words of PR description from ~250 words of human prompts across this session)