### PR TITLE
feat: event-specific stealth preview deployments via issue label

### DIFF
--- a/.github/workflows/event-preview.yml
+++ b/.github/workflows/event-preview.yml
@@ -48,11 +48,9 @@ jobs:
 
       - name: Generate event index.html
         env:
-          EVENT_TITLE: ${{ secrets.PARTYKIT_EVENT_TITLE }}
           REDIRECT_URL: ${{ steps.config.outputs.redirect_url }}
         run: |
-          sed -e "s|{{EVENT_TITLE}}|$EVENT_TITLE|g" \
-              -e "s|{{REDIRECT_URL}}|$REDIRECT_URL|g" \
+          sed "s|{{REDIRECT_URL}}|$REDIRECT_URL|g" \
               public/index.event.template.html > public/index.html
 
       - name: Deploy event preview

--- a/.github/workflows/event-preview.yml
+++ b/.github/workflows/event-preview.yml
@@ -1,0 +1,136 @@
+name: Deploy Event Preview
+
+on:
+  issues:
+    types: [labeled, closed]
+
+jobs:
+  deploy-event-preview:
+    if: github.event.action == 'labeled' && github.event.label.name == 'event-preview'
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 18
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+
+      - name: Parse issue config
+        id: config
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+        run: |
+          SLUG=$(echo "$ISSUE_BODY" | grep 'slug:' | sed 's/.*slug: *//' | tr -d '\r\n' | head -c 40)
+          [ -z "$SLUG" ] && SLUG="event-$ISSUE_NUMBER"
+          HASH=$(echo "$ISSUE_BODY" | grep 'hash:' | sed 's/.*hash: *//' | tr -d '\r\n' | head -c 10)
+          [ -z "$HASH" ] && HASH="v4"
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+          echo "redirect_url=/#$HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Generate partykit.event.json
+        env:
+          PARTYKIT_EVENT_PROJECT: ${{ secrets.PARTYKIT_EVENT_PROJECT }}
+        run: |
+          jq --arg name "$PARTYKIT_EVENT_PROJECT" \
+             '.name = $name | .serve.build.define["process.env.PARTYKIT_EVENT_BUILD"] = "\"true\""' \
+             partykit.json > partykit.event.json
+
+      - name: Generate event index.html
+        env:
+          EVENT_TITLE: ${{ secrets.PARTYKIT_EVENT_TITLE }}
+          REDIRECT_URL: ${{ steps.config.outputs.redirect_url }}
+        run: |
+          sed -e "s|{{EVENT_TITLE}}|$EVENT_TITLE|g" \
+              -e "s|{{REDIRECT_URL}}|$REDIRECT_URL|g" \
+              public/index.event.template.html > public/index.html
+
+      - name: Deploy event preview
+        env:
+          PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
+          PARTYKIT_LOGIN: patcon
+          SLUG: ${{ steps.config.outputs.slug }}
+        run: |
+          pnpm exec partykit deploy --config partykit.event.json --preview "$SLUG"
+
+      - name: Post deployment comment
+        uses: actions/github-script@v9
+        env:
+          SLUG: ${{ steps.config.outputs.slug }}
+          PARTYKIT_EVENT_PROJECT: ${{ secrets.PARTYKIT_EVENT_PROJECT }}
+        with:
+          script: |
+            const slug = process.env.SLUG;
+            const project = process.env.PARTYKIT_EVENT_PROJECT;
+            const url = `https://${slug}.${project}.patcon.partykit.dev`;
+            const marker = '<!-- event-preview-url -->';
+            const body = `${marker}\nEvent preview deployed: ${url}\n\nClose this issue to tear down the preview.`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body,
+            });
+
+  delete-event-preview:
+    if: github.event.action == 'closed' && contains(toJson(github.event.issue.labels.*.name), 'event-preview')
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 18
+          cache: "pnpm"
+      - run: pnpm install --frozen-lockfile
+
+      - name: Parse slug from issue
+        id: config
+        env:
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          SLUG=$(echo "$ISSUE_BODY" | grep 'slug:' | sed 's/.*slug: *//' | tr -d '\r\n' | head -c 40)
+          [ -z "$SLUG" ] && SLUG="event-$ISSUE_NUMBER"
+          echo "slug=$SLUG" >> "$GITHUB_OUTPUT"
+
+      - name: Generate partykit.event.json
+        env:
+          PARTYKIT_EVENT_PROJECT: ${{ secrets.PARTYKIT_EVENT_PROJECT }}
+        run: |
+          jq --arg name "$PARTYKIT_EVENT_PROJECT" \
+             '.name = $name | .serve.build.define["process.env.PARTYKIT_EVENT_BUILD"] = "\"true\""' \
+             partykit.json > partykit.event.json
+
+      - name: Delete event preview
+        env:
+          PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
+          PARTYKIT_LOGIN: patcon
+          SLUG: ${{ steps.config.outputs.slug }}
+        run: |
+          pnpm exec partykit delete --config partykit.event.json --preview "$SLUG" --force
+
+      - name: Post teardown comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Event preview torn down.',
+            });

--- a/.github/workflows/event-preview.yml
+++ b/.github/workflows/event-preview.yml
@@ -43,7 +43,7 @@ jobs:
           PARTYKIT_EVENT_PROJECT: ${{ secrets.PARTYKIT_EVENT_PROJECT }}
         run: |
           jq --arg name "$PARTYKIT_EVENT_PROJECT" \
-             '.name = $name | .serve.build.define["process.env.PARTYKIT_EVENT_BUILD"] = "\"true\""' \
+             '.name = $name | .serve.build.define["PARTYKIT_EVENT_BUILD"] = "true"' \
              partykit.json > partykit.event.json
 
       - name: Generate event index.html
@@ -113,7 +113,7 @@ jobs:
           PARTYKIT_EVENT_PROJECT: ${{ secrets.PARTYKIT_EVENT_PROJECT }}
         run: |
           jq --arg name "$PARTYKIT_EVENT_PROJECT" \
-             '.name = $name | .serve.build.define["process.env.PARTYKIT_EVENT_BUILD"] = "\"true\""' \
+             '.name = $name | .serve.build.define["PARTYKIT_EVENT_BUILD"] = "true"' \
              partykit.json > partykit.event.json
 
       - name: Delete event preview

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 23 (2026-04-27)
 
 ### Added
+- Event preview deployment: open an issue with the `event-preview` label to spin up a stealth preview on a secondary PartyKit project; close the issue to tear it down. The preview serves a bare redirect page (no tool branding) and the GitHub corner is compiled out of the bundle for event builds.
+
+### Added
 - Mood Sounds: volume slider (0–200%) added above the start button
 - Mood Sounds: significantly boosted output level — tripled oscillator gains, tightened compressor, added 2.5× makeup gain after compression
 - V4: new `mood-tones` interface — ambient generative audio keyed to live audience reaction position; unlock via `?interface=mood-tones` or push from the People tab; audience sync defaults on

--- a/app/client.tsx
+++ b/app/client.tsx
@@ -150,7 +150,7 @@ function App() {
   else if (hash === '#valence-viz') page = <ValenceViz />;
   else page = <IndexApp />;
 
-  return <>{page}<GithubCorner /></>;
+  return <>{page}{process.env.PARTYKIT_EVENT_BUILD !== 'true' && <GithubCorner />}</>;
 }
 
 createRoot(document.getElementById("app")!).render(<App />);

--- a/app/client.tsx
+++ b/app/client.tsx
@@ -1,4 +1,5 @@
 import "./styles.css";
+declare const PARTYKIT_EVENT_BUILD: boolean;
 import { createRoot } from "react-dom/client";
 import { useState, useEffect } from "react";
 import { QRCodeSVG } from "qrcode.react";
@@ -150,7 +151,7 @@ function App() {
   else if (hash === '#valence-viz') page = <ValenceViz />;
   else page = <IndexApp />;
 
-  return <>{page}{process.env.PARTYKIT_EVENT_BUILD !== 'true' && <GithubCorner />}</>;
+  return <>{page}{!PARTYKIT_EVENT_BUILD && <GithubCorner />}</>;
 }
 
 createRoot(document.getElementById("app")!).render(<App />);

--- a/partykit.json
+++ b/partykit.json
@@ -9,7 +9,8 @@
       "entry": "app/client.tsx",
       "define": {
         "process.env.PARTYKIT_SUPABASE_URL": "\"https://cufrmdhkoabpwilwztym.supabase.co\"",
-        "process.env.PARTYKIT_SUPABASE_ANON_KEY": "\"sb_publishable_HoNA1ULIi6X_bW9-4UJOMQ_zUuNogkJ\""
+        "process.env.PARTYKIT_SUPABASE_ANON_KEY": "\"sb_publishable_HoNA1ULIi6X_bW9-4UJOMQ_zUuNogkJ\"",
+        "PARTYKIT_EVENT_BUILD": "false"
       }
     }
   }

--- a/public/index.event.template.html
+++ b/public/index.event.template.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, shrink-to-fit=no, viewport-fit=cover" />
-    <title>{{EVENT_TITLE}}</title>
+    <title>App</title>
     <meta http-equiv="refresh" content="0;url={{REDIRECT_URL}}" />
     <script>window.location.replace('{{REDIRECT_URL}}')</script>
   </head>

--- a/public/index.event.template.html
+++ b/public/index.event.template.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, shrink-to-fit=no, viewport-fit=cover" />
+    <title>{{EVENT_TITLE}}</title>
+    <meta http-equiv="refresh" content="0;url={{REDIRECT_URL}}" />
+    <script>window.location.replace('{{REDIRECT_URL}}')</script>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
## Summary

- New `event-preview.yml` workflow: adding the `event-preview` label to an issue deploys a stealth preview to a secondary PartyKit project; closing the issue tears it down
- Redirect-only `index.event.template.html` served as the entry page — no framework refs, no branding
- GitHub corner compiled out of the bundle for event builds via a new `PARTYKIT_EVENT_BUILD` esbuild define constant

## Two new repo secrets required before the workflow will succeed

| Secret | Value |
|---|---|
| `PARTYKIT_EVENT_PROJECT` | The secondary PartyKit project name |
| `PARTYKIT_EVENT_TITLE` | Generic page title shown in the browser tab (e.g. `App`) |

## Issue body format to trigger a deploy

~~~
```config
slug: myevent
hash: v4
```
~~~

Both fields optional — slug defaults to `event-{issue-number}`, hash defaults to `v4`.

## Test plan

- [ ] Add `PARTYKIT_EVENT_PROJECT` and `PARTYKIT_EVENT_TITLE` secrets to the repo
- [ ] Merge this PR
- [ ] Open a test issue, add `event-preview` label — confirm workflow runs and posts a preview URL comment
- [ ] Visit the preview URL — confirm redirect to `/#v4`, correct title, no GitHub corner
- [ ] Confirm GitHub corner still appears on the main production URL
- [ ] Close the test issue — confirm teardown workflow runs

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~120 words of PR description from ~120 words of human prompts across this session)