### PR TITLE
feat: feedback stars popup (#30 MVP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. Releases cut every Monday morning ET; each section header is `## Week N (YYYY-MM-DD)` where the date is the Monday that week starts on, and Week 0 = 2025-11-17.
 
+## Week 23 (2026-04-27)
+
+### Added
+- V4 People tab: "Send popup…" now shows two selectable options — "Coder role" (GitHub username) and "★ Star rating" (feedback); selecting star rating sends a 1–5 star modal to participants, and their responses are stored in the emcee's localStorage ([#30](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/30))
+- V4 People tab: new "Feedback Stars" group-by option — groups all seen participants into buckets by their submitted star rating (5★ down to 0★ plus "No response"), enabling the emcee to target high or low scorers with follow-up actions ([#30](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/30))
+
 ## Week 22 (2026-04-20)
 
 ### Changed

--- a/app/components/AdminPanelV4/SendPopupModal.tsx
+++ b/app/components/AdminPanelV4/SendPopupModal.tsx
@@ -1,14 +1,22 @@
+import { useState } from "react";
 import type { ReactionLabelSet } from "../../voteLabels";
 import type { PushTarget } from "./types";
 
 interface SendPopupModalProps {
   pushTarget: PushTarget;
   activeLabels: ReactionLabelSet;
-  onSend: () => void;
+  onSend: (activityName: string) => void;
   onClose: () => void;
 }
 
+const POPUP_OPTIONS = [
+  { activityName: 'githubUsername', label: 'Coder role', description: 'Asks for their GitHub username to confirm they can contribute code.' },
+  { activityName: 'feedbackStars', label: '★ Star rating', description: 'Asks participants to rate their experience on a 1–5 star scale.' },
+] as const;
+
 export default function SendPopupModal({ pushTarget, activeLabels, onSend, onClose }: SendPopupModalProps) {
+  const [selected, setSelected] = useState<string>('githubUsername');
+
   const targetDescription =
     pushTarget.kind === 'user'
       ? <span style={{ color: '#ccc', fontFamily: 'monospace' }}>{pushTarget.userId}</span>
@@ -28,13 +36,21 @@ export default function SendPopupModal({ pushTarget, activeLabels, onSend, onClo
         <div style={{ fontSize: 13, color: '#888' }}>
           Send popup to {targetDescription}
         </div>
-        <div style={{ background: '#252525', border: '1px solid #333', borderRadius: 6, padding: '10px 12px' }}>
-          <p style={{ fontWeight: 600, margin: '0 0 2px', fontSize: 13, color: '#ddd' }}>Coder role</p>
-          <p style={{ color: '#666', fontSize: 12, margin: 0 }}>Asks for their GitHub username to confirm they can contribute code.</p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {POPUP_OPTIONS.map(opt => (
+            <div
+              key={opt.activityName}
+              onClick={() => setSelected(opt.activityName)}
+              style={{ background: selected === opt.activityName ? '#1e2d4a' : '#252525', border: `1px solid ${selected === opt.activityName ? '#2a5cba' : '#333'}`, borderRadius: 6, padding: '10px 12px', cursor: 'pointer' }}
+            >
+              <p style={{ fontWeight: 600, margin: '0 0 2px', fontSize: 13, color: '#ddd' }}>{opt.label}</p>
+              <p style={{ color: '#666', fontSize: 12, margin: 0 }}>{opt.description}</p>
+            </div>
+          ))}
         </div>
         <div style={{ display: 'flex', gap: 8 }}>
           <button
-            onClick={onSend}
+            onClick={() => onSend(selected)}
             autoFocus
             style={{ flex: 1, padding: '8px', background: '#2a5cba', color: '#fff', border: 'none', borderRadius: 6, fontSize: 13, cursor: 'pointer' }}
           >

--- a/app/components/AdminPanelV4/hooks/useParticipants.ts
+++ b/app/components/AdminPanelV4/hooks/useParticipants.ts
@@ -154,7 +154,7 @@ export function useParticipants(socket: PartySocket, room: string, activeAnchors
     interfaceAcceptances,
     openMenuUserId, setOpenMenuUserId,
     openMenuGroupKey, setOpenMenuGroupKey,
-    feedbackStars,
+    feedbackStars, setFeedbackStars,
     snapMoment,
     applyConnected,
     handleSocketEvent,

--- a/app/components/AdminPanelV4/hooks/useParticipants.ts
+++ b/app/components/AdminPanelV4/hooks/useParticipants.ts
@@ -14,7 +14,7 @@ export function useParticipants(socket: PartySocket, room: string, activeAnchors
     } catch { return new Set(); }
   });
   const [liveCursors, setLiveCursors]         = useState<Map<string, { x: number; y: number }>>(new Map());
-  const [participantGrouping, setParticipantGrouping] = useState<'none' | 'valence'>('valence');
+  const [participantGrouping, setParticipantGrouping] = useState<'none' | 'valence' | 'feedbackStars'>('valence');
   const [moments, setMoments]                 = useState<MomentSnapshot[]>(() => {
     try {
       return JSON.parse(localStorage.getItem(`v4-moments-${room}`) ?? '[]');
@@ -31,6 +31,11 @@ export function useParticipants(socket: PartySocket, room: string, activeAnchors
   const [interfaceAcceptances, setInterfaceAcceptances] = useState<{ userId: string; interfaceName: string }[]>([]);
   const [openMenuUserId, setOpenMenuUserId]       = useState<string | null>(null);
   const [openMenuGroupKey, setOpenMenuGroupKey]   = useState<string | null>(null);
+  const [feedbackStars, setFeedbackStars]         = useState<Record<string, number>>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(`v4-feedback-stars-${room}`) ?? '{}');
+    } catch { return {}; }
+  });
 
   const staleTimersRef    = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
   const activeAnchorsRef  = useRef<ReactionAnchors>(activeAnchors);
@@ -84,6 +89,17 @@ export function useParticipants(socket: PartySocket, room: string, activeAnchors
   };
 
   const handleSocketEvent = (data: Record<string, unknown>) => {
+    if (data.type === 'feedbackStarsSubmitted') {
+      const userId = data.userId as string;
+      const stars = data.stars as number;
+      setFeedbackStars(prev => {
+        const next = { ...prev, [userId]: stars };
+        localStorage.setItem(`v4-feedback-stars-${room}`, JSON.stringify(next));
+        return next;
+      });
+      return;
+    }
+
     if (data.type === 'interfaceAccepted') {
       setInterfaceAcceptances(prev => [...prev, { userId: data.userId as string, interfaceName: data.interfaceName as string }]);
       return;
@@ -138,6 +154,7 @@ export function useParticipants(socket: PartySocket, room: string, activeAnchors
     interfaceAcceptances,
     openMenuUserId, setOpenMenuUserId,
     openMenuGroupKey, setOpenMenuGroupKey,
+    feedbackStars,
     snapMoment,
     applyConnected,
     handleSocketEvent,

--- a/app/components/AdminPanelV4/index.tsx
+++ b/app/components/AdminPanelV4/index.tsx
@@ -269,6 +269,7 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
             setPendingInterfaceName={participants.setPendingInterfaceName}
             onSendHaptic={setPendingHapticTarget}
             onSendPopup={setPendingPopupTarget}
+            feedbackStars={participants.feedbackStars}
             interfaceAcceptances={participants.interfaceAcceptances}
             activeLabels={labels.activeLabels}
             activeAnchors={anchors.activeAnchors}
@@ -329,8 +330,8 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
         <SendPopupModal
           pushTarget={pendingPopupTarget}
           activeLabels={labels.activeLabels}
-          onSend={() => {
-            const msg: Record<string, unknown> = { type: 'triggerActivity', activityName: 'githubUsername' };
+          onSend={(activityName) => {
+            const msg: Record<string, unknown> = { type: 'triggerActivity', activityName };
             if (pendingPopupTarget.kind === 'user') msg.targetUserId = pendingPopupTarget.userId;
             else if (pendingPopupTarget.kind === 'users') msg.targetUserIds = pendingPopupTarget.userIds;
             else if (pendingPopupTarget.kind === 'region') msg.targetRegion = pendingPopupTarget.region;

--- a/app/components/AdminPanelV4/index.tsx
+++ b/app/components/AdminPanelV4/index.tsx
@@ -270,6 +270,7 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
             onSendHaptic={setPendingHapticTarget}
             onSendPopup={setPendingPopupTarget}
             feedbackStars={participants.feedbackStars}
+            setFeedbackStars={participants.setFeedbackStars}
             interfaceAcceptances={participants.interfaceAcceptances}
             activeLabels={labels.activeLabels}
             activeAnchors={anchors.activeAnchors}

--- a/app/components/AdminPanelV4/tabs/ParticipantsTab.tsx
+++ b/app/components/AdminPanelV4/tabs/ParticipantsTab.tsx
@@ -11,8 +11,8 @@ interface ParticipantsTabProps {
   seenUsers: Set<string>;
   setSeenUsers: (v: Set<string>) => void;
   liveCursors: Map<string, { x: number; y: number }>;
-  participantGrouping: 'none' | 'valence';
-  setParticipantGrouping: (v: 'none' | 'valence') => void;
+  participantGrouping: 'none' | 'valence' | 'feedbackStars';
+  setParticipantGrouping: (v: 'none' | 'valence' | 'feedbackStars') => void;
   moments: MomentSnapshot[];
   selectedMomentId: string | null;
   setSelectedMomentId: (v: string | null) => void;
@@ -26,6 +26,7 @@ interface ParticipantsTabProps {
   setPendingInterfaceName: (v: string) => void;
   onSendHaptic: (target: PushTarget) => void;
   onSendPopup: (target: PushTarget) => void;
+  feedbackStars: Record<string, number>;
   interfaceAcceptances: { userId: string; interfaceName: string }[];
   activeLabels: ReactionLabelSet;
   activeAnchors: ReactionAnchors;
@@ -41,6 +42,7 @@ function ParticipantsTabInner({
   openMenuUserId, setOpenMenuUserId,
   openMenuGroupKey, setOpenMenuGroupKey,
   setPushTarget, setPendingInterfaceName, onSendHaptic, onSendPopup,
+  feedbackStars,
   interfaceAcceptances, activeLabels, activeAnchors, room, selfUserId,
 }: ParticipantsTabProps) {
   const offerInterface = (target: PushTarget) => {
@@ -62,13 +64,14 @@ function ParticipantsTabInner({
         <label style={{ color: '#aaa', fontSize: 13 }}>Group by:</label>
         <select
           value={participantGrouping}
-          onChange={e => setParticipantGrouping(e.target.value as 'none' | 'valence')}
+          onChange={e => setParticipantGrouping(e.target.value as 'none' | 'valence' | 'feedbackStars')}
           style={{ background: '#222', color: '#eee', border: '1px solid #555', padding: '4px 8px', borderRadius: 4 }}
         >
           <option value="valence">Valence</option>
+          <option value="feedbackStars">Feedback Stars</option>
           <option value="none">None</option>
         </select>
-        {participantGrouping === 'valence' && (
+        {participantGrouping === 'valence' && moments.length > 0 && (
           <select
             value={selectedMomentId ?? ''}
             onChange={e => setSelectedMomentId(e.target.value || null)}
@@ -104,6 +107,91 @@ function ParticipantsTabInner({
                 onSendHaptic={() => { setOpenMenuUserId(null); onSendHaptic({ kind: 'user', userId }); }}
                 onSendPopup={() => { setOpenMenuUserId(null); onSendPopup({ kind: 'user', userId }); }}
               />
+            );
+          })}
+        </div>
+      ) : participantGrouping === 'feedbackStars' ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          {[5, 4, 3, 2, 1, 0, -1].map(stars => {
+            const groupKey = `feedback-${stars}`;
+            const groupLabel = stars === -1 ? 'No response' : '★'.repeat(stars) + '☆'.repeat(5 - stars);
+            const members = [...seenUsers].filter(userId =>
+              stars === -1 ? feedbackStars[userId] === undefined : feedbackStars[userId] === stars
+            );
+            const collapsed = collapsedGroups.has(groupKey);
+            return (
+              <div key={groupKey}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: collapsed ? 0 : 6, paddingRight: 10 }}>
+                  <button onClick={() => toggleGroupCollapse(groupKey)} style={{ background: 'none', border: 'none', color: '#666', cursor: 'pointer', padding: 0, fontSize: 10, width: 12, textAlign: 'center', flexShrink: 0 }}>
+                    {collapsed ? '▶' : '▼'}
+                  </button>
+                  <span style={{ fontSize: 12, fontWeight: 600, color: '#888', letterSpacing: '0.08em', flex: 1, cursor: 'pointer' }} onClick={() => toggleGroupCollapse(groupKey)}>
+                    {groupLabel} ({members.length})
+                  </span>
+                  <div style={{ position: 'relative' }}>
+                    <button
+                      onClick={() => setOpenMenuGroupKey(prev => prev === groupKey ? null : groupKey)}
+                      style={{ fontSize: 11, padding: '2px 8px', background: '#333', border: '1px solid #555', color: '#aaa', borderRadius: 3, cursor: 'pointer' }}
+                    >
+                      ···
+                    </button>
+                    {openMenuGroupKey === groupKey && (
+                      <div style={{ position: 'absolute', right: 0, top: '100%', marginTop: 2, background: '#252525', border: '1px solid #444', borderRadius: 6, boxShadow: '0 4px 12px rgba(0,0,0,0.5)', zIndex: 100, minWidth: 160 }}>
+                        <button
+                          onPointerDown={e => e.stopPropagation()}
+                          onClick={() => { setOpenMenuGroupKey(null); offerInterface({ kind: 'users', userIds: members, label: groupLabel }); }}
+                          style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 12px', background: 'none', border: 'none', color: '#ddd', fontSize: 13, cursor: 'pointer' }}
+                        >
+                          Offer interface…
+                        </button>
+                        <button
+                          onPointerDown={e => e.stopPropagation()}
+                          onClick={() => { setOpenMenuGroupKey(null); onSendHaptic({ kind: 'users', userIds: members, label: groupLabel }); }}
+                          style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 12px', background: 'none', border: 'none', color: '#ddd', fontSize: 13, cursor: 'pointer' }}
+                        >
+                          Send buzz…
+                        </button>
+                        <button
+                          onPointerDown={e => e.stopPropagation()}
+                          onClick={() => { setOpenMenuGroupKey(null); onSendPopup({ kind: 'users', userIds: members, label: groupLabel }); }}
+                          style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 12px', background: 'none', border: 'none', color: '#ddd', fontSize: 13, cursor: 'pointer' }}
+                        >
+                          Send popup…
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+                {!collapsed && (
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+                    {members.length === 0 ? (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '6px 10px' }}>
+                        <span style={{ width: 8, height: 8, flexShrink: 0 }} />
+                        <span style={{ fontFamily: 'monospace', fontSize: 12, color: '#444', fontStyle: 'italic', flex: 1 }}>empty</span>
+                      </div>
+                    ) : members.map(userId => {
+                      const online = connectedUsers.has(userId);
+                      const cursor = liveCursors.get(userId);
+                      const region = cursor ? computeReactionRegion(cursor.x, cursor.y, activeAnchors) : null;
+                      return (
+                        <ParticipantRow
+                          key={userId}
+                          userId={userId}
+                          region={region}
+                          labels={activeLabels}
+                          online={online}
+                          isSelf={userId === selfUserId}
+                          isMenuOpen={openMenuUserId === userId}
+                          onMenuToggle={() => setOpenMenuUserId(prev => prev === userId ? null : userId)}
+                          onOfferInterface={() => { setOpenMenuUserId(null); offerInterface({ kind: 'user', userId }); }}
+                          onSendHaptic={() => { setOpenMenuUserId(null); onSendHaptic({ kind: 'user', userId }); }}
+                          onSendPopup={() => { setOpenMenuUserId(null); onSendPopup({ kind: 'user', userId }); }}
+                        />
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
             );
           })}
         </div>

--- a/app/components/AdminPanelV4/tabs/ParticipantsTab.tsx
+++ b/app/components/AdminPanelV4/tabs/ParticipantsTab.tsx
@@ -27,6 +27,7 @@ interface ParticipantsTabProps {
   onSendHaptic: (target: PushTarget) => void;
   onSendPopup: (target: PushTarget) => void;
   feedbackStars: Record<string, number>;
+  setFeedbackStars: (v: Record<string, number>) => void;
   interfaceAcceptances: { userId: string; interfaceName: string }[];
   activeLabels: ReactionLabelSet;
   activeAnchors: ReactionAnchors;
@@ -42,7 +43,7 @@ function ParticipantsTabInner({
   openMenuUserId, setOpenMenuUserId,
   openMenuGroupKey, setOpenMenuGroupKey,
   setPushTarget, setPendingInterfaceName, onSendHaptic, onSendPopup,
-  feedbackStars,
+  feedbackStars, setFeedbackStars,
   interfaceAcceptances, activeLabels, activeAnchors, room, selfUserId,
 }: ParticipantsTabProps) {
   const offerInterface = (target: PushTarget) => {
@@ -373,7 +374,18 @@ function ParticipantsTabInner({
       )}
 
       {seenUsers.size > 0 && (
-        <div style={{ marginTop: 16, display: 'flex', justifyContent: 'flex-end' }}>
+        <div style={{ marginTop: 16, display: 'flex', justifyContent: 'flex-end', gap: 12 }}>
+          {Object.keys(feedbackStars).length > 0 && (
+            <button
+              onClick={() => {
+                localStorage.removeItem(`v4-feedback-stars-${room}`);
+                setFeedbackStars({});
+              }}
+              style={{ fontSize: 11, color: '#555', background: 'none', border: 'none', cursor: 'pointer', padding: '2px 0' }}
+            >
+              Clear feedback
+            </button>
+          )}
           <button
             onClick={() => {
               localStorage.removeItem(`v4-seen-users-${room}`);

--- a/app/components/FeedbackStarsModal.tsx
+++ b/app/components/FeedbackStarsModal.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+
+interface FeedbackStarsModalProps {
+  onSubmit: (stars: number) => void;
+  onDismiss: () => void;
+}
+
+export default function FeedbackStarsModal({ onSubmit, onDismiss }: FeedbackStarsModalProps) {
+  const [selected, setSelected] = useState<number | null>(null);
+  const [hovered, setHovered] = useState<number | null>(null);
+  const [done, setDone] = useState(false);
+
+  const handleSubmit = () => {
+    if (selected === null) return;
+    onSubmit(selected);
+    setDone(true);
+  };
+
+  const display = hovered ?? selected ?? -1;
+
+  return (
+    <div className="github-modal-overlay" onClick={e => { if (e.target === e.currentTarget) onDismiss(); }}>
+      <div className="github-modal">
+        {!done ? (
+          <>
+            <p className="github-modal-title">How's it going?</p>
+            <p className="github-modal-body">Rate your experience so far.</p>
+            <div style={{ display: 'flex', justifyContent: 'center', gap: 8, margin: '8px 0 16px' }}>
+              {[1, 2, 3, 4, 5].map(star => (
+                <button
+                  key={star}
+                  onClick={() => setSelected(star)}
+                  onMouseEnter={() => setHovered(star)}
+                  onMouseLeave={() => setHovered(null)}
+                  style={{ fontSize: 32, background: 'none', border: 'none', cursor: 'pointer', padding: 0, lineHeight: 1, color: star <= display ? '#f5c518' : '#555', transition: 'color 0.1s' }}
+                >
+                  ★
+                </button>
+              ))}
+            </div>
+            <button
+              className="github-modal-btn-primary"
+              onClick={handleSubmit}
+              disabled={selected === null}
+            >
+              Submit
+            </button>
+            <button className="github-modal-btn-dismiss" onClick={onDismiss}>Not now</button>
+          </>
+        ) : (
+          <>
+            <p className="github-modal-title">Thanks!</p>
+            <p className="github-modal-body">Your feedback has been shared with the emcee.</p>
+            <button className="github-modal-btn-primary" onClick={onDismiss}>Close</button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -7,6 +7,7 @@ import InterfaceChipBar from "./InterfaceChipBar";
 import SocialPanel from "./SocialPanel";
 import type { ActivityMode, SocialConfig } from "../types";
 import GithubUsernameModal from "./GithubUsernameModal";
+import FeedbackStarsModal from "./FeedbackStarsModal";
 import InterfacePushModal from "./InterfacePushModal";
 import HapticPushModal from "./HapticPushModal";
 import { WebHaptics } from "web-haptics";
@@ -113,6 +114,7 @@ export default function ReactionCanvasAppV4() {
   const [debug, setDebug] = useState(() => new URLSearchParams(window.location.search).get('debug') === '1');
   const reactionStateRef = useRef<ReactionState>(null);
   const [showGithubModal, setShowGithubModal] = useState(false);
+  const [showFeedbackStarsModal, setShowFeedbackStarsModal] = useState(false);
   const [pushedInterface, setPushedInterface] = useState<string | null>(null);
   const [hapticPending, setHapticPending] = useState(false);
   const [suppressHapticModal, setSuppressHapticModal] = useState(false);
@@ -269,6 +271,7 @@ export default function ReactionCanvasAppV4() {
             onSocketReady={(send) => { socketSendRef.current = send; }}
             onActivityTriggered={(activityName) => {
               if (activityName === 'githubUsername') setShowGithubModal(true);
+              if (activityName === 'feedbackStars') setShowFeedbackStarsModal(true);
             }}
             onInterfacePushed={(name) => setPushedInterface(name)}
             onHapticPushed={() => {
@@ -320,6 +323,19 @@ export default function ReactionCanvasAppV4() {
                 }));
               }}
               onDismiss={() => setShowGithubModal(false)}
+            />
+          )}
+          {showFeedbackStarsModal && (
+            <FeedbackStarsModal
+              onSubmit={(stars) => {
+                socketSendRef.current?.(JSON.stringify({
+                  type: 'submitFeedbackStars',
+                  stars,
+                  timestamp: Date.now(),
+                }));
+                setShowFeedbackStarsModal(false);
+              }}
+              onDismiss={() => setShowFeedbackStarsModal(false)}
             />
           )}
           {pushedInterface && (

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -330,6 +330,7 @@ export default function ReactionCanvasAppV4() {
               onSubmit={(stars) => {
                 socketSendRef.current?.(JSON.stringify({
                   type: 'submitFeedbackStars',
+                  userId,
                   stars,
                   timestamp: Date.now(),
                 }));

--- a/party/server.ts
+++ b/party/server.ts
@@ -123,10 +123,16 @@ interface SetUserCapEvent {
 
 interface TriggerActivityEvent {
   type: 'triggerActivity';
-  activityName: 'githubUsername';
+  activityName: 'githubUsername' | 'feedbackStars';
   targetUserId?: string;
   targetRegion?: 'positive' | 'negative' | 'neutral' | null;
   targetUserIds?: string[];
+}
+
+interface SubmitFeedbackStarsEvent {
+  type: 'submitFeedbackStars';
+  stars: number;
+  timestamp: number;
 }
 
 interface SetSocialConfigEvent {
@@ -184,7 +190,7 @@ interface Vote {
   timestamp: number;
 }
 
-type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SetSocialConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent;
+type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent;
 
 // ===== REACTION REGION HELPER (mirrors app/utils/voteRegion.ts) =====
 const DEFAULT_ANCHORS = {
@@ -499,6 +505,8 @@ export default class Server implements Party.Server {
         this.githubSubmissions.push(submission);
         // Broadcast to admins so they see it live
         this.room.broadcast(JSON.stringify({ type: 'githubUsernameSubmitted', ...submission }));
+      } else if (event.type === 'submitFeedbackStars') {
+        this.room.broadcast(JSON.stringify({ type: 'feedbackStarsSubmitted', userId: sender.id, stars: event.stars, timestamp: event.timestamp || Date.now() }));
       } else if (event.type === 'setSocialConfig') {
         this.roomSocialConfig = event.config;
         this.room.broadcast(JSON.stringify({ type: 'socialConfigChanged', config: this.roomSocialConfig }));

--- a/party/server.ts
+++ b/party/server.ts
@@ -131,6 +131,7 @@ interface TriggerActivityEvent {
 
 interface SubmitFeedbackStarsEvent {
   type: 'submitFeedbackStars';
+  userId: string;
   stars: number;
   timestamp: number;
 }
@@ -506,7 +507,7 @@ export default class Server implements Party.Server {
         // Broadcast to admins so they see it live
         this.room.broadcast(JSON.stringify({ type: 'githubUsernameSubmitted', ...submission }));
       } else if (event.type === 'submitFeedbackStars') {
-        this.room.broadcast(JSON.stringify({ type: 'feedbackStarsSubmitted', userId: sender.id, stars: event.stars, timestamp: event.timestamp || Date.now() }));
+        this.room.broadcast(JSON.stringify({ type: 'feedbackStarsSubmitted', userId: event.userId, stars: event.stars, timestamp: event.timestamp || Date.now() }));
       } else if (event.type === 'setSocialConfig') {
         this.roomSocialConfig = event.config;
         this.room.broadcast(JSON.stringify({ type: 'socialConfigChanged', config: this.roomSocialConfig }));


### PR DESCRIPTION
## Summary

- **"Send popup…" now offers two options**: "Coder role" (existing GitHub username) and "★ Star rating" — selectable via a card list in the same modal
- Participants sent a star rating see a 1–5 tap-to-select modal; on submit their response is sent back via WebSocket and stored in the emcee's localStorage (`v4-feedback-stars-{room}`)
- **New "Feedback Stars" group-by** in the People tab — buckets all seen participants by their submitted rating (5★ → 0★ + "No response"), with the same ··· action menus (Offer interface, Send buzz, Send popup) on each group

## Test plan

- [ ] Open `localhost:1999#v4?interface=emcee&room=test` (emcee view)
- [ ] Open `localhost:1999#v4?room=test&forceView=mobile` (participant view)
- [ ] In emcee People tab → ··· on a connected user → "Send popup…" → see two selectable cards → select "★ Star rating" → Send
- [ ] Participant sees star rating modal; select 4 stars → Submit; confirm "Thanks!" screen
- [ ] In emcee People tab → Group by: "Feedback Stars" → user appears in "★★★★☆" bucket
- [ ] Emcee can send buzz/popup/offer interface to a star bucket group
- [ ] Reload emcee page; ratings persist from localStorage

Closes #30 (MVP — star rating only; freehand drawing canvas deferred to a future PR per the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~120 words of PR description from ~60 words of human prompts across this session)