### PR TITLE
feat: press-to-hold mic button in Moments tab for voice moment labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 23 (2026-04-27)
 
 ### Added
+- V4 Moments tab: press-and-hold mic button at the bottom of the tab uses the browser's Web Speech API to pre-fill the upcoming "Now" moment label by voice — button starts disabled and requests mic permission on first tap; each hold-to-speak overrides the previous label
 - V4 People tab: "Send popup…" now shows two selectable options — "Coder role" (GitHub username) and "★ Star rating" (feedback); selecting star rating sends a 1–5 star modal to participants, and their responses are stored in the emcee's localStorage ([#30](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/30))
 - V4 People tab: new "Feedback Stars" group-by option — groups all seen participants into buckets by their submitted star rating (5★ down to 0★ plus "No response"), enabling the emcee to target high or low scorers with follow-up actions ([#30](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/30))
 

--- a/app/components/AdminPanelV4/index.tsx
+++ b/app/components/AdminPanelV4/index.tsx
@@ -331,7 +331,7 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
 
       {/* === MOMENTS MIC BUTTON === */}
       {activeTab === 'moments' && (
-        <div style={{ flexShrink: 0, borderTop: '1px solid #222', padding: '8px 16px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+        <div style={{ flexShrink: 0, borderTop: '1px solid #222', padding: '8px 16px calc(8px + env(safe-area-inset-bottom))', display: 'flex', flexDirection: 'column', gap: 6 }}>
           <button
             disabled={micState === 'requesting' || micState === 'error'}
             onClick={micState === 'idle' ? requestMicAccess : undefined}
@@ -359,11 +359,9 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
             {micState === 'recording' && '● Release to set label'}
             {micState === 'error' && '🎤 Mic unavailable'}
           </button>
-          {micState === 'error' && (
-            <span style={{ fontSize: 11, color: '#555', textAlign: 'center' }}>
-              {SpeechRecognitionCtor ? 'Check browser mic permissions' : 'Speech recognition not supported in this browser'}
-            </span>
-          )}
+          <span style={{ fontSize: 11, color: '#555', textAlign: 'center', visibility: micState === 'error' ? 'visible' : 'hidden' }}>
+            {SpeechRecognitionCtor ? 'Check browser mic permissions' : 'Speech recognition not supported in this browser'}
+          </span>
         </div>
       )}
 

--- a/app/components/AdminPanelV4/index.tsx
+++ b/app/components/AdminPanelV4/index.tsx
@@ -42,6 +42,34 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
   const [pendingHapticTarget, setPendingHapticTarget] = useState<PushTarget | null>(null);
   const [pendingPopupTarget, setPendingPopupTarget]   = useState<PushTarget | null>(null);
 
+  // Mic state for Moments tab voice annotation
+  type MicState = 'idle' | 'requesting' | 'ready' | 'recording' | 'error';
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const SpeechRecognitionCtor: (new () => any) | null = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition ?? null;
+  const [micState, setMicState] = useState<MicState>(SpeechRecognitionCtor ? 'idle' : 'error');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const micRecognitionRef = useRef<any>(null);
+  const requestMicAccess = () => {
+    if (!navigator.mediaDevices?.getUserMedia) { setMicState('error'); return; }
+    setMicState('requesting');
+    navigator.mediaDevices.getUserMedia({ audio: true })
+      .then(() => setMicState('ready'))
+      .catch(() => setMicState('error'));
+  };
+  const startMicRecording = () => {
+    if (!SpeechRecognitionCtor) return;
+    const r = new SpeechRecognitionCtor();
+    r.continuous = false;
+    r.interimResults = false;
+    r.onresult = (e: any) => participants.setMomentLabelInput(e.results[0][0].transcript); // eslint-disable-line @typescript-eslint/no-explicit-any
+    r.onend = () => setMicState('ready');
+    r.onerror = () => setMicState('ready');
+    micRecognitionRef.current = r;
+    r.start();
+    setMicState('recording');
+  };
+  const stopMicRecording = () => micRecognitionRef.current?.stop();
+
   // Ref-based dispatch so all hooks see the same handler regardless of creation order
   const dispatchRef = useRef<(data: Record<string, unknown>) => void>(() => {});
 
@@ -300,6 +328,44 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
           />
         )}
       </div>
+
+      {/* === MOMENTS MIC BUTTON === */}
+      {activeTab === 'moments' && (
+        <div style={{ flexShrink: 0, borderTop: '1px solid #222', padding: '8px 16px', display: 'flex', flexDirection: 'column', gap: 6 }}>
+          <button
+            disabled={micState === 'requesting' || micState === 'error'}
+            onClick={micState === 'idle' ? requestMicAccess : undefined}
+            onPointerDown={micState === 'ready' ? startMicRecording : undefined}
+            onPointerUp={micState === 'recording' ? stopMicRecording : undefined}
+            onPointerLeave={micState === 'recording' ? stopMicRecording : undefined}
+            style={{
+              width: '100%',
+              padding: '14px',
+              borderRadius: 8,
+              border: 'none',
+              fontSize: 14,
+              fontWeight: 700,
+              cursor: micState === 'requesting' || micState === 'error' ? 'not-allowed' : 'pointer',
+              background: micState === 'recording' ? '#7a1a1a' : micState === 'ready' ? '#1a3a1a' : '#222',
+              color: micState === 'error' ? '#666' : micState === 'recording' ? '#faa' : micState === 'ready' ? '#4c4' : '#aaa',
+              transition: 'background 0.15s',
+              userSelect: 'none',
+              touchAction: 'none',
+            }}
+          >
+            {micState === 'idle' && '🎤 Enable mic'}
+            {micState === 'requesting' && 'Requesting mic…'}
+            {micState === 'ready' && '🎤 Hold to speak'}
+            {micState === 'recording' && '● Release to set label'}
+            {micState === 'error' && '🎤 Mic unavailable'}
+          </button>
+          {micState === 'error' && (
+            <span style={{ fontSize: 11, color: '#555', textAlign: 'center' }}>
+              {SpeechRecognitionCtor ? 'Check browser mic permissions' : 'Speech recognition not supported in this browser'}
+            </span>
+          )}
+        </div>
+      )}
 
       {/* === MODALS === */}
       {pendingHapticTarget && (

--- a/app/components/AdminPanelV4/tabs/MomentsTab.tsx
+++ b/app/components/AdminPanelV4/tabs/MomentsTab.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useRef, useState } from "react";
 import { computeReactionRegion } from "../../../utils/voteRegion";
 import type { ReactionAnchors, ReactionRegion } from "../../../utils/voteRegion";
 import type { ReactionLabelSet } from "../../../voteLabels";
@@ -24,6 +24,15 @@ interface MomentsTabProps {
   room: string;
 }
 
+type MicState = 'idle' | 'requesting' | 'ready' | 'recording' | 'error';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const SpeechRecognitionCtor: (new () => { continuous: boolean; interimResults: boolean; onresult: ((e: any) => void) | null; onend: (() => void) | null; onerror: (() => void) | null; start: () => void; stop: () => void }) | null =
+  typeof window !== 'undefined'
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ? ((window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition ?? null)
+    : null;
+
 function MomentsTabInner({
   moments, setMoments,
   seenUsers, connectedUsers, liveCursors,
@@ -33,6 +42,36 @@ function MomentsTabInner({
   editingMomentLabel, setEditingMomentLabel,
   snapMoment, activeLabels, activeAnchors, room,
 }: MomentsTabProps) {
+  const [micState, setMicState] = useState<MicState>(SpeechRecognitionCtor ? 'idle' : 'error');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const recognitionRef = useRef<any>(null);
+
+  const requestMicAccess = () => {
+    setMicState('requesting');
+    navigator.mediaDevices.getUserMedia({ audio: true })
+      .then(() => setMicState('ready'))
+      .catch(() => setMicState('error'));
+  };
+
+  const startRecording = () => {
+    if (!SpeechRecognitionCtor) return;
+    const recognition = new SpeechRecognitionCtor();
+    recognition.continuous = false;
+    recognition.interimResults = false;
+    recognition.onresult = (e) => {
+      setMomentLabelInput(e.results[0][0].transcript);
+    };
+    recognition.onend = () => setMicState('ready');
+    recognition.onerror = () => setMicState('ready');
+    recognitionRef.current = recognition;
+    recognition.start();
+    setMicState('recording');
+  };
+
+  const stopRecording = () => {
+    recognitionRef.current?.stop();
+  };
+
   const toggleExpanded = (id: string) => {
     setExpandedMoments(prev => {
       const s = new Set(prev);
@@ -230,6 +269,42 @@ function MomentsTabInner({
           })}
         </div>
       )}
+
+      {/* Mic button */}
+      <div style={{ marginTop: 24, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+        <button
+          disabled={micState === 'requesting' || micState === 'error'}
+          onClick={micState === 'idle' ? requestMicAccess : undefined}
+          onPointerDown={micState === 'ready' ? startRecording : undefined}
+          onPointerUp={micState === 'recording' ? stopRecording : undefined}
+          onPointerLeave={micState === 'recording' ? stopRecording : undefined}
+          style={{
+            width: '100%',
+            padding: '14px',
+            borderRadius: 8,
+            border: 'none',
+            fontSize: 14,
+            fontWeight: 700,
+            cursor: micState === 'requesting' || micState === 'error' ? 'not-allowed' : 'pointer',
+            background: micState === 'recording' ? '#7a1a1a' : micState === 'ready' ? '#1a3a1a' : '#222',
+            color: micState === 'error' ? '#666' : micState === 'recording' ? '#faa' : micState === 'ready' ? '#4c4' : '#aaa',
+            transition: 'background 0.15s',
+            userSelect: 'none',
+            touchAction: 'none',
+          }}
+        >
+          {micState === 'idle' && '🎤 Enable mic'}
+          {micState === 'requesting' && 'Requesting mic…'}
+          {micState === 'ready' && '🎤 Hold to speak'}
+          {micState === 'recording' && '● Release to set label'}
+          {micState === 'error' && '🎤 Mic unavailable'}
+        </button>
+        {micState === 'error' && (
+          <span style={{ fontSize: 11, color: '#555', textAlign: 'center' }}>
+            {SpeechRecognitionCtor ? 'Check browser mic permissions' : 'Speech recognition not supported in this browser'}
+          </span>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/components/AdminPanelV4/tabs/MomentsTab.tsx
+++ b/app/components/AdminPanelV4/tabs/MomentsTab.tsx
@@ -47,6 +47,10 @@ function MomentsTabInner({
   const recognitionRef = useRef<any>(null);
 
   const requestMicAccess = () => {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setMicState('error');
+      return;
+    }
     setMicState('requesting');
     navigator.mediaDevices.getUserMedia({ audio: true })
       .then(() => setMicState('ready'))

--- a/app/components/AdminPanelV4/tabs/MomentsTab.tsx
+++ b/app/components/AdminPanelV4/tabs/MomentsTab.tsx
@@ -275,7 +275,7 @@ function MomentsTabInner({
       )}
 
       {/* Mic button */}
-      <div style={{ marginTop: 24, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8 }}>
+      <div style={{ position: 'sticky', bottom: 0, marginTop: 24, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, background: '#111', paddingBottom: 8, paddingTop: 8 }}>
         <button
           disabled={micState === 'requesting' || micState === 'error'}
           onClick={micState === 'idle' ? requestMicAccess : undefined}

--- a/app/components/AdminPanelV4/tabs/MomentsTab.tsx
+++ b/app/components/AdminPanelV4/tabs/MomentsTab.tsx
@@ -1,4 +1,4 @@
-import { memo, useRef, useState } from "react";
+import { memo } from "react";
 import { computeReactionRegion } from "../../../utils/voteRegion";
 import type { ReactionAnchors, ReactionRegion } from "../../../utils/voteRegion";
 import type { ReactionLabelSet } from "../../../voteLabels";
@@ -24,15 +24,6 @@ interface MomentsTabProps {
   room: string;
 }
 
-type MicState = 'idle' | 'requesting' | 'ready' | 'recording' | 'error';
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const SpeechRecognitionCtor: (new () => { continuous: boolean; interimResults: boolean; onresult: ((e: any) => void) | null; onend: (() => void) | null; onerror: (() => void) | null; start: () => void; stop: () => void }) | null =
-  typeof window !== 'undefined'
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    ? ((window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition ?? null)
-    : null;
-
 function MomentsTabInner({
   moments, setMoments,
   seenUsers, connectedUsers, liveCursors,
@@ -42,40 +33,6 @@ function MomentsTabInner({
   editingMomentLabel, setEditingMomentLabel,
   snapMoment, activeLabels, activeAnchors, room,
 }: MomentsTabProps) {
-  const [micState, setMicState] = useState<MicState>(SpeechRecognitionCtor ? 'idle' : 'error');
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const recognitionRef = useRef<any>(null);
-
-  const requestMicAccess = () => {
-    if (!navigator.mediaDevices?.getUserMedia) {
-      setMicState('error');
-      return;
-    }
-    setMicState('requesting');
-    navigator.mediaDevices.getUserMedia({ audio: true })
-      .then(() => setMicState('ready'))
-      .catch(() => setMicState('error'));
-  };
-
-  const startRecording = () => {
-    if (!SpeechRecognitionCtor) return;
-    const recognition = new SpeechRecognitionCtor();
-    recognition.continuous = false;
-    recognition.interimResults = false;
-    recognition.onresult = (e) => {
-      setMomentLabelInput(e.results[0][0].transcript);
-    };
-    recognition.onend = () => setMicState('ready');
-    recognition.onerror = () => setMicState('ready');
-    recognitionRef.current = recognition;
-    recognition.start();
-    setMicState('recording');
-  };
-
-  const stopRecording = () => {
-    recognitionRef.current?.stop();
-  };
-
   const toggleExpanded = (id: string) => {
     setExpandedMoments(prev => {
       const s = new Set(prev);
@@ -274,41 +231,6 @@ function MomentsTabInner({
         </div>
       )}
 
-      {/* Mic button */}
-      <div style={{ position: 'sticky', bottom: 0, marginTop: 24, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 8, background: '#111', paddingBottom: 8, paddingTop: 8 }}>
-        <button
-          disabled={micState === 'requesting' || micState === 'error'}
-          onClick={micState === 'idle' ? requestMicAccess : undefined}
-          onPointerDown={micState === 'ready' ? startRecording : undefined}
-          onPointerUp={micState === 'recording' ? stopRecording : undefined}
-          onPointerLeave={micState === 'recording' ? stopRecording : undefined}
-          style={{
-            width: '100%',
-            padding: '14px',
-            borderRadius: 8,
-            border: 'none',
-            fontSize: 14,
-            fontWeight: 700,
-            cursor: micState === 'requesting' || micState === 'error' ? 'not-allowed' : 'pointer',
-            background: micState === 'recording' ? '#7a1a1a' : micState === 'ready' ? '#1a3a1a' : '#222',
-            color: micState === 'error' ? '#666' : micState === 'recording' ? '#faa' : micState === 'ready' ? '#4c4' : '#aaa',
-            transition: 'background 0.15s',
-            userSelect: 'none',
-            touchAction: 'none',
-          }}
-        >
-          {micState === 'idle' && '🎤 Enable mic'}
-          {micState === 'requesting' && 'Requesting mic…'}
-          {micState === 'ready' && '🎤 Hold to speak'}
-          {micState === 'recording' && '● Release to set label'}
-          {micState === 'error' && '🎤 Mic unavailable'}
-        </button>
-        {micState === 'error' && (
-          <span style={{ fontSize: 11, color: '#555', textAlign: 'center' }}>
-            {SpeechRecognitionCtor ? 'Check browser mic permissions' : 'Speech recognition not supported in this browser'}
-          </span>
-        )}
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a press-and-hold mic button at the bottom of the V4 Moments tab
- Uses the browser's Web Speech API to transcribe speech directly into the "Now" moment label — each hold overrides the previous value
- Button starts in a disabled "Enable mic" state; first tap requests mic permission, then transitions to press-to-hold mode
- Guards against `navigator.mediaDevices` being `undefined` on non-HTTPS origins (Chrome blocks mic on insecure contexts — the button will show an error state rather than getting stuck at "Requesting…")

## Test plan

- [ ] Open `#v4?forceView=mobile&interface=emcee` via the deployed HTTPS URL and navigate to Moments tab
- [ ] Confirm mic button appears at the bottom in "Enable mic" state
- [ ] Tap — browser should prompt for mic permission
- [ ] After granting, button should change to "Hold to speak"
- [ ] Hold button, speak, release — "Now" label should update with transcript
- [ ] Confirm a second hold overrides the previous label
- [ ] Test on HTTP (LAN dev): confirm button shows error state rather than getting stuck at "Requesting mic…"

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~100 words of PR description from ~60 words of human prompts across this session)