### PR TITLE
feat: mood-tones interface — generative audio driven by audience reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ### Added
 - Mood Sounds: volume slider (0–200%) added above the start button
 - Mood Sounds: significantly boosted output level — tripled oscillator gains, tightened compressor, added 2.5× makeup gain after compression
+- V4: new `mood-tones` interface — ambient generative audio keyed to live audience reaction position; unlock via `?interface=mood-tones` or push from the People tab; audience sync defaults on
 
 ### Fixed
 - V4 haptic modal: "Show this popup when a buzz is sent" checkbox now defaults to unchecked on non-haptic devices

--- a/app/components/AdminPanelV4/OfferInterfaceModal.tsx
+++ b/app/components/AdminPanelV4/OfferInterfaceModal.tsx
@@ -52,6 +52,7 @@ export default function OfferInterfaceModal({
           style={{ background: '#333', border: '1px solid #555', color: '#eee', borderRadius: 6, padding: '8px 10px', fontSize: 13 }}
         >
           <option value="social">social</option>
+          <option value="mood-tones">mood-tones</option>
           <option value="emcee">emcee</option>
         </select>
         <div style={{ display: 'flex', gap: 8 }}>

--- a/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
+++ b/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
@@ -35,7 +35,7 @@ const ROWS: { id: string; label: string; desc: string; patchable: boolean; activ
   { id: 'image-canvas', label: 'Image Canvas',    desc: 'React over a shared background image',           patchable: false, activityMode: true  },
   { id: 'soccer',       label: 'Soccer',          desc: 'Top-down physics ball — kick with your cursor',  patchable: false, activityMode: true  },
   { id: 'social',       label: 'Social Sharing',  desc: 'Bluesky · Twitter / X · Mastodon',              patchable: true,  activityMode: true  },
-  { id: 'mood-tones',   label: 'Mood Tones',      desc: 'Generative audio keyed to audience reactions',  patchable: true,  activityMode: false },
+  { id: 'mood-tones',   label: 'Mood Tones',      desc: 'Generative audio keyed to audience reactions',  patchable: true,  activityMode: true  },
 ];
 
 export default function InterfacesTab({

--- a/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
+++ b/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
@@ -30,11 +30,12 @@ function getPatchUrl(interfaceName: string): string {
   return `${window.location.origin}${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
 }
 
-const ROWS: { id: ActivityMode; label: string; desc: string; patchable: boolean }[] = [
-  { id: 'canvas',       label: 'Reaction Canvas', desc: 'Standard reaction canvas',                       patchable: false },
-  { id: 'image-canvas', label: 'Image Canvas',    desc: 'React over a shared background image',           patchable: false },
-  { id: 'soccer',       label: 'Soccer',          desc: 'Top-down physics ball — kick with your cursor',  patchable: false },
-  { id: 'social',       label: 'Social Sharing',  desc: 'Bluesky · Twitter / X · Mastodon',              patchable: true  },
+const ROWS: { id: string; label: string; desc: string; patchable: boolean; activityMode: boolean }[] = [
+  { id: 'canvas',       label: 'Reaction Canvas', desc: 'Standard reaction canvas',                       patchable: false, activityMode: true  },
+  { id: 'image-canvas', label: 'Image Canvas',    desc: 'React over a shared background image',           patchable: false, activityMode: true  },
+  { id: 'soccer',       label: 'Soccer',          desc: 'Top-down physics ball — kick with your cursor',  patchable: false, activityMode: true  },
+  { id: 'social',       label: 'Social Sharing',  desc: 'Bluesky · Twitter / X · Mastodon',              patchable: true,  activityMode: true  },
+  { id: 'mood-tones',   label: 'Mood Tones',      desc: 'Generative audio keyed to audience reactions',  patchable: true,  activityMode: false },
 ];
 
 export default function InterfacesTab({
@@ -43,8 +44,8 @@ export default function InterfacesTab({
   setImageConfigOpen, setSocialConfigOpen, setCanvasSettingsOpen,
   onClearRoleAssignments,
 }: InterfacesTabProps) {
-  const [patchDialogOpen, setPatchDialogOpen] = useState(false);
-  const patchUrl = getPatchUrl('social');
+  const [patchInterface, setPatchInterface] = useState<string | null>(null);
+  const patchUrl = patchInterface ? getPatchUrl(patchInterface) : '';
 
   return (
     <div>
@@ -61,13 +62,13 @@ export default function InterfacesTab({
           </tr>
         </thead>
         <tbody>
-          {ROWS.map(({ id, label, desc, patchable }) => {
+          {ROWS.map(({ id, label, desc, patchable, activityMode }) => {
             const isActive = activity === id;
             return (
               <tr key={id} style={{ borderTop: '1px solid #2a2a2a' }}>
                 {/* Description */}
                 <td style={{ padding: '10px 8px 10px 0' }}>
-                  <label style={{ cursor: 'pointer', display: 'block' }} htmlFor={`activity-${id}`}>
+                  <label style={{ cursor: activityMode ? 'pointer' : 'default', display: 'block' }} htmlFor={activityMode ? `activity-${id}` : undefined}>
                     <span style={{ fontWeight: isActive ? 600 : 400, color: isActive ? '#eee' : '#bbb' }}>{label}</span>
                     <span style={{ color: '#666', marginLeft: 8 }}>{desc}</span>
                     {id === 'canvas' && (
@@ -83,14 +84,18 @@ export default function InterfacesTab({
                 </td>
                 {/* Solo */}
                 <td style={{ textAlign: 'center', padding: '10px 8px' }}>
-                  <input
-                    id={`activity-${id}`}
-                    type="radio"
-                    name="activity"
-                    value={id}
-                    checked={isActive}
-                    onChange={() => sendActivity(id)}
-                  />
+                  {activityMode ? (
+                    <input
+                      id={`activity-${id}`}
+                      type="radio"
+                      name="activity"
+                      value={id}
+                      checked={isActive}
+                      onChange={() => sendActivity(id as ActivityMode)}
+                    />
+                  ) : (
+                    <span style={{ color: '#3a3a3a', fontSize: 11 }}>—</span>
+                  )}
                 </td>
                 {/* Commons — placeholder */}
                 <td style={{ textAlign: 'center', padding: '10px 8px', color: '#3a3a3a' }}>—</td>
@@ -98,10 +103,10 @@ export default function InterfacesTab({
                 <td style={{ textAlign: 'center', padding: '10px 0 10px 8px' }}>
                   {patchable ? (
                     <button
-                      onClick={() => setPatchDialogOpen(true)}
+                      onClick={() => setPatchInterface(id)}
                       style={{ background: 'none', border: 'none', color: '#888', cursor: 'pointer', padding: 4, lineHeight: 0 }}
                       title="Share patch URL"
-                      aria-label="Share social interface URL"
+                      aria-label={`Share ${label} interface URL`}
                     >
                       {QR_ICON}
                     </button>
@@ -138,16 +143,16 @@ export default function InterfacesTab({
         <button className="v3-admin-btn v3-admin-btn--destructive" onClick={onClearRoleAssignments}>Clear all role assignments</button>
       </div>
 
-      {/* Patch dialog — social sharing URL */}
-      {patchDialogOpen && (
-        <div className="share-qr-modal" onClick={() => setPatchDialogOpen(false)}>
+      {/* Patch dialog — share URL for patchable interfaces */}
+      {patchInterface && (
+        <div className="share-qr-modal" onClick={() => setPatchInterface(null)}>
           <div className="share-qr-modal-card" onClick={e => e.stopPropagation()}>
-            <p className="share-qr-modal-title">Social Sharing — add without push</p>
+            <p className="share-qr-modal-title">{ROWS.find(r => r.id === patchInterface)?.label} — add without push</p>
             <div className="v2-mobile-gate-qr">
               <QRCodeSVG value={patchUrl} size={220} />
             </div>
             <p className="share-qr-modal-url">{patchUrl}</p>
-            <button className="share-qr-modal-close" onClick={() => setPatchDialogOpen(false)}>Close</button>
+            <button className="share-qr-modal-close" onClick={() => setPatchInterface(null)}>Close</button>
           </div>
         </div>
       )}

--- a/app/components/HapticPushModal.tsx
+++ b/app/components/HapticPushModal.tsx
@@ -7,7 +7,7 @@ interface HapticPushModalProps {
 }
 
 export default function HapticPushModal({ onDismiss, suppressed, onSuppressChange }: HapticPushModalProps) {
-  const [suppress, setSuppress] = useState(true);
+  const [suppress, setSuppress] = useState(suppressed);
 
   const handleOk = () => {
     onSuppressChange(suppress);

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -297,7 +297,11 @@ export default function MoodTonesPanel({ room }: { room: string }) {
   const applyAudienceMood = useCallback(() => {
     if (!audienceSyncRef.current) return;
     const cursors = cursorsRef.current;
-    if (cursors.size === 0) return;
+    if (cursors.size === 0) {
+      moodRef.current = 50;
+      setMood(50);
+      return;
+    }
     let val: number;
     if (valenceModeRef.current === 'continuous') {
       let sum = 0;

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -229,8 +229,9 @@ const OSC_GAIN: Record<string, number> = { sawtooth: 0.10, square: 0.15, triangl
 const DEFAULT_HOST = 'polislike-partykit-reaction-canvas.patcon.partykit.dev';
 
 function makeWsUrl(room: string): string {
-  const host = window.location.hostname === 'localhost' ? 'localhost:1999' : DEFAULT_HOST;
-  const proto = host.startsWith('localhost') ? 'ws' : 'wss';
+  const isLocal = window.location.port === '1999';
+  const host = isLocal ? `${window.location.hostname}:1999` : DEFAULT_HOST;
+  const proto = isLocal ? 'ws' : 'wss';
   const uid = typeof crypto !== 'undefined' && (crypto as { randomUUID?: () => string }).randomUUID
     ? (crypto as { randomUUID: () => string }).randomUUID()
     : Math.random().toString(36).slice(2);

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -294,12 +294,18 @@ export default function MoodTonesPanel({ room }: { room: string }) {
   }, [volume]);
 
   // ── Audience mood ──────────────────────────────────────────────
+  const setMoodWithDisplay = useCallback((value: number) => {
+    moodRef.current = value;
+    setMood(value);
+    const p = interpolateWaypoints(presetRef.current, value / 100);
+    setDisplayInfo(prev => ({ ...prev, emoji: p.emoji, chordName: p.chordName }));
+  }, []);
+
   const applyAudienceMood = useCallback(() => {
     if (!audienceSyncRef.current) return;
     const cursors = cursorsRef.current;
     if (cursors.size === 0) {
-      moodRef.current = 50;
-      setMood(50);
+      setMoodWithDisplay(50);
       return;
     }
     let val: number;
@@ -315,10 +321,8 @@ export default function MoodTonesPanel({ room }: { room: string }) {
       }
       val = (sum / cursors.size + 1) / 2 * 100;
     }
-    const clamped = Math.round(clamp(val, 0, 100));
-    moodRef.current = clamped;
-    setMood(clamped);
-  }, []);
+    setMoodWithDisplay(Math.round(clamp(val, 0, 100)));
+  }, [setMoodWithDisplay]);
 
   useEffect(() => {
     if (audienceSync) applyAudienceMood();

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -696,7 +696,7 @@ export default function MoodTonesPanel({ room }: { room: string }) {
           <div style={{ marginTop: '0.9rem', marginBottom: '0.9rem' }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' as const }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                <span style={s.toggleLabel}>audience sync</span>
+                <span style={s.toggleLabel}>user sync</span>
                 <div style={s.pillToggle}>
                   <button style={s.pillBtn(!audienceSync)} onClick={() => setAudienceSync(false)}>off</button>
                   <button style={s.pillBtn(audienceSync)}  onClick={() => setAudienceSync(true)}>on</button>

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -757,6 +757,11 @@ export default function MoodTonesPanel({ room }: { room: string }) {
           <button style={s.playBtn(playing)} onClick={playing ? stopPlaying : startPlaying}>
             {playing ? '■ stop' : '▶ start'}
           </button>
+          {/iPhone|iPad|iPod/i.test(navigator.userAgent) && (
+            <div style={{ fontSize: '0.72rem', color: '#6060a0', marginTop: '0.4rem', textAlign: 'center', visibility: playing ? 'visible' : 'hidden' }}>
+              no sound? check silent switch
+            </div>
+          )}
         </div>
 
         {/* WS status + explain */}

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -590,9 +590,8 @@ export default function MoodTonesPanel({ room }: { room: string }) {
   // ── Inline styles ──────────────────────────────────────────────
   const s = {
     wrap: { padding: '1.25rem', maxWidth: 520, margin: '0 auto' } as React.CSSProperties,
-    presets: { display: 'flex', gap: 6, marginBottom: '1.25rem', flexWrap: 'wrap' as const },
+    presets: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6, marginBottom: '1.25rem' },
     presetBtn: (active: boolean): React.CSSProperties => ({
-      flex: '1 1 100px', minWidth: 100,
       padding: '0.5rem 0.7rem', borderRadius: 10,
       border: `1px solid ${active ? '#5050a0' : '#2a2a3a'}`,
       background: active ? '#1e1e30' : '#141420',

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -710,11 +710,9 @@ export default function MoodTonesPanel({ room }: { room: string }) {
                 </div>
               </div>
             </div>
-            {audienceSync && (
-              <div style={{ ...s.audienceCount, marginTop: 5, marginLeft: 0 }}>
-                audience: <span style={{ color: '#8080b0', fontWeight: 600 }}>{audienceCount}</span>
-              </div>
-            )}
+            <div style={{ ...s.audienceCount, marginTop: 5, marginLeft: 0 }}>
+              audience: <span style={{ color: '#8080b0', fontWeight: 600 }}>{audienceCount}</span>
+            </div>
           </div>
 
           {/* Viz bars */}

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -1,0 +1,761 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+
+// ── Types ─────────────────────────────────────────────────────────
+
+interface Waypoint {
+  t: number;
+  chord: number[];
+  velocity: number;
+  tempo: number;
+  pitchBend: number;
+  oscType: string;
+  octShift: number;
+  emoji: string;
+  chordName: string;
+  color: [number, number, number];
+  explain: string;
+}
+
+interface Preset {
+  id: string;
+  emoji: string;
+  label: string;
+  sliderGradient: string;
+  waypoints: Waypoint[];
+}
+
+interface WaypointInterp {
+  chordLo: number[];
+  chordHi: number[];
+  chordBlend: number;
+  chord: number[];
+  velocity: number;
+  tempo: number;
+  pitchBend: number;
+  oscTypeA: string;
+  oscTypeB: string;
+  oscBlend: number;
+  evilAmount: number;
+  octShift: number;
+  chordName: string;
+  emoji: string;
+  color: [number, number, number];
+  explain: string;
+}
+
+// ── Data ──────────────────────────────────────────────────────────
+
+const NOTE_NAMES = ['C','C#','D','D#','E','F','F#','G','G#','A','A#','B'];
+
+const PRESETS: Preset[] = [
+  {
+    id: 'sad-happy',
+    emoji: '😢→😄',
+    label: 'sad → happy',
+    sliderGradient: 'linear-gradient(to right, #4466bb, #e8a030)',
+    waypoints: [
+      { t: 0,   chord: [48,51,55,60], velocity: 38,  tempo: 640, pitchBend: -0.35, oscType: 'triangle', octShift: 0,
+        emoji: '😢', chordName: 'C min', color: [60,100,200],
+        explain: 'C minor, hushed (vel 38), slow (640ms). Pitch bent flat.' },
+      { t: 0.5, chord: [48,51,55,60], velocity: 72,  tempo: 430, pitchBend: 0,     oscType: 'triangle', octShift: 0,
+        emoji: '😐', chordName: 'C min', color: [130,130,160],
+        explain: 'Midpoint — still minor but warming up, tempo picking up.' },
+      { t: 1,   chord: [48,52,55,60], velocity: 112, tempo: 270, pitchBend:  0.35, oscType: 'triangle', octShift: 0,
+        emoji: '😄', chordName: 'C maj', color: [220,160,40],
+        explain: 'C major, bright (vel 112), fast (270ms). Pitch bent sharp.' },
+    ],
+  },
+  {
+    id: 'angry-happy',
+    emoji: '😡→😄',
+    label: 'angry → happy',
+    sliderGradient: 'linear-gradient(to right, #cc3030, #e8a030)',
+    waypoints: [
+      { t: 0,    chord: [36,39,43,48], velocity: 82,  tempo: 240, pitchBend: 0,   oscType: 'angry',    octShift: 0,
+        emoji: '😡', chordName: 'C dim', color: [200,40,40],
+        explain: 'Detuned unison + noise FM + inharmonic modulator. Evil via instability, not volume.' },
+      { t: 0.35, chord: [43,46,50,55], velocity: 74,  tempo: 360, pitchBend: 0,   oscType: 'angry',    octShift: 0,
+        emoji: '😤', chordName: 'G min', color: [160,90,60],
+        explain: 'Anger easing — still detuned and unstable, but opening up.' },
+      { t: 0.55, chord: [43,46,50,55], velocity: 64,  tempo: 430, pitchBend: 0,   oscType: 'triangle', octShift: 0,
+        emoji: '😐', chordName: 'G min', color: [130,110,130],
+        explain: 'Same chord, instability fading — evil drains without a pitch jump.' },
+      { t: 0.75, chord: [45,48,52,57], velocity: 72,  tempo: 370, pitchBend: 0.1, oscType: 'triangle', octShift: 0,
+        emoji: '🙂', chordName: 'A min', color: [160,130,80],
+        explain: 'A minor now — chord moves only after instability is already gone.' },
+      { t: 1,    chord: [48,52,55,60], velocity: 108, tempo: 290, pitchBend: 0.3, oscType: 'triangle', octShift: 0,
+        emoji: '😄', chordName: 'C maj', color: [220,160,40],
+        explain: 'C major, bright and fast. Anger fully resolved into joy.' },
+    ],
+  },
+  {
+    id: 'tense-serene',
+    emoji: '😰→😌',
+    label: 'tense → serene',
+    sliderGradient: 'linear-gradient(to right, #8833aa, #30aa88)',
+    waypoints: [
+      { t: 0,    chord: [48,53,56,62], velocity: 95, tempo: 220, pitchBend:  0.5,  oscType: 'sawtooth', octShift: 0,
+        emoji: '😰', chordName: 'C sus4♭7', color: [160,40,200],
+        explain: 'Suspended dissonant cluster, fast and tense. Pitch bent high.' },
+      { t: 0.35, chord: [48,51,55,58], velocity: 72, tempo: 400, pitchBend:  0.2,  oscType: 'triangle', octShift: 0,
+        emoji: '😟', chordName: 'C min7', color: [130,70,160],
+        explain: 'Minor 7th — still unsettled but the urgency is easing.' },
+      { t: 0.65, chord: [48,52,55,59], velocity: 52, tempo: 560, pitchBend:  0,    oscType: 'triangle', octShift: 0,
+        emoji: '🙂', chordName: 'Cmaj7', color: [60,150,130],
+        explain: 'Major 7th — warm, floating. Tension mostly released.' },
+      { t: 1,    chord: [48,52,55,60], velocity: 36, tempo: 800, pitchBend: -0.1,  oscType: 'triangle', octShift: 0,
+        emoji: '😌', chordName: 'C maj', color: [40,180,140],
+        explain: 'Pure sine tone, very soft (vel 36), slow (800ms). Total serenity.' },
+    ],
+  },
+  {
+    id: 'eerie-wonder',
+    emoji: '👻→🤩',
+    label: 'eerie → wonder',
+    sliderGradient: 'linear-gradient(to right, #224466, #aa6600)',
+    waypoints: [
+      { t: 0,   chord: [42,45,48,54], velocity: 44,  tempo: 700, pitchBend: -0.2,  oscType: 'sawtooth', octShift: 0,
+        emoji: '👻', chordName: 'F# dim', color: [40,80,130],
+        explain: 'F# diminished — unsettling, sparse, low velocity. Slow and hollow.' },
+      { t: 0.5, chord: [48,51,55,62], velocity: 65,  tempo: 450, pitchBend:  0.15, oscType: 'triangle', octShift: 0,
+        emoji: '😮', chordName: 'C min9', color: [100,100,160],
+        explain: 'Minor 9 chord — mysterious but opening up. Something approaching.' },
+      { t: 1,   chord: [48,52,55,64], velocity: 100, tempo: 260, pitchBend:  0.4,  oscType: 'triangle', octShift: 1,
+        emoji: '🤩', chordName: 'C maj9', color: [200,140,30],
+        explain: 'Major 9, bright velocity, fast — full revelation. Octave up.' },
+    ],
+  },
+];
+
+// ── Pure helpers ──────────────────────────────────────────────────
+
+function noteName(n: number): string {
+  return NOTE_NAMES[n % 12] + Math.floor(n / 12 - 1);
+}
+function lerp(a: number, b: number, t: number): number { return a + (b - a) * t; }
+function clamp(v: number, lo: number, hi: number): number { return Math.max(lo, Math.min(hi, v)); }
+function midiToFreq(note: number, bendSemitones: number): number {
+  return 440 * Math.pow(2, (note - 69 + bendSemitones) / 12);
+}
+
+const ANCHORS = {
+  positive: { x: 95, y: 5  },
+  negative: { x: 5,  y: 95 },
+  neutral:  { x: 95, y: 95 },
+};
+
+function computeRegion(nx: number, ny: number): string {
+  const x = nx / 100, y = ny / 100;
+  const pos = { x: ANCHORS.positive.x / 100, y: ANCHORS.positive.y / 100 };
+  const neg = { x: ANCHORS.negative.x / 100, y: ANCHORS.negative.y / 100 };
+  const neu = { x: ANCHORS.neutral.x  / 100, y: ANCHORS.neutral.y  / 100 };
+  const denom = (neg.y - neu.y) * (pos.x - neu.x) + (neu.x - neg.x) * (pos.y - neu.y);
+  if (Math.abs(denom) < 1e-10) {
+    const dp = Math.hypot(x - pos.x, y - pos.y);
+    const dn = Math.hypot(x - neg.x, y - neg.y);
+    const dz = Math.hypot(x - neu.x, y - neu.y);
+    const m  = Math.min(dp, dn, dz);
+    if (m === dp) return 'positive';
+    if (m === dn) return 'negative';
+    return 'neutral';
+  }
+  const wPos = ((neg.y - neu.y) * (x - neu.x) + (neu.x - neg.x) * (y - neu.y)) / denom;
+  const wNeg = ((neu.y - pos.y) * (x - neu.x) + (pos.x - neu.x) * (y - neu.y)) / denom;
+  const wNeu = 1 - wPos - wNeg;
+  const mx = Math.max(wPos, wNeg, wNeu);
+  if (mx === wPos) return 'positive';
+  if (mx === wNeg) return 'negative';
+  return 'neutral';
+}
+
+function cursorMoodValue(nx: number, ny: number): number {
+  const x = nx / 100, y = ny / 100;
+  const pos = { x: ANCHORS.positive.x / 100, y: ANCHORS.positive.y / 100 };
+  const neg = { x: ANCHORS.negative.x / 100, y: ANCHORS.negative.y / 100 };
+  const neu = { x: ANCHORS.neutral.x  / 100, y: ANCHORS.neutral.y  / 100 };
+  const denom = (neg.y - neu.y) * (pos.x - neu.x) + (neu.x - neg.x) * (pos.y - neu.y);
+  if (Math.abs(denom) < 1e-10) {
+    const dp = Math.hypot(x - pos.x, y - pos.y) || 1e-9;
+    const dn = Math.hypot(x - neg.x, y - neg.y) || 1e-9;
+    const dz = Math.hypot(x - neu.x, y - neu.y) || 1e-9;
+    const invSum = 1/dp + 1/dn + 1/dz;
+    const wPos = (1/dp) / invSum;
+    const wNeg = (1/dn) / invSum;
+    const wNeu = 1 - wPos - wNeg;
+    return clamp(wPos * 100 + wNeg * 0 + wNeu * 50, 0, 100);
+  }
+  const wPos = ((neg.y - neu.y) * (x - neu.x) + (neu.x - neg.x) * (y - neu.y)) / denom;
+  const wNeg = ((neu.y - pos.y) * (x - neu.x) + (pos.x - neu.x) * (y - neu.y)) / denom;
+  const wNeu = 1 - wPos - wNeg;
+  return clamp(wPos * 100 + wNeg * 0 + wNeu * 50, 0, 100);
+}
+
+function interpolateWaypoints(preset: Preset, t: number): WaypointInterp {
+  const wps = preset.waypoints;
+  let lo = wps[0], hi = wps[wps.length - 1];
+  for (let i = 0; i < wps.length - 1; i++) {
+    if (t >= wps[i].t && t <= wps[i + 1].t) { lo = wps[i]; hi = wps[i + 1]; break; }
+  }
+  const span = hi.t - lo.t || 1;
+  const f = clamp((t - lo.t) / span, 0, 1);
+  const nearest = f < 0.5 ? lo : hi;
+  const loEvil = lo.oscType === 'angry' ? 1 : 0;
+  const hiEvil = hi.oscType === 'angry' ? 1 : 0;
+  const chordsMatch = JSON.stringify(lo.chord) === JSON.stringify(hi.chord);
+  return {
+    chordLo:    lo.chord,
+    chordHi:    hi.chord,
+    chordBlend: chordsMatch ? 0 : f,
+    chord:      nearest.chord,
+    velocity:   Math.round(lerp(lo.velocity, hi.velocity, f)),
+    tempo:      Math.round(lerp(lo.tempo, hi.tempo, f)),
+    pitchBend:  lerp(lo.pitchBend, hi.pitchBend, f),
+    oscTypeA:   lo.oscType === 'angry' ? 'triangle' : lo.oscType,
+    oscTypeB:   hi.oscType === 'angry' ? 'triangle' : hi.oscType,
+    oscBlend:   lo.oscType === hi.oscType ? 0 : f,
+    evilAmount: lerp(loEvil, hiEvil, f),
+    octShift:   nearest.octShift,
+    chordName:  nearest.chordName,
+    emoji:      nearest.emoji,
+    color:      lo.color.map((c, i) => Math.round(lerp(c, hi.color[i], f))) as [number,number,number],
+    explain:    nearest.explain,
+  };
+}
+
+// ── Audio gain per oscillator type ────────────────────────────────
+const OSC_GAIN: Record<string, number> = { sawtooth: 0.10, square: 0.15, triangle: 0.32, sine: 0.55 };
+
+// ── WebSocket URL ─────────────────────────────────────────────────
+const DEFAULT_HOST = 'polislike-partykit-reaction-canvas.patcon.partykit.dev';
+
+function makeWsUrl(room: string): string {
+  const host = window.location.hostname === 'localhost' ? 'localhost:1999' : DEFAULT_HOST;
+  const proto = host.startsWith('localhost') ? 'ws' : 'wss';
+  const uid = typeof crypto !== 'undefined' && (crypto as { randomUUID?: () => string }).randomUUID
+    ? (crypto as { randomUUID: () => string }).randomUUID()
+    : Math.random().toString(36).slice(2);
+  return `${proto}://${host}/parties/main/${encodeURIComponent(room)}?isAdmin=true&userId=${uid}`;
+}
+
+// ── Component ─────────────────────────────────────────────────────
+
+interface BarState { height: number; color: [number,number,number]; active: boolean; }
+
+const RESET_BARS: BarState[] = [0,1,2,3].map(() => ({ height: 3, color: [42,42,64], active: false }));
+
+export default function MoodTonesPanel({ room }: { room: string }) {
+  const [activePreset, setActivePreset]   = useState<Preset>(PRESETS[0]);
+  const [playing, setPlaying]             = useState(false);
+  const [mood, setMood]                   = useState(0);
+  const [audienceSync, setAudienceSync]   = useState(true);
+  const [valenceMode, setValenceMode]     = useState<'continuous'|'unit'>('continuous');
+  const [volume, setVolume]               = useState(100);
+  const [currentChord, setCurrentChord]   = useState<number[]>([]);
+  const [litNote, setLitNote]             = useState<number|null>(null);
+  const [bars, setBars]                   = useState<BarState[]>(RESET_BARS);
+  const [wsStatus, setWsStatus]           = useState<'disconnected'|'connecting'|'connected'>('disconnected');
+  const [audienceCount, setAudienceCount] = useState(0);
+  const [displayInfo, setDisplayInfo]     = useState({ emoji: PRESETS[0].waypoints[0].emoji, chordName: '—', velocity: '—', tempo: '—', octave: '—', explain: 'Select a preset and drag the slider.' });
+
+  // Audio refs
+  const audioCtxRef   = useRef<AudioContext|null>(null);
+  const masterBusRef  = useRef<DynamicsCompressorNode|null>(null);
+  const volumeNodeRef = useRef<GainNode|null>(null);
+  const schedTimerRef = useRef<ReturnType<typeof setTimeout>|null>(null);
+
+  // Loop-state refs (avoid stale closures in setTimeout tick)
+  const moodRef         = useRef(0);
+  const playingRef      = useRef(false);
+  const presetRef       = useRef<Preset>(PRESETS[0]);
+  const noteIndexRef    = useRef(0);
+  const currentChordRef = useRef<number[]>([]);
+
+  // WS refs
+  const wsRef           = useRef<WebSocket|null>(null);
+  const cursorsRef      = useRef<Map<string,{x:number;y:number;region:string}>>(new Map());
+  const cursorRegionsRef= useRef<Map<string,string>>(new Map());
+  const audienceSyncRef = useRef(true);
+  const valenceModeRef  = useRef<'continuous'|'unit'>('continuous');
+
+  // Keep refs in sync with state
+  useEffect(() => { moodRef.current = mood; }, [mood]);
+  useEffect(() => { playingRef.current = playing; }, [playing]);
+  useEffect(() => { presetRef.current = activePreset; }, [activePreset]);
+  useEffect(() => { audienceSyncRef.current = audienceSync; }, [audienceSync]);
+  useEffect(() => { valenceModeRef.current = valenceMode; }, [valenceMode]);
+
+  // Volume change → update live gain node
+  useEffect(() => {
+    if (volumeNodeRef.current) volumeNodeRef.current.gain.value = volume / 100;
+  }, [volume]);
+
+  // ── Audience mood ──────────────────────────────────────────────
+  const applyAudienceMood = useCallback(() => {
+    if (!audienceSyncRef.current) return;
+    const cursors = cursorsRef.current;
+    if (cursors.size === 0) return;
+    let val: number;
+    if (valenceModeRef.current === 'continuous') {
+      let sum = 0;
+      for (const [, c] of cursors) sum += cursorMoodValue(c.x, c.y);
+      val = sum / cursors.size;
+    } else {
+      let sum = 0;
+      for (const [, c] of cursors) {
+        if (c.region === 'positive') sum += 1;
+        else if (c.region === 'negative') sum += -1;
+      }
+      val = (sum / cursors.size + 1) / 2 * 100;
+    }
+    const clamped = Math.round(clamp(val, 0, 100));
+    moodRef.current = clamped;
+    setMood(clamped);
+  }, []);
+
+  useEffect(() => {
+    if (audienceSync) applyAudienceMood();
+  }, [audienceSync, valenceMode, applyAudienceMood]);
+
+  // ── WebSocket ──────────────────────────────────────────────────
+  useEffect(() => {
+    let reconnectTimer: ReturnType<typeof setTimeout>|null = null;
+    let dead = false;
+
+    function connect() {
+      if (dead) return;
+      setWsStatus('connecting');
+      const socket = new WebSocket(makeWsUrl(room));
+      wsRef.current = socket;
+
+      socket.onopen = () => { if (!dead) setWsStatus('connected'); };
+
+      socket.onmessage = (evt) => {
+        if (dead) return;
+        let data: { type: string; position?: { userId: string; x: number; y: number } };
+        try { data = JSON.parse(evt.data as string); } catch { return; }
+        if (data.type === 'move' || data.type === 'touch') {
+          const { userId, x, y } = data.position!;
+          const region = computeRegion(x, y);
+          const prevRegion = cursorRegionsRef.current.get(userId);
+          cursorsRef.current.set(userId, { x, y, region });
+          if (valenceModeRef.current === 'continuous' || region !== prevRegion) {
+            cursorRegionsRef.current.set(userId, region);
+            setAudienceCount(cursorsRef.current.size);
+            applyAudienceMood();
+          }
+        } else if (data.type === 'remove') {
+          const { userId } = data.position!;
+          cursorsRef.current.delete(userId);
+          cursorRegionsRef.current.delete(userId);
+          setAudienceCount(cursorsRef.current.size);
+          applyAudienceMood();
+        }
+      };
+
+      socket.onerror = () => { if (!dead) setWsStatus('disconnected'); };
+
+      socket.onclose = () => {
+        if (dead) return;
+        setWsStatus('disconnected');
+        reconnectTimer = setTimeout(connect, 3000);
+      };
+    }
+
+    connect();
+
+    return () => {
+      dead = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      if (wsRef.current) { wsRef.current.onclose = null; wsRef.current.close(); wsRef.current = null; }
+    };
+  }, [room, applyAudienceMood]);
+
+  // ── Audio helpers ──────────────────────────────────────────────
+  function makeSawFilter(freq: number, vel: number): BiquadFilterNode {
+    const ctx = audioCtxRef.current!;
+    const f = ctx.createBiquadFilter();
+    f.type = 'lowpass';
+    f.frequency.value = clamp(freq * (1.2 + (vel / 127) * 2.5), 200, 3200);
+    f.Q.value = 0.8;
+    return f;
+  }
+
+  function playAngryTone(freq: number, vel: number, durMs: number, evilAmount: number) {
+    const ctx = audioCtxRef.current; const bus = masterBusRef.current;
+    if (!ctx || !bus) return;
+    const evil = clamp(evilAmount, 0, 1);
+    if (evil < 0.001) return;
+    const velNorm  = clamp(vel / 127, 0, 1);
+    const amp      = 0.07 * velNorm * evil;
+    const durSec   = durMs / 1000;
+    const now      = ctx.currentTime;
+    const end      = now + durSec;
+    const sustainEnd = now + durSec * 0.72;
+    const masterGain = ctx.createGain();
+    masterGain.gain.setValueAtTime(0.0001, now);
+    masterGain.gain.exponentialRampToValueAtTime(Math.max(amp, 0.0001), now + 0.01);
+    masterGain.gain.setValueAtTime(amp, now + 0.01);
+    masterGain.gain.exponentialRampToValueAtTime(0.0001, sustainEnd);
+    masterGain.connect(bus);
+    const detuneCents = evil * 18;
+    for (const detune of [-detuneCents, detuneCents]) {
+      const osc = ctx.createOscillator(); const gain = ctx.createGain();
+      osc.type = 'sawtooth';
+      osc.frequency.value = freq * Math.pow(2, detune / 1200);
+      gain.gain.value = 0.45;
+      osc.connect(gain); gain.connect(masterGain);
+      osc.start(now); osc.stop(end);
+    }
+    if (evil > 0.05) {
+      const lfoRate  = 1.8 + Math.random() * 1.2;
+      const lfoDepth = evil * freq * 0.008;
+      const lfo = ctx.createOscillator(); const lfoGain = ctx.createGain();
+      lfo.type = 'sine'; lfo.frequency.value = lfoRate; lfoGain.gain.value = lfoDepth;
+      const modCarrier = ctx.createOscillator(); const modGain = ctx.createGain();
+      modCarrier.type = 'triangle'; modCarrier.frequency.value = freq * 1.003;
+      lfo.connect(lfoGain); lfoGain.connect(modCarrier.frequency);
+      modGain.gain.value = 0.18 * evil;
+      modCarrier.connect(modGain); modGain.connect(masterGain);
+      lfo.start(now); lfo.stop(end); modCarrier.start(now); modCarrier.stop(end);
+    }
+    if (evil > 0.1) {
+      const fmRatio = 2.13 + evil * 0.4;
+      const fmDepth = evil * freq * 0.06;
+      const fmMod = ctx.createOscillator(); const fmModGain = ctx.createGain();
+      const fmCarrier = ctx.createOscillator(); const fmCarGain = ctx.createGain();
+      fmMod.type = 'sine'; fmMod.frequency.value = freq * fmRatio; fmModGain.gain.value = fmDepth;
+      fmCarrier.type = 'sine'; fmCarrier.frequency.value = freq; fmCarGain.gain.value = 0.22 * evil;
+      fmMod.connect(fmModGain); fmModGain.connect(fmCarrier.frequency);
+      fmCarrier.connect(fmCarGain); fmCarGain.connect(masterGain);
+      fmMod.start(now); fmMod.stop(end); fmCarrier.start(now); fmCarrier.stop(end);
+    }
+  }
+
+  function playTone(freq: number, vel: number, durMs: number, oscTypeA: string, oscTypeB: string, blend: number) {
+    const ctx = audioCtxRef.current; const bus = masterBusRef.current;
+    if (!ctx || !bus || vel < 0.5) return;
+    const velNorm = vel / 127;
+    const durSec  = durMs / 1000;
+    const now     = ctx.currentTime;
+    const end     = now + durSec;
+    function makeOsc(type: string, gainScale: number) {
+      if (gainScale < 0.005) return;
+      const baseAmp = (OSC_GAIN[type] ?? 0.10) * velNorm * gainScale;
+      const osc  = ctx!.createOscillator(); const gain = ctx!.createGain();
+      osc.type = type as OscillatorType;
+      osc.frequency.value = freq;
+      if (type === 'sine' || type === 'triangle') {
+        gain.gain.setValueAtTime(Math.max(baseAmp, 0.0001), now);
+        gain.gain.exponentialRampToValueAtTime(0.0001, now + durSec * 0.92);
+      } else {
+        const attackEnd  = now + 0.008;
+        const sustainEnd = now + durSec * 0.45;
+        gain.gain.setValueAtTime(0.0001, now);
+        gain.gain.exponentialRampToValueAtTime(Math.max(baseAmp, 0.0001), attackEnd);
+        gain.gain.setValueAtTime(Math.max(baseAmp, 0.0001), attackEnd);
+        gain.gain.exponentialRampToValueAtTime(0.0001, sustainEnd);
+      }
+      if (type === 'sawtooth') {
+        const filter = makeSawFilter(freq, vel);
+        osc.connect(filter); filter.connect(gain);
+      } else {
+        osc.connect(gain);
+      }
+      gain.connect(bus!);
+      osc.start(now); osc.stop(end);
+    }
+    const b = clamp(blend || 0, 0, 1);
+    makeOsc(oscTypeA, 1 - b);
+    if (oscTypeB && oscTypeB !== oscTypeA && b > 0.01) makeOsc(oscTypeB, b);
+  }
+
+  // ── Tick loop ──────────────────────────────────────────────────
+  // tickRef always points to the latest closure so setTimeout never goes stale
+  const tickRef = useRef<() => void>(() => {});
+  tickRef.current = () => {
+    if (!playingRef.current) return;
+    const t = moodRef.current / 100;
+    const p = interpolateWaypoints(presetRef.current, t);
+
+    const chordLo   = p.chordLo.map(n => n + p.octShift * 12);
+    const chordHi   = p.chordHi.map(n => n + p.octShift * 12);
+    const useHi     = Math.random() < p.chordBlend;
+    const activeChord = useHi ? chordHi : chordLo;
+
+    const displayChord = p.chordBlend > 0.5 ? chordHi : chordLo;
+    if (JSON.stringify(displayChord) !== JSON.stringify(currentChordRef.current)) {
+      currentChordRef.current = [...displayChord];
+      setCurrentChord([...displayChord]);
+      noteIndexRef.current = 0;
+    }
+
+    const idx  = noteIndexRef.current % activeChord.length;
+    const note = activeChord[idx];
+    noteIndexRef.current++;
+
+    const freq = midiToFreq(note, p.pitchBend * 2);
+    playAngryTone(freq, p.velocity, p.tempo * 0.8, p.evilAmount);
+    playTone(freq, p.velocity * (1 - p.evilAmount), p.tempo * 0.8, p.oscTypeA, p.oscTypeB, p.oscBlend);
+
+    setLitNote(note);
+    const maxH = 52;
+    setBars([0,1,2,3].map(i => ({
+      height: i === idx % 4
+        ? Math.round(lerp(16, maxH, p.velocity / 127))
+        : Math.round(p.velocity / 127 * 14),
+      color:  p.color,
+      active: i === idx % 4,
+    })));
+    setDisplayInfo({
+      emoji:     p.emoji,
+      chordName: p.chordName,
+      velocity:  String(p.velocity),
+      tempo:     p.tempo + 'ms',
+      octave:    p.octShift === 0 ? '±0' : (p.octShift > 0 ? '+' : '') + p.octShift,
+      explain:   p.explain,
+    });
+
+    schedTimerRef.current = setTimeout(() => tickRef.current(), p.tempo);
+  };
+
+  // ── Start / stop ───────────────────────────────────────────────
+  function startPlaying() {
+    if (!audioCtxRef.current) {
+      const Ctx = window.AudioContext ?? (window as Window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+      const ctx = new Ctx();
+      const bus = ctx.createDynamicsCompressor();
+      bus.threshold.value = -24; bus.knee.value = 10;
+      bus.ratio.value = 8; bus.attack.value = 0.003; bus.release.value = 0.15;
+      const makeup = ctx.createGain(); makeup.gain.value = 2.5;
+      const vol = ctx.createGain(); vol.gain.value = volume / 100;
+      bus.connect(makeup); makeup.connect(vol); vol.connect(ctx.destination);
+      audioCtxRef.current = ctx; masterBusRef.current = bus; volumeNodeRef.current = vol;
+    }
+    if (audioCtxRef.current.state === 'suspended') void audioCtxRef.current.resume();
+    playingRef.current = true;
+    setPlaying(true);
+    noteIndexRef.current = 0;
+    tickRef.current();
+  }
+
+  function stopPlaying() {
+    playingRef.current = false;
+    setPlaying(false);
+    if (schedTimerRef.current) clearTimeout(schedTimerRef.current);
+    setLitNote(null);
+    setBars(RESET_BARS);
+  }
+
+  // Cleanup audio on unmount
+  useEffect(() => {
+    return () => {
+      playingRef.current = false;
+      if (schedTimerRef.current) clearTimeout(schedTimerRef.current);
+      if (audioCtxRef.current) { void audioCtxRef.current.close(); audioCtxRef.current = null; }
+    };
+  }, []);
+
+  // ── Preset selection ───────────────────────────────────────────
+  function selectPreset(p: Preset) {
+    setActivePreset(p);
+    presetRef.current = p;
+    if (!audienceSyncRef.current) {
+      moodRef.current = 0;
+      setMood(0);
+    }
+    noteIndexRef.current = 0;
+    currentChordRef.current = [];
+    setCurrentChord([]);
+    const wp = p.waypoints;
+    setDisplayInfo(prev => ({
+      ...prev,
+      emoji: wp[0].emoji,
+      chordName: wp[0].chordName,
+      explain: 'Drag the slider to change mood.',
+    }));
+  }
+
+  // ── Inline styles ──────────────────────────────────────────────
+  const s = {
+    wrap: { padding: '1.25rem', maxWidth: 520, margin: '0 auto' } as React.CSSProperties,
+    presets: { display: 'flex', gap: 6, marginBottom: '1.25rem', flexWrap: 'wrap' as const },
+    presetBtn: (active: boolean): React.CSSProperties => ({
+      flex: '1 1 100px', minWidth: 100,
+      padding: '0.5rem 0.7rem', borderRadius: 10,
+      border: `1px solid ${active ? '#5050a0' : '#2a2a3a'}`,
+      background: active ? '#1e1e30' : '#141420',
+      color: active ? '#c0c0ff' : '#7070a0',
+      fontSize: '0.78rem', fontWeight: 500, cursor: 'pointer',
+      textAlign: 'center', lineHeight: 1.4,
+    }),
+    emojiDisplay: { textAlign: 'center' as const, fontSize: '2.2rem', marginBottom: '0.9rem', lineHeight: 1 },
+    emojiRow: { display: 'flex', alignItems: 'center', gap: 10, marginBottom: '1.1rem' },
+    emojiEnd: { fontSize: '1.4rem', flexShrink: 0 },
+    sliderWrap: { flex: 1 },
+    sliderLabels: { display: 'flex', justifyContent: 'space-between', marginTop: 4, fontSize: '0.68rem', color: '#505070' },
+    range: { width: '100%' } as React.CSSProperties,
+    syncRow: { display: 'flex', alignItems: 'center', gap: 10, marginTop: '0.9rem', marginBottom: '0.9rem', flexWrap: 'wrap' as const },
+    toggleLabel: { fontSize: '0.68rem', color: '#505070', textTransform: 'uppercase' as const, letterSpacing: '0.05em' },
+    pillToggle: { display: 'flex', background: '#141420', border: '1px solid #2a2a3a', borderRadius: 20, overflow: 'hidden' },
+    pillBtn: (active: boolean): React.CSSProperties => ({
+      padding: '0.28rem 0.7rem', fontSize: '0.72rem', fontWeight: 500,
+      border: 'none', background: active ? '#2a2a48' : 'transparent',
+      color: active ? '#a0a0e0' : '#505070', cursor: 'pointer', borderRadius: 20,
+    }),
+    audienceCount: { fontSize: '0.7rem', color: '#505070', marginLeft: 'auto' },
+    viz: { display: 'flex', alignItems: 'flex-end', gap: 5, height: 52, marginBottom: '1rem', padding: '0 2px' },
+    chips: { display: 'flex', gap: 5, flexWrap: 'wrap' as const, marginBottom: '1rem', minHeight: 24 },
+    chip: (lit: boolean): React.CSSProperties => ({
+      fontSize: '0.7rem', padding: '2px 8px', borderRadius: 20,
+      background: lit ? '#2a3860' : '#222230',
+      color: lit ? '#90b0ff' : '#6060a0',
+      border: `1px solid ${lit ? '#4060b0' : '#303050'}`,
+      fontWeight: 500,
+    }),
+    stats: { display: 'grid', gridTemplateColumns: 'repeat(4,1fr)', gap: 6, marginBottom: '1rem' },
+    stat: { background: '#141420', borderRadius: 8, padding: '0.45rem 0.5rem', textAlign: 'center' as const },
+    statLabel: { fontSize: '0.58rem', color: '#505070', textTransform: 'uppercase' as const, letterSpacing: '0.05em', marginBottom: 3 },
+    statValue: { fontSize: '0.85rem', fontWeight: 600, color: '#b0b0d0' },
+    volumeRow: { display: 'flex', alignItems: 'center', gap: 8, marginBottom: '0.75rem' },
+    volumeLabel: { fontSize: '0.7rem', color: '#505070', width: '2.2rem', textAlign: 'right' as const, flexShrink: 0 },
+    playBtn: (playing: boolean): React.CSSProperties => ({
+      width: '100%', padding: '0.65rem', borderRadius: 10,
+      border: `1px solid ${playing ? '#30a060' : '#3a3a50'}`,
+      background: playing ? '#1a3020' : '#1a1a28',
+      color: playing ? '#60e090' : '#b0b0d0',
+      fontSize: '0.85rem', fontWeight: 500, cursor: 'pointer',
+    }),
+    explain: { background: '#141420', border: '1px solid #1e1e32', borderRadius: 10, padding: '0.75rem 1rem', fontSize: '0.78rem', color: '#6060a0', lineHeight: 1.65, minHeight: 40, marginTop: '0.75rem' },
+    wsStatus: { fontSize: '0.68rem', color: wsStatus === 'connected' ? '#40a060' : wsStatus === 'connecting' ? '#6060a0' : '#606080', marginBottom: '0.75rem' },
+  };
+
+  const wp0 = activePreset.waypoints[0];
+  const wpN = activePreset.waypoints[activePreset.waypoints.length - 1];
+
+  return (
+    <div style={{ background: '#0f0f13', minHeight: '100%', color: '#e8e8ec', fontFamily: 'system-ui, sans-serif', overflowY: 'auto' }}>
+      <div style={s.wrap}>
+        <div style={{ fontSize: '0.68rem', fontWeight: 500, color: '#606080', letterSpacing: '0.08em', textTransform: 'uppercase', marginBottom: '1rem' }}>
+          mood tones
+        </div>
+
+        <div style={{ background: '#1a1a24', border: '1px solid #2a2a38', borderRadius: 16, padding: '1.25rem', marginBottom: '0.75rem' }}>
+
+          {/* Presets */}
+          <div style={s.presets}>
+            {PRESETS.map(p => (
+              <button key={p.id} style={s.presetBtn(activePreset.id === p.id)} onClick={() => selectPreset(p)}>
+                <span style={{ fontSize: '1rem', display: 'block', marginBottom: 2 }}>{p.emoji}</span>
+                <span style={{ fontSize: '0.68rem', opacity: 0.75 }}>{p.label}</span>
+              </button>
+            ))}
+          </div>
+
+          {/* Big emoji */}
+          <div style={s.emojiDisplay}>{displayInfo.emoji}</div>
+
+          {/* Slider */}
+          <div style={s.emojiRow}>
+            <span style={s.emojiEnd}>{wp0.emoji}</span>
+            <div style={s.sliderWrap}>
+              <input
+                type="range" min={0} max={100} value={mood} step={1}
+                disabled={audienceSync}
+                style={{ ...s.range, background: activePreset.sliderGradient, opacity: audienceSync ? 0.6 : 1, cursor: audienceSync ? 'not-allowed' : 'pointer' }}
+                onChange={e => {
+                  if (audienceSync) return;
+                  const v = parseInt(e.target.value);
+                  moodRef.current = v;
+                  setMood(v);
+                  setDisplayInfo(prev => {
+                    const p = interpolateWaypoints(activePreset, v / 100);
+                    return { ...prev, emoji: p.emoji, chordName: p.chordName, velocity: String(p.velocity), tempo: p.tempo + 'ms', octave: p.octShift === 0 ? '±0' : (p.octShift > 0 ? '+' : '') + p.octShift, explain: p.explain };
+                  });
+                }}
+              />
+              <div style={s.sliderLabels}>
+                <span>{wp0.chordName.toLowerCase()}</span>
+                <span>{wpN.chordName.toLowerCase()}</span>
+              </div>
+            </div>
+            <span style={s.emojiEnd}>{wpN.emoji}</span>
+          </div>
+
+          {/* Audience sync */}
+          <div style={s.syncRow}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+              <span style={s.toggleLabel}>audience sync</span>
+              <div style={s.pillToggle}>
+                <button style={s.pillBtn(!audienceSync)} onClick={() => setAudienceSync(false)}>off</button>
+                <button style={s.pillBtn(audienceSync)}  onClick={() => setAudienceSync(true)}>on</button>
+              </div>
+            </div>
+            {audienceSync && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <span style={s.toggleLabel}>valence</span>
+                <div style={s.pillToggle}>
+                  <button style={s.pillBtn(valenceMode === 'continuous')} onClick={() => setValenceMode('continuous')}>continuous</button>
+                  <button style={s.pillBtn(valenceMode === 'unit')}       onClick={() => setValenceMode('unit')}>unit</button>
+                </div>
+              </div>
+            )}
+            {audienceSync && (
+              <div style={s.audienceCount}>
+                audience: <span style={{ color: '#8080b0', fontWeight: 600 }}>{audienceCount}</span>
+              </div>
+            )}
+          </div>
+
+          {/* Viz bars */}
+          <div style={s.viz}>
+            {bars.map((b, i) => (
+              <div key={i} style={{
+                flex: 1, borderRadius: '3px 3px 0 0', minHeight: 3,
+                height: b.height,
+                background: `rgb(${b.color[0]},${b.color[1]},${b.color[2]})`,
+                opacity: b.active ? 1 : 0.35,
+                transition: 'height 0.1s ease, background 0.35s ease',
+              }} />
+            ))}
+          </div>
+
+          {/* Note chips */}
+          <div style={s.chips}>
+            {currentChord.map(n => (
+              <span key={n} style={s.chip(litNote === n)}>{noteName(n)}</span>
+            ))}
+          </div>
+
+          {/* Stats */}
+          <div style={s.stats}>
+            {[['chord', displayInfo.chordName], ['velocity', displayInfo.velocity], ['tempo', displayInfo.tempo], ['octave', displayInfo.octave]].map(([label, value]) => (
+              <div key={label} style={s.stat}>
+                <div style={s.statLabel}>{label}</div>
+                <div style={s.statValue}>{value}</div>
+              </div>
+            ))}
+          </div>
+
+          {/* Volume */}
+          <div style={s.volumeRow}>
+            <span style={{ fontSize: '1rem', flexShrink: 0 }}>🔈</span>
+            <input type="range" min={0} max={200} value={volume} step={1} style={{ flex: 1 }}
+              onChange={e => setVolume(parseInt(e.target.value))} />
+            <span style={s.volumeLabel}>{volume}%</span>
+          </div>
+
+          {/* Play button */}
+          <button style={s.playBtn(playing)} onClick={playing ? stopPlaying : startPlaying}>
+            {playing ? '■ stop' : '▶ start'}
+          </button>
+        </div>
+
+        {/* WS status + explain */}
+        <div style={s.wsStatus}>
+          {wsStatus === 'connected' ? `connected · room: ${room} · ${audienceCount} participant${audienceCount !== 1 ? 's' : ''}` : wsStatus === 'connecting' ? 'connecting…' : 'not connected'}
+        </div>
+        <div style={s.explain}>{displayInfo.explain}</div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -335,23 +335,23 @@ export default function MoodTonesPanel({ room }: { room: string }) {
 
       socket.onmessage = (evt) => {
         if (dead) return;
-        let data: { type: string; position?: { userId: string; x: number; y: number } };
+        let data: { type: string; count?: number; position?: { userId: string; x: number; y: number } };
         try { data = JSON.parse(evt.data as string); } catch { return; }
-        if (data.type === 'move' || data.type === 'touch') {
+        if (data.type === 'presenceCount') {
+          setAudienceCount(data.count ?? 0);
+        } else if (data.type === 'move' || data.type === 'touch') {
           const { userId, x, y } = data.position!;
           const region = computeRegion(x, y);
           const prevRegion = cursorRegionsRef.current.get(userId);
           cursorsRef.current.set(userId, { x, y, region });
           if (valenceModeRef.current === 'continuous' || region !== prevRegion) {
             cursorRegionsRef.current.set(userId, region);
-            setAudienceCount(cursorsRef.current.size);
             applyAudienceMood();
           }
         } else if (data.type === 'remove') {
           const { userId } = data.position!;
           cursorsRef.current.delete(userId);
           cursorRegionsRef.current.delete(userId);
-          setAudienceCount(cursorsRef.current.size);
           applyAudienceMood();
         }
       };

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -256,7 +256,10 @@ export default function MoodTonesPanel({ room }: { room: string }) {
   const [bars, setBars]                   = useState<BarState[]>(RESET_BARS);
   const [wsStatus, setWsStatus]           = useState<'disconnected'|'connecting'|'connected'>('disconnected');
   const [audienceCount, setAudienceCount] = useState(0);
-  const [displayInfo, setDisplayInfo]     = useState({ emoji: PRESETS[0].waypoints[0].emoji, chordName: '—', velocity: '—', tempo: '—', octave: '—', explain: 'Select a preset and drag the slider.' });
+  const [displayInfo, setDisplayInfo]     = useState(() => {
+    const p = interpolateWaypoints(PRESETS[0], 0.5);
+    return { emoji: p.emoji, chordName: p.chordName, velocity: '—', tempo: '—', octave: '—', explain: 'Select a preset and drag the slider.' };
+  });
 
   // Audio refs
   const audioCtxRef   = useRef<AudioContext|null>(null);
@@ -567,11 +570,11 @@ export default function MoodTonesPanel({ room }: { room: string }) {
     noteIndexRef.current = 0;
     currentChordRef.current = [];
     setCurrentChord([]);
-    const wp = p.waypoints;
+    const mid = interpolateWaypoints(p, (audienceSyncRef.current ? moodRef.current : 50) / 100);
     setDisplayInfo(prev => ({
       ...prev,
-      emoji: wp[0].emoji,
-      chordName: wp[0].chordName,
+      emoji: mid.emoji,
+      chordName: mid.chordName,
       explain: 'Drag the slider to change mood.',
     }));
   }

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -693,25 +693,25 @@ export default function MoodTonesPanel({ room }: { room: string }) {
           </div>
 
           {/* Audience sync */}
-          <div style={s.syncRow}>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-              <span style={s.toggleLabel}>audience sync</span>
-              <div style={s.pillToggle}>
-                <button style={s.pillBtn(!audienceSync)} onClick={() => setAudienceSync(false)}>off</button>
-                <button style={s.pillBtn(audienceSync)}  onClick={() => setAudienceSync(true)}>on</button>
+          <div style={{ marginTop: '0.9rem', marginBottom: '0.9rem' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexWrap: 'wrap' as const }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <span style={s.toggleLabel}>audience sync</span>
+                <div style={s.pillToggle}>
+                  <button style={s.pillBtn(!audienceSync)} onClick={() => setAudienceSync(false)}>off</button>
+                  <button style={s.pillBtn(audienceSync)}  onClick={() => setAudienceSync(true)}>on</button>
+                </div>
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, opacity: audienceSync ? 1 : 0.4 }}>
+                <span style={s.toggleLabel}>valence</span>
+                <div style={s.pillToggle}>
+                  <button style={s.pillBtn(valenceMode === 'continuous')} onClick={() => { if (audienceSync) setValenceMode('continuous'); }}>continuous</button>
+                  <button style={s.pillBtn(valenceMode === 'unit')}       onClick={() => { if (audienceSync) setValenceMode('unit'); }}>unit</button>
+                </div>
               </div>
             </div>
             {audienceSync && (
-              <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-                <span style={s.toggleLabel}>valence</span>
-                <div style={s.pillToggle}>
-                  <button style={s.pillBtn(valenceMode === 'continuous')} onClick={() => setValenceMode('continuous')}>continuous</button>
-                  <button style={s.pillBtn(valenceMode === 'unit')}       onClick={() => setValenceMode('unit')}>unit</button>
-                </div>
-              </div>
-            )}
-            {audienceSync && (
-              <div style={s.audienceCount}>
+              <div style={{ ...s.audienceCount, marginTop: 5, marginLeft: 0 }}>
                 audience: <span style={{ color: '#8080b0', fontWeight: 600 }}>{audienceCount}</span>
               </div>
             )}

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -247,7 +247,7 @@ const RESET_BARS: BarState[] = [0,1,2,3].map(() => ({ height: 3, color: [42,42,6
 export default function MoodTonesPanel({ room }: { room: string }) {
   const [activePreset, setActivePreset]   = useState<Preset>(PRESETS[0]);
   const [playing, setPlaying]             = useState(false);
-  const [mood, setMood]                   = useState(0);
+  const [mood, setMood]                   = useState(50);
   const [audienceSync, setAudienceSync]   = useState(true);
   const [valenceMode, setValenceMode]     = useState<'continuous'|'unit'>('continuous');
   const [volume, setVolume]               = useState(100);
@@ -265,7 +265,7 @@ export default function MoodTonesPanel({ room }: { room: string }) {
   const schedTimerRef = useRef<ReturnType<typeof setTimeout>|null>(null);
 
   // Loop-state refs (avoid stale closures in setTimeout tick)
-  const moodRef         = useRef(0);
+  const moodRef         = useRef(50);
   const playingRef      = useRef(false);
   const presetRef       = useRef<Preset>(PRESETS[0]);
   const noteIndexRef    = useRef(0);
@@ -561,8 +561,8 @@ export default function MoodTonesPanel({ room }: { room: string }) {
     setActivePreset(p);
     presetRef.current = p;
     if (!audienceSyncRef.current) {
-      moodRef.current = 0;
-      setMood(0);
+      moodRef.current = 50;
+      setMood(50);
     }
     noteIndexRef.current = 0;
     currentChordRef.current = [];

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -760,9 +760,11 @@ export default function MoodTonesPanel({ room }: { room: string }) {
         </div>
 
         {/* WS status + explain */}
-        <div style={s.wsStatus}>
-          {wsStatus === 'connected' ? `connected · room: ${room} · ${audienceCount} participant${audienceCount !== 1 ? 's' : ''}` : wsStatus === 'connecting' ? 'connecting…' : 'not connected'}
-        </div>
+        {wsStatus !== 'connected' && (
+          <div style={s.wsStatus}>
+            {wsStatus === 'connecting' ? 'connecting…' : 'not connected'}
+          </div>
+        )}
         <div style={s.explain}>{displayInfo.explain}</div>
       </div>
     </div>

--- a/app/components/MoodTonesPanel.tsx
+++ b/app/components/MoodTonesPanel.tsx
@@ -705,8 +705,8 @@ export default function MoodTonesPanel({ room }: { room: string }) {
               <div style={{ display: 'flex', alignItems: 'center', gap: 6, opacity: audienceSync ? 1 : 0.4 }}>
                 <span style={s.toggleLabel}>valence</span>
                 <div style={s.pillToggle}>
-                  <button style={s.pillBtn(valenceMode === 'continuous')} onClick={() => { if (audienceSync) setValenceMode('continuous'); }}>continuous</button>
-                  <button style={s.pillBtn(valenceMode === 'unit')}       onClick={() => { if (audienceSync) setValenceMode('unit'); }}>unit</button>
+                  <button style={s.pillBtn(valenceMode === 'continuous')} onClick={() => { if (audienceSync) setValenceMode('continuous'); }}>smooth</button>
+                  <button style={s.pillBtn(valenceMode === 'unit')}       onClick={() => { if (audienceSync) setValenceMode('unit'); }}>binary</button>
                 </div>
               </div>
             </div>

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -214,8 +214,11 @@ export default function ReactionCanvasAppV4() {
       {activeInterface === 'canvas' && activity === 'social' && (
         <SocialPanel socialConfig={serverSocialConfig} />
       )}
+      {activeInterface === 'canvas' && activity === 'mood-tones' && (
+        <MoodTonesPanel room={room} />
+      )}
       {/* Canvas is always mounted to keep the WebSocket alive for all interfaces */}
-      <div className="v2-vote-canvas-container" style={{ flex: 1, display: (activeInterface === 'canvas' && activity !== 'social') ? undefined : 'none' }}>
+      <div className="v2-vote-canvas-container" style={{ flex: 1, display: (activeInterface === 'canvas' && activity !== 'social' && activity !== 'mood-tones') ? undefined : 'none' }}>
           {activity === 'image-canvas' && serverImageUrl && (
             <img
               src={serverImageUrl}

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -120,7 +120,9 @@ export default function ReactionCanvasAppV4() {
   const [showFeedbackStarsModal, setShowFeedbackStarsModal] = useState(false);
   const [pushedInterface, setPushedInterface] = useState<string | null>(null);
   const [hapticPending, setHapticPending] = useState(false);
-  const [suppressHapticModal, setSuppressHapticModal] = useState(true);
+  const [suppressHapticModal, setSuppressHapticModal] = useState(
+    () => localStorage.getItem('v4-suppress-haptic-modal') !== 'false'
+  );
   const [hapticEnabled, setHapticEnabled] = useState(WebHaptics.isSupported);
   const [hapticFlashing, setHapticFlashing] = useState(false);
   const hapticFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -381,7 +383,7 @@ export default function ReactionCanvasAppV4() {
             <HapticPushModal
               onDismiss={() => setHapticPending(false)}
               suppressed={suppressHapticModal}
-              onSuppressChange={setSuppressHapticModal}
+              onSuppressChange={v => { setSuppressHapticModal(v); localStorage.setItem('v4-suppress-haptic-modal', String(v)); }}
             />
           )}
         </div>

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -120,7 +120,7 @@ export default function ReactionCanvasAppV4() {
   const [showFeedbackStarsModal, setShowFeedbackStarsModal] = useState(false);
   const [pushedInterface, setPushedInterface] = useState<string | null>(null);
   const [hapticPending, setHapticPending] = useState(false);
-  const [suppressHapticModal, setSuppressHapticModal] = useState(false);
+  const [suppressHapticModal, setSuppressHapticModal] = useState(true);
   const [hapticEnabled, setHapticEnabled] = useState(WebHaptics.isSupported);
   const [hapticFlashing, setHapticFlashing] = useState(false);
   const hapticFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -5,6 +5,7 @@ import TouchLayer from "./TouchLayer";
 import AdminPanelV4 from "./AdminPanelV4";
 import InterfaceChipBar from "./InterfaceChipBar";
 import SocialPanel from "./SocialPanel";
+import MoodTonesPanel from "./MoodTonesPanel";
 import type { ActivityMode, SocialConfig } from "../types";
 import GithubUsernameModal from "./GithubUsernameModal";
 import FeedbackStarsModal from "./FeedbackStarsModal";
@@ -54,6 +55,7 @@ function getUnlockedInterfaces(): string[] {
   const interfaces = ['canvas'];
   if (p.get('interface') === 'emcee') interfaces.push('emcee');
   if (p.get('interface') === 'social') interfaces.push('social');
+  if (p.get('interface') === 'mood-tones') interfaces.push('mood-tones');
   try {
     const stored = JSON.parse(localStorage.getItem(PUSHED_INTERFACES_KEY) ?? '[]');
     if (Array.isArray(stored)) {
@@ -184,7 +186,7 @@ export default function ReactionCanvasAppV4() {
 
   const showChipBar = unlockedInterfaces.length >= 2;
   const chipBarOffset = showChipBar ? CHIP_BAR_HEIGHT : 0;
-  const KNOWN_CHIPS: Record<string, string> = { canvas: 'Canvas', emcee: 'Emcee', social: 'Social' };
+  const KNOWN_CHIPS: Record<string, string> = { canvas: 'Canvas', emcee: 'Emcee', social: 'Social', 'mood-tones': 'Mood Tones' };
   const INTERFACE_CHIPS = unlockedInterfaces.map(key => ({
     key,
     label: KNOWN_CHIPS[key] ?? (key.charAt(0).toUpperCase() + key.slice(1)),
@@ -203,6 +205,8 @@ export default function ReactionCanvasAppV4() {
         <AdminPanelV4 room={room} selfUserId={userId} />
       ) : activeInterface === 'social' ? (
         <SocialPanel socialConfig={serverSocialConfig} />
+      ) : activeInterface === 'mood-tones' ? (
+        <MoodTonesPanel room={room} />
       ) : null}
       {/* When activity is 'social', show SocialPanel as a flex sibling (fills the
           remaining height below the chip bar, same as the chip-based case).

--- a/app/types.ts
+++ b/app/types.ts
@@ -28,7 +28,7 @@ export interface Statement {
   text: string;
 }
 
-export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social';
+export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social' | 'mood-tones';
 
 export interface SocialConfig {
   default: string;


### PR DESCRIPTION
## Summary

| user | admin |
|---|---|
| <img width="1080" height="2400" alt="Screenshot_20260427-180617" src="https://github.com/user-attachments/assets/a6f10998-bf0f-499b-8986-999f990fee47" /> | <img width="1080" height="2400" alt="Screenshot_20260427-180522" src="https://github.com/user-attachments/assets/e66fb174-42e3-412f-b2ac-b6c7a7c238ff" /> |


- Adds a new `mood-tones` V4 interface that plays generative ambient music (4 presets: sad→happy, angry→happy, tense→serene, eerie→wonder) keyed to live audience reaction positions
- Unlocked via `?interface=mood-tones` URL param, or pushed from the People tab (emcee flow), or selected as a canvas activity mode from the Interfaces tab
- Audience sync defaults on — mood slider tracks the live average of participant cursor positions; snaps to center when no one is touching
- Includes volume slider (0–200%), viz bars, note chips, play/stop button, and smooth/binary valence modes
- Also generalizes the Interfaces tab patch dialog so any patchable interface (not just Social) can show its own share QR
- Fixes haptic modal suppression: modal is now fully suppressed by default on non-haptic devices (previous fix only changed the checkbox default inside the modal)

## Test plan

- [x] `localhost:1999#v4?interface=mood-tones` — chip bar shows Canvas + Mood Tones, panel loads with slider at center
- [x] Hit start, drag slider — audio changes with mood
- [x] Open second tab on canvas, move cursor — Mood Tones slider follows live
- [x] Toggle user sync off — slider becomes manually draggable
- [x] Toggle user sync on with empty canvas — slider snaps to center
- [x] Emcee People tab → "Offer interface…" includes mood-tones option
- [x] Interfaces tab has Mood Tones row with radio button and share/QR link
- [x] Test on LAN IP (not localhost) — audience sync still works
- [x] On non-haptic device, haptic modal does not appear on first buzz
- [x] `tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~150 words of PR description from ~400 words of human prompts across this session)