### PR TITLE
feat: presenter interface for common/projector canvas view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ### Added
 - V4: new `?interface=presenter` URL param opens a standalone read-only "Common" canvas — shows all participant cursors live, bypasses the mobile gate, excluded from presence count, no touch interaction; intended for projector/shared-display use
+- V4 Interfaces tab: Commons column now shows radio buttons mirroring Solo — reflects and controls the current activity mode for the presenter screen (both share one room-wide activity for now)
 - Valence onboarding v2: "style past like cursor" checkbox — when unchecked, trace and fill segments retain the color they held at the moment they were drawn rather than retroactively reflecting the cursor's current valence
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 23 (2026-04-27)
 
 ### Added
+- V4: new `?interface=presenter` URL param opens a standalone read-only "Common" canvas — shows all participant cursors live, bypasses the mobile gate, excluded from presence count, no touch interaction; intended for projector/shared-display use
 - Valence onboarding v2: "style past like cursor" checkbox — when unchecked, trace and fill segments retain the color they held at the moment they were drawn rather than retroactively reflecting the cursor's current valence
 
 ### Fixed

--- a/app/components/AdminPanelV4/hooks/useRoomConfig.ts
+++ b/app/components/AdminPanelV4/hooks/useRoomConfig.ts
@@ -5,6 +5,7 @@ import type PartySocket from "partysocket";
 export function useRoomConfig(socket: PartySocket) {
   const [avatarStyle, setAvatarStyle]         = useState<string | null>(null);
   const [activity, setActivity]               = useState<ActivityMode>('canvas');
+  const [commonsActivity, setCommonsActivity] = useState<ActivityMode>('canvas');
   const [soccerScore, setSoccerScore]         = useState({ left: 0, right: 0 });
   const [imageConfigOpen, setImageConfigOpen] = useState(false);
   const [roomImageUrl, setRoomImageUrl]       = useState('');
@@ -25,6 +26,11 @@ export function useRoomConfig(socket: PartySocket) {
   const sendActivity = (act: ActivityMode) => {
     setActivity(act);
     socket.send(JSON.stringify({ type: 'setActivity', activity: act }));
+  };
+
+  const sendCommonsActivity = (act: ActivityMode) => {
+    setCommonsActivity(act);
+    socket.send(JSON.stringify({ type: 'setCommonsActivity', activity: act }));
   };
 
   const sendImageUrl = (url: string) => {
@@ -50,6 +56,7 @@ export function useRoomConfig(socket: PartySocket) {
   const applyConnected = (data: Record<string, unknown>) => {
     if ('roomAvatarStyle' in data) setAvatarStyle((data.roomAvatarStyle as string | null) ?? null);
     if ('currentActivity' in data) setActivity((data.currentActivity as ActivityMode) ?? 'canvas');
+    if ('commonsActivity' in data) setCommonsActivity((data.commonsActivity as ActivityMode) ?? 'canvas');
     if ('roomImageUrl' in data) setRoomImageUrl((data.roomImageUrl as string) ?? '');
     if ('roomSocialConfig' in data) setRoomSocialConfig((data.roomSocialConfig as SocialConfig | null) ?? null);
     if ('soccerScore' in data && data.soccerScore) setSoccerScore(data.soccerScore as { left: number; right: number });
@@ -64,6 +71,8 @@ export function useRoomConfig(socket: PartySocket) {
       setAvatarStyle((data.avatarStyle as string | null) ?? null);
     } else if (data.type === 'activityChanged') {
       setActivity((data.activity as ActivityMode) ?? 'canvas');
+    } else if (data.type === 'commonsActivityChanged') {
+      setCommonsActivity((data.activity as ActivityMode) ?? 'canvas');
     } else if (data.type === 'imageUrlChanged') {
       setRoomImageUrl((data.url as string) ?? '');
     } else if (data.type === 'socialConfigChanged') {
@@ -88,6 +97,8 @@ export function useRoomConfig(socket: PartySocket) {
     capInput, setCapInput,
     sendAvatarStyle,
     sendActivity,
+    sendCommonsActivity,
+    commonsActivity,
     sendImageUrl,
     sendSocialConfig,
     resetSoccerScore,

--- a/app/components/AdminPanelV4/index.tsx
+++ b/app/components/AdminPanelV4/index.tsx
@@ -283,8 +283,10 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
         {activeTab === 'interfaces' && (
           <InterfacesTab
             activity={roomConfig.activity}
+            commonsActivity={roomConfig.commonsActivity}
             soccerScore={roomConfig.soccerScore}
             sendActivity={roomConfig.sendActivity}
+            sendCommonsActivity={roomConfig.sendCommonsActivity}
             resetSoccerScore={roomConfig.resetSoccerScore}
             setImageConfigOpen={roomConfig.setImageConfigOpen}
             setSocialConfigOpen={roomConfig.setSocialConfigOpen}

--- a/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
+++ b/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
@@ -5,8 +5,10 @@ import type { ActivityMode } from "../../../types";
 
 interface InterfacesTabProps {
   activity: ActivityMode;
+  commonsActivity: ActivityMode;
   soccerScore: { left: number; right: number };
   sendActivity: (act: ActivityMode) => void;
+  sendCommonsActivity: (act: ActivityMode) => void;
   resetSoccerScore: () => void;
   setImageConfigOpen: (v: boolean) => void;
   setSocialConfigOpen: (v: boolean) => void;
@@ -38,8 +40,8 @@ const ROWS: { id: ActivityMode; label: string; desc: string; patchable: boolean 
 ];
 
 export default function InterfacesTab({
-  activity, soccerScore,
-  sendActivity, resetSoccerScore,
+  activity, commonsActivity, soccerScore,
+  sendActivity, sendCommonsActivity, resetSoccerScore,
   setImageConfigOpen, setSocialConfigOpen, setCanvasSettingsOpen,
   onClearRoleAssignments,
 }: InterfacesTabProps) {
@@ -98,8 +100,8 @@ export default function InterfacesTab({
                     type="radio"
                     name="activity-commons"
                     value={id}
-                    checked={isActive}
-                    onChange={() => sendActivity(id)}
+                    checked={commonsActivity === id}
+                    onChange={() => sendCommonsActivity(id)}
                   />
                 </td>
                 {/* Patch */}

--- a/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
+++ b/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
@@ -92,8 +92,16 @@ export default function InterfacesTab({
                     onChange={() => sendActivity(id)}
                   />
                 </td>
-                {/* Commons — placeholder */}
-                <td style={{ textAlign: 'center', padding: '10px 8px', color: '#3a3a3a' }}>—</td>
+                {/* Commons */}
+                <td style={{ textAlign: 'center', padding: '10px 8px' }}>
+                  <input
+                    type="radio"
+                    name="activity-commons"
+                    value={id}
+                    checked={isActive}
+                    onChange={() => sendActivity(id)}
+                  />
+                </td>
                 {/* Patch */}
                 <td style={{ textAlign: 'center', padding: '10px 0 10px 8px' }}>
                   {patchable ? (

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -131,7 +131,11 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
             setAvatarStyle(data.roomAvatarStyle ?? null);
             onRoomAvatarStyleChange?.(data.roomAvatarStyle ?? null);
           }
-          if ('currentActivity' in data) {
+          if (readOnly && 'commonsActivity' in data) {
+            const act = data.commonsActivity ?? 'canvas';
+            setActivity(act);
+            onActivityChange?.(act);
+          } else if (!readOnly && 'currentActivity' in data) {
             const act = data.currentActivity ?? 'canvas';
             setActivity(act);
             onActivityChange?.(act);
@@ -207,13 +211,21 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
           return;
         }
 
-        if (data.type === 'activityChanged') {
+        if (data.type === 'activityChanged' && !readOnly) {
           const act = data.activity ?? 'canvas';
           setActivity(act);
           onActivityChange?.(act);
           if (data.ball) setBallPos({ x: data.ball.x, y: data.ball.y });
           if (data.score) setSoccerScore(data.score);
           if (data.activity !== 'soccer') setBallPos(null);
+          return;
+        }
+
+        if (data.type === 'commonsActivityChanged' && readOnly) {
+          const act = data.activity ?? 'canvas';
+          setActivity(act);
+          onActivityChange?.(act);
+          if (act !== 'soccer') setBallPos(null);
           return;
         }
 

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -51,6 +51,8 @@ const PUSHED_INTERFACES_KEY = 'v4-pushed-interfaces';
 
 function getUnlockedInterfaces(): string[] {
   const p = new URLSearchParams(window.location.search);
+  // presenter opens standalone — no chip bar, no canvas alongside
+  if (p.get('interface') === 'presenter') return ['presenter'];
   const interfaces = ['canvas'];
   if (p.get('interface') === 'emcee') interfaces.push('emcee');
   if (p.get('interface') === 'social') interfaces.push('social');
@@ -93,7 +95,9 @@ export default function ReactionCanvasAppV4() {
     const unlocked = getUnlockedInterfaces();
     const saved = localStorage.getItem('v4-active-interface');
     if (saved && unlocked.includes(saved)) return saved;
-    return unlocked.includes('emcee') ? 'emcee' : 'canvas';
+    return unlocked.includes('emcee') ? 'emcee'
+         : unlocked.includes('presenter') ? 'presenter'
+         : 'canvas';
   });
   const [userId] = useState(() => getPersistentUserId());
   const [canvasBackgroundReactionState, setCanvasBackgroundReactionState] = useState<ReactionState>(null);
@@ -127,6 +131,7 @@ export default function ReactionCanvasAppV4() {
 
   // Derived early so useCallback deps below can reference it (must still be before any early return)
   const isEmcee = unlockedInterfaces.includes('emcee');
+  const isPresenter = unlockedInterfaces.includes('presenter');
 
   const triggerBuzzForUpdate = useCallback(() => {
     if (hapticFlashTimeoutRef.current) clearTimeout(hapticFlashTimeoutRef.current);
@@ -140,19 +145,19 @@ export default function ReactionCanvasAppV4() {
   }, [hapticEnabled, suppressHapticModal, triggerHaptic]);
 
   const handleRoomLabelsChange = useCallback((labels: ReactionLabelSet | null) => {
-    if (hasConnectedRef.current && !isEmcee) triggerBuzzForUpdate();
+    if (hasConnectedRef.current && !isEmcee && !isPresenter) triggerBuzzForUpdate();
     setServerLabels(labels);
-  }, [isEmcee, triggerBuzzForUpdate]);
+  }, [isEmcee, isPresenter, triggerBuzzForUpdate]);
 
   const handleActivityChange = useCallback((act: ActivityMode) => {
-    if (hasConnectedRef.current && !isEmcee) triggerBuzzForUpdate();
+    if (hasConnectedRef.current && !isEmcee && !isPresenter) triggerBuzzForUpdate();
     setActivity(act);
-  }, [isEmcee, triggerBuzzForUpdate]);
+  }, [isEmcee, isPresenter, triggerBuzzForUpdate]);
 
   const handleRoomImageUrlChange = useCallback((url: string) => {
-    if (hasConnectedRef.current && !isEmcee) triggerBuzzForUpdate();
+    if (hasConnectedRef.current && !isEmcee && !isPresenter) triggerBuzzForUpdate();
     setServerImageUrl(url);
-  }, [isEmcee, triggerBuzzForUpdate]);
+  }, [isEmcee, isPresenter, triggerBuzzForUpdate]);
 
   useEffect(() => {
     localStorage.setItem('v4-active-interface', activeInterface);
@@ -172,7 +177,7 @@ export default function ReactionCanvasAppV4() {
     socketSendRef.current?.(JSON.stringify({ type: 'requestJoin' }));
   };
 
-  if (!isEmcee && !isTouchDevice() && !isMobileForced()) {
+  if (!isEmcee && !isPresenter && !isTouchDevice() && !isMobileForced()) {
     return <MobileOnlyGate />;
   }
 
@@ -184,7 +189,7 @@ export default function ReactionCanvasAppV4() {
 
   const showChipBar = unlockedInterfaces.length >= 2;
   const chipBarOffset = showChipBar ? CHIP_BAR_HEIGHT : 0;
-  const KNOWN_CHIPS: Record<string, string> = { canvas: 'Canvas', emcee: 'Emcee', social: 'Social' };
+  const KNOWN_CHIPS: Record<string, string> = { canvas: 'Canvas', emcee: 'Emcee', social: 'Social', presenter: 'Common' };
   const INTERFACE_CHIPS = unlockedInterfaces.map(key => ({
     key,
     label: KNOWN_CHIPS[key] ?? (key.charAt(0).toUpperCase() + key.slice(1)),
@@ -207,11 +212,11 @@ export default function ReactionCanvasAppV4() {
       {/* When activity is 'social', show SocialPanel as a flex sibling (fills the
           remaining height below the chip bar, same as the chip-based case).
           Canvas container is hidden but stays mounted to keep the socket alive. */}
-      {activeInterface === 'canvas' && activity === 'social' && (
+      {(activeInterface === 'canvas' || activeInterface === 'presenter') && activity === 'social' && (
         <SocialPanel socialConfig={serverSocialConfig} />
       )}
       {/* Canvas is always mounted to keep the WebSocket alive for all interfaces */}
-      <div className="v2-vote-canvas-container" style={{ flex: 1, display: (activeInterface === 'canvas' && activity !== 'social') ? undefined : 'none' }}>
+      <div className="v2-vote-canvas-container" style={{ flex: 1, display: ((activeInterface === 'canvas' || activeInterface === 'presenter') && activity !== 'social') ? undefined : 'none' }}>
           {activity === 'image-canvas' && serverImageUrl && (
             <img
               src={serverImageUrl}
@@ -238,14 +243,14 @@ export default function ReactionCanvasAppV4() {
           </div>
           <div className="debug-hint">{debug ? 'd: debug on' : 'd: debug'}</div>
           <div className={`v3-rec-badge${isRecording ? '' : ' v3-rec-badge--off'}`}>● REC</div>
-          <ShareQRButton />
-          <HapticIndicatorButton
+          {!isPresenter && <ShareQRButton />}
+          {!isPresenter && <HapticIndicatorButton
             enabled={hapticEnabled}
             flashing={hapticFlashing}
             canVibrate={WebHaptics.isSupported}
             onToggle={() => { if (WebHaptics.isSupported) setHapticEnabled(prev => !prev); }}
             onShowInfo={() => setHapticPending(true)}
-          />
+          />}
           {touchPos && (
             <div
               className="v2-touch-indicator"
@@ -255,6 +260,7 @@ export default function ReactionCanvasAppV4() {
           <Canvas
             room={room}
             userId={userId}
+            readOnly={isPresenter}
             colorCursorsByVote={true}
             currentReactionState={canvasBackgroundReactionState}
             heightOffset={chipBarOffset}
@@ -290,7 +296,10 @@ export default function ReactionCanvasAppV4() {
               setUnlockedInterfaces(getUnlockedInterfaces());
               setActiveInterface(prev => {
                 const urlBased = getUnlockedInterfaces();
-                return urlBased.includes(prev) ? prev : (urlBased.includes('emcee') ? 'emcee' : 'canvas');
+                return urlBased.includes(prev) ? prev
+                     : urlBased.includes('emcee') ? 'emcee'
+                     : urlBased.includes('presenter') ? 'presenter'
+                     : 'canvas';
               });
             }}
             onRoomImageUrlChange={handleRoomImageUrlChange}
@@ -307,7 +316,7 @@ export default function ReactionCanvasAppV4() {
               {nowLabel}
             </div>
           )}
-          {!isViewer && activity !== 'social' && (
+          {!isViewer && !isPresenter && activity !== 'social' && (
             <TouchLayer
               room={room}
               userId={userId}

--- a/party/server.ts
+++ b/party/server.ts
@@ -107,6 +107,11 @@ interface SetActivityEvent {
   activity: ActivityMode;
 }
 
+interface SetCommonsActivityEvent {
+  type: 'setCommonsActivity';
+  activity: ActivityMode;
+}
+
 interface SetImageUrlEvent {
   type: 'setImageUrl';
   url: string;
@@ -196,7 +201,7 @@ interface SetNowLabelEvent {
   label: string;
 }
 
-type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent;
+type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetCommonsActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent;
 
 // ===== REACTION REGION HELPER (mirrors app/utils/voteRegion.ts) =====
 const DEFAULT_ANCHORS = {
@@ -250,6 +255,7 @@ export default class Server implements Party.Server {
   private roomAnchors: ReactionAnchors | null = null;
   private roomAvatarStyle: string | null = null;
   private currentActivity: ActivityMode = 'canvas';
+  private commonsActivity: ActivityMode = 'canvas';
   private roomImageUrl: string = '';
   private nowLabel: string = '';
   private roomSocialConfig: { default: string; twitter: string; bluesky: string; mastodon: string } | null = null;
@@ -369,6 +375,7 @@ export default class Server implements Party.Server {
       roomAnchors: this.roomAnchors,
       roomAvatarStyle: this.roomAvatarStyle,
       currentActivity: this.currentActivity,
+      commonsActivity: this.commonsActivity,
       roomImageUrl: this.roomImageUrl,
       nowLabel: this.nowLabel,
       roomSocialConfig: this.roomSocialConfig,
@@ -484,6 +491,9 @@ export default class Server implements Party.Server {
           ball: this.currentActivity === 'soccer' ? this.ballState : null,
           score: this.soccerScore,
         }));
+      } else if (event.type === 'setCommonsActivity') {
+        this.commonsActivity = event.activity;
+        this.room.broadcast(JSON.stringify({ type: 'commonsActivityChanged', activity: this.commonsActivity }));
       } else if (event.type === 'setNowLabel') {
         this.nowLabel = event.label;
         this.room.broadcast(JSON.stringify({ type: 'nowLabelChanged', label: this.nowLabel }));


### PR DESCRIPTION
## Summary

- Adds `?interface=presenter` URL param to V4 that opens a standalone read-only canvas designed for projectors or shared displays
- Shows all participant cursors live; bypasses the mobile-only gate (it's a desktop/projector view)
- Connects as read-only — excluded from the participant presence count
- Suppresses personal-interaction UI: no TouchLayer, no ShareQRButton, no HapticIndicatorButton, no haptic buzz callbacks
- Opens alone (no chip bar) since it replaces `canvas` in the unlocked interfaces list rather than joining it

## Test plan

- [ ] Open `?interface=presenter#v4` on desktop — full-screen canvas without mobile gate
- [ ] Open a second tab as a regular participant and move cursor — presence count should be 1 (not 2); presenter cursor should not appear
- [ ] Participant cursor visible on presenter screen
- [ ] No touch interaction possible from presenter screen (TouchLayer absent)
- [ ] No ShareQRButton or HapticIndicatorButton visible on presenter screen
- [ ] `pnpm tsc --noEmit` passes
- [ ] `pnpm vitest --run` passes (31 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~150 words of PR description from ~80 words of human prompts across this session)