### PR TITLE
feat: add Treevites interface — live invite-tree leaderboard

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -27,6 +27,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     permissions:
       pull-requests: write
+      deployments: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -37,15 +38,46 @@ jobs:
           node-version: 18
           cache: "pnpm"
       - run: pnpm install --frozen-lockfile
+      - name: Create GitHub deployment
+        id: deployment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const num = context.payload.pull_request.number;
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.payload.pull_request.head.sha,
+              environment: `pr-${num}`,
+              auto_merge: false,
+              required_contexts: [],
+              description: `PR #${num} preview`,
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.id,
+              state: 'in_progress',
+            });
+            core.setOutput('deployment_id', deployment.id);
       - run: pnpm run cachebust && pnpm exec partykit deploy --preview pr-${{ github.event.pull_request.number }}
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon
-      - uses: actions/github-script@v9
+      - name: Mark deployment success and post preview URL
+        uses: actions/github-script@v9
         with:
           script: |
             const num = context.payload.pull_request.number;
             const url = `https://pr-${num}.polislike-partykit-reaction-canvas.patcon.partykit.dev`;
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.deployment_id }},
+              state: 'success',
+              environment_url: url,
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
             const marker = '<!-- preview-url -->';
             const body = `${marker}\nPreview deployed: ${url}`;
             const { data: comments } = await github.rest.issues.listComments({

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 23 (2026-04-27)
 
+### Added
+- V4: new **Treevites** interface — live invite-tree leaderboard showing who invited whom (transitively). Every shareable QR code now carries an invite chain so the tree builds passively in the background; the leaderboard UI is only shown to participants who've been issued the interface via the People tab or the Interfaces "Share" QR. Closes [#68](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/68).
+
 ### Fixed
 - V4 mood-tones: WebSocket no longer hardcodes the production PartyKit host — derives host from `window.location` so preview deployments connect to their own server instead of prod
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 23 (2026-04-27)
 
 ### Added
-- V4: new **Treevites** interface — live invite-tree leaderboard showing who invited whom (transitively). Every shareable QR code now carries an invite chain so the tree builds passively in the background; the leaderboard UI is only shown to participants who've been issued the interface via the People tab or the Interfaces "Share" QR. Closes [#68](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/68).
+- V4: new **Leaderboard** interface — invite-tree leaderboard showing downstream invite counts. Every shareable QR carries an invite chain so the tree builds passively; the leaderboard UI is only shown to participants issued the interface via the People tab or the Interfaces "Share" QR. Closes [#68](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/68). ([#69](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/69))
+- CI: PR preview deployments now report a GitHub Deployment status, so the PR header shows "This branch was successfully deployed" with a direct link to the preview environment. ([#69](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/69))
+
+### Fixed
+- V4 Leaderboard: selecting Leaderboard as the Solo interface from the Interfaces tab now correctly shows the leaderboard instead of the canvas. ([#69](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/69))
+- V4 Leaderboard: `?inviteChain` URL param is stripped after being read into localStorage, preventing accidental sharing of the raw invite chain. ([#69](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/69))
+- V4 Leaderboard: stored invite chain now takes priority over any `?inviteChain` URL param — once a parent is established, rescanning a different QR code cannot reassign parentage, preserving tree integrity across server restarts. ([#69](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/69))
 
 ### Fixed
 - V4 mood-tones: WebSocket no longer hardcodes the production PartyKit host — derives host from `window.location` so preview deployments connect to their own server instead of prod

--- a/app/components/AdminPanelV4/OfferInterfaceModal.tsx
+++ b/app/components/AdminPanelV4/OfferInterfaceModal.tsx
@@ -53,6 +53,7 @@ export default function OfferInterfaceModal({
         >
           <option value="social">social</option>
           <option value="mood-tones">mood-tones</option>
+          <option value="treevites">treevites</option>
           <option value="emcee">emcee</option>
         </select>
         <div style={{ display: 'flex', gap: 8 }}>

--- a/app/components/AdminPanelV4/index.tsx
+++ b/app/components/AdminPanelV4/index.tsx
@@ -29,9 +29,10 @@ const ALL_TABS: AdminTab[] = ['record', 'labels', 'anchors', 'avatars', 'interfa
 interface AdminPanelV4Props {
   room: string;
   selfUserId?: string;
+  selfChain?: string[];
 }
 
-export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
+export default function AdminPanelV4({ room, selfUserId, selfChain }: AdminPanelV4Props) {
   const tabStorageKey = `v4-admin-tab-${room}`;
   const [activeTab, setActiveTab] = useState<AdminTab>(() => {
     const saved = localStorage.getItem(tabStorageKey);
@@ -290,6 +291,8 @@ export default function AdminPanelV4({ room, selfUserId }: AdminPanelV4Props) {
             setSocialConfigOpen={roomConfig.setSocialConfigOpen}
             setCanvasSettingsOpen={roomConfig.setCanvasSettingsOpen}
             onClearRoleAssignments={() => socket.send(JSON.stringify({ type: 'clearPushedInterfaces' }))}
+            selfId={selfUserId}
+            selfChain={selfChain}
           />
         )}
         {activeTab === 'events' && (

--- a/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
+++ b/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
@@ -42,7 +42,7 @@ const ROWS: { id: string; label: string; desc: string; patchable: boolean; activ
   { id: 'soccer',       label: 'Soccer',          desc: 'Top-down physics ball — kick with your cursor',  patchable: false, activityMode: true  },
   { id: 'social',       label: 'Social Sharing',  desc: 'Bluesky · Twitter / X · Mastodon',              patchable: true,  activityMode: true  },
   { id: 'mood-tones',   label: 'Mood Tones',      desc: 'Generative audio keyed to audience reactions',  patchable: true,  activityMode: true  },
-  { id: 'treevites',    label: 'Treevites',        desc: 'Live invite-tree leaderboard — who invited whom', patchable: true, activityMode: true  },
+  { id: 'treevites',    label: 'Leaderboard',      desc: 'Invite stats — who invited whom',                patchable: true, activityMode: true  },
 ];
 
 export default function InterfacesTab({

--- a/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
+++ b/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { QRCodeSVG } from "qrcode.react";
 import { IoMdSettings } from "react-icons/io";
 import type { ActivityMode } from "../../../types";
+import { appendSelfToChain } from "../../../utils/inviteChain";
 
 interface InterfacesTabProps {
   activity: ActivityMode;
@@ -12,6 +13,8 @@ interface InterfacesTabProps {
   setSocialConfigOpen: (v: boolean) => void;
   setCanvasSettingsOpen: (v: boolean) => void;
   onClearRoleAssignments: () => void;
+  selfId?: string;
+  selfChain?: string[];
 }
 
 const QR_ICON = (
@@ -21,11 +24,14 @@ const QR_ICON = (
   </svg>
 );
 
-function getPatchUrl(interfaceName: string): string {
+function getPatchUrl(interfaceName: string, selfId?: string, selfChain?: string[]): string {
   const p = new URLSearchParams(window.location.search);
   p.delete('forceView');
   p.delete('admin');
   p.set('interface', interfaceName);
+  if (selfId && selfChain !== undefined) {
+    p.set('inviteChain', appendSelfToChain(selfChain, selfId).join(','));
+  }
   const qs = p.toString();
   return `${window.location.origin}${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
 }
@@ -36,16 +42,17 @@ const ROWS: { id: string; label: string; desc: string; patchable: boolean; activ
   { id: 'soccer',       label: 'Soccer',          desc: 'Top-down physics ball — kick with your cursor',  patchable: false, activityMode: true  },
   { id: 'social',       label: 'Social Sharing',  desc: 'Bluesky · Twitter / X · Mastodon',              patchable: true,  activityMode: true  },
   { id: 'mood-tones',   label: 'Mood Tones',      desc: 'Generative audio keyed to audience reactions',  patchable: true,  activityMode: true  },
+  { id: 'treevites',    label: 'Treevites',        desc: 'Live invite-tree leaderboard — who invited whom', patchable: true, activityMode: true  },
 ];
 
 export default function InterfacesTab({
   activity, soccerScore,
   sendActivity, resetSoccerScore,
   setImageConfigOpen, setSocialConfigOpen, setCanvasSettingsOpen,
-  onClearRoleAssignments,
+  onClearRoleAssignments, selfId, selfChain,
 }: InterfacesTabProps) {
   const [patchInterface, setPatchInterface] = useState<string | null>(null);
-  const patchUrl = patchInterface ? getPatchUrl(patchInterface) : '';
+  const patchUrl = patchInterface ? getPatchUrl(patchInterface, selfId, selfChain) : '';
 
   return (
     <div>

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -48,8 +48,9 @@ interface CanvasProps {
   onRoomImageUrlChange?: (url: string) => void;
   onActivityChange?: (activity: ActivityMode) => void;
   onSocialConfigChange?: (config: { default: string; twitter: string; bluesky: string; mastodon: string; instagram: string } | null) => void;
-  onConnected?: () => void;
+  onConnected?: (initialInviteEdges?: Record<string, string>) => void;
   onNowLabelChange?: (label: string) => void;
+  onInviteEdges?: (edges: Record<string, string>) => void;
 }
 
 // Clip an infinite line (defined by two points) to the rectangle [0,w]×[0,h].
@@ -73,7 +74,7 @@ function clipLineToRect(
   return [px + tMin * dx, py + tMin * dy, px + tMax * dx, py + tMax * dy];
 }
 
-export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onInterfacePushed, onPushedInterfacesCleared, onHapticPushed, onRoomImageUrlChange, onActivityChange, onSocialConfigChange, onConnected, onNowLabelChange, debug = false }: CanvasProps) {
+export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onInterfacePushed, onPushedInterfacesCleared, onHapticPushed, onRoomImageUrlChange, onActivityChange, onSocialConfigChange, onConnected, onNowLabelChange, onInviteEdges, debug = false }: CanvasProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [cursors, setCursors] = useState<Map<string, CursorPosition>>(new Map());
   const [anchors, setAnchors] = useState<ReactionAnchors>(DEFAULT_ANCHORS);
@@ -151,7 +152,18 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
           if ('roomSocialConfig' in data) onSocialConfigChange?.(data.roomSocialConfig ?? null);
           onConnectedAsViewer?.(data.isViewer ?? false, data.userCap ?? null);
           onViewerCount?.(data.viewerCount ?? 0);
-          onConnected?.();
+          onConnected?.(data.inviteEdges ?? undefined);
+          return;
+        }
+
+        if (data.type === 'inviteEdges') {
+          if (data.edges && Array.isArray(data.edges)) {
+            const edgeMap: Record<string, string> = {};
+            for (const [inviterId, inviteeId] of data.edges as Array<[string, string]>) {
+              edgeMap[inviteeId] = inviterId;
+            }
+            onInviteEdges?.(edgeMap);
+          }
           return;
         }
 

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -233,8 +233,11 @@ export default function ReactionCanvasAppV4() {
       {activeInterface === 'canvas' && activity === 'mood-tones' && (
         <MoodTonesPanel room={room} />
       )}
+      {activeInterface === 'canvas' && activity === 'treevites' && (
+        <Treevites selfId={userId} inviteEdges={inviteEdges} />
+      )}
       {/* Canvas is always mounted to keep the WebSocket alive for all interfaces */}
-      <div className="v2-vote-canvas-container" style={{ flex: 1, display: (activeInterface === 'canvas' && activity !== 'social' && activity !== 'mood-tones') ? undefined : 'none' }}>
+      <div className="v2-vote-canvas-container" style={{ flex: 1, display: (activeInterface === 'canvas' && activity !== 'social' && activity !== 'mood-tones' && activity !== 'treevites') ? undefined : 'none' }}>
           {activity === 'image-canvas' && serverImageUrl && (
             <img
               src={serverImageUrl}

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -200,7 +200,7 @@ export default function ReactionCanvasAppV4() {
 
   const showChipBar = unlockedInterfaces.length >= 2;
   const chipBarOffset = showChipBar ? CHIP_BAR_HEIGHT : 0;
-  const KNOWN_CHIPS: Record<string, string> = { canvas: 'Canvas', emcee: 'Emcee', social: 'Social', 'mood-tones': 'Mood Tones', treevites: 'Treevites' };
+  const KNOWN_CHIPS: Record<string, string> = { canvas: 'Canvas', emcee: 'Emcee', social: 'Social', 'mood-tones': 'Mood Tones', treevites: 'Leaderboard' };
   const INTERFACE_CHIPS = unlockedInterfaces.map(key => ({
     key,
     label: KNOWN_CHIPS[key] ?? (key.charAt(0).toUpperCase() + key.slice(1)),

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -107,6 +107,12 @@ export default function ReactionCanvasAppV4() {
     const storedChain = getStoredChain(room);
     const chain = urlChain.length > 0 ? urlChain : storedChain;
     if (chain.length > 0) storeChain(room, chain);
+    if (urlChain.length > 0) {
+      const p = new URLSearchParams(window.location.search);
+      p.delete('inviteChain');
+      const qs = p.toString();
+      window.history.replaceState(null, '', `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`);
+    }
     return chain;
   });
   const [inviteEdges, setInviteEdges] = useState<Record<string, string>>({});

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -105,8 +105,11 @@ export default function ReactionCanvasAppV4() {
     const room = getRoomParamFromUrl();
     const urlChain = parseInviteChain(window.location.search);
     const storedChain = getStoredChain(room);
-    const chain = urlChain.length > 0 ? urlChain : storedChain;
-    if (chain.length > 0) storeChain(room, chain);
+    // Stored chain takes priority — once a parent is established, rescanning
+    // a different QR must not reassign parentage (would corrupt the tree on
+    // server restart, since localStorage is the rebuild source of truth).
+    const chain = storedChain.length > 0 ? storedChain : urlChain;
+    if (chain.length > 0 && storedChain.length === 0) storeChain(room, chain);
     if (urlChain.length > 0) {
       const p = new URLSearchParams(window.location.search);
       p.delete('inviteChain');

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -19,7 +19,9 @@ import { getReactionLabelSet } from "../voteLabels";
 import type { ReactionLabelSet } from "../voteLabels";
 import { getPersistentUserId } from "../utils/userId";
 import ShareQRButton from "./ShareQRButton";
+import { parseInviteChain, appendSelfToChain, chainToEdges, storeChain, getStoredChain } from "../utils/inviteChain";
 import HapticIndicatorButton from "./HapticIndicatorButton";
+import Treevites from "./Treevites";
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
 
@@ -56,6 +58,7 @@ function getUnlockedInterfaces(): string[] {
   if (p.get('interface') === 'emcee') interfaces.push('emcee');
   if (p.get('interface') === 'social') interfaces.push('social');
   if (p.get('interface') === 'mood-tones') interfaces.push('mood-tones');
+  if (p.get('interface') === 'treevites') interfaces.push('treevites');
   try {
     const stored = JSON.parse(localStorage.getItem(PUSHED_INTERFACES_KEY) ?? '[]');
     if (Array.isArray(stored)) {
@@ -98,6 +101,15 @@ export default function ReactionCanvasAppV4() {
     return unlocked.includes('emcee') ? 'emcee' : 'canvas';
   });
   const [userId] = useState(() => getPersistentUserId());
+  const [selfChain] = useState<string[]>(() => {
+    const room = getRoomParamFromUrl();
+    const urlChain = parseInviteChain(window.location.search);
+    const storedChain = getStoredChain(room);
+    const chain = urlChain.length > 0 ? urlChain : storedChain;
+    if (chain.length > 0) storeChain(room, chain);
+    return chain;
+  });
+  const [inviteEdges, setInviteEdges] = useState<Record<string, string>>({});
   const [canvasBackgroundReactionState, setCanvasBackgroundReactionState] = useState<ReactionState>(null);
   const [presenceCount, setPresenceCount] = useState<number>(0);
   const [activeCursorCount, setActiveCursorCount] = useState<number>(0);
@@ -188,7 +200,7 @@ export default function ReactionCanvasAppV4() {
 
   const showChipBar = unlockedInterfaces.length >= 2;
   const chipBarOffset = showChipBar ? CHIP_BAR_HEIGHT : 0;
-  const KNOWN_CHIPS: Record<string, string> = { canvas: 'Canvas', emcee: 'Emcee', social: 'Social', 'mood-tones': 'Mood Tones' };
+  const KNOWN_CHIPS: Record<string, string> = { canvas: 'Canvas', emcee: 'Emcee', social: 'Social', 'mood-tones': 'Mood Tones', treevites: 'Treevites' };
   const INTERFACE_CHIPS = unlockedInterfaces.map(key => ({
     key,
     label: KNOWN_CHIPS[key] ?? (key.charAt(0).toUpperCase() + key.slice(1)),
@@ -204,11 +216,13 @@ export default function ReactionCanvasAppV4() {
         />
       )}
       {activeInterface === 'emcee' ? (
-        <AdminPanelV4 room={room} selfUserId={userId} />
+        <AdminPanelV4 room={room} selfUserId={userId} selfChain={selfChain} />
       ) : activeInterface === 'social' ? (
         <SocialPanel socialConfig={serverSocialConfig} />
       ) : activeInterface === 'mood-tones' ? (
         <MoodTonesPanel room={room} />
+      ) : activeInterface === 'treevites' ? (
+        <Treevites selfId={userId} inviteEdges={inviteEdges} />
       ) : null}
       {/* When activity is 'social', show SocialPanel as a flex sibling (fills the
           remaining height below the chip bar, same as the chip-based case).
@@ -247,7 +261,7 @@ export default function ReactionCanvasAppV4() {
           </div>
           <div className="debug-hint">{debug ? 'd: debug on' : 'd: debug'}</div>
           <div className={`v3-rec-badge${isRecording ? '' : ' v3-rec-badge--off'}`}>● REC</div>
-          <ShareQRButton />
+          <ShareQRButton selfId={userId} selfChain={selfChain} />
           <HapticIndicatorButton
             enabled={hapticEnabled}
             flashing={hapticFlashing}
@@ -271,7 +285,15 @@ export default function ReactionCanvasAppV4() {
             onActiveCursorCountChange={setActiveCursorCount}
             onSimulatedCursorCountChange={setSimulatedCursorCount}
             onRecordingStateChange={setIsRecording}
-            onConnected={() => { hasConnectedRef.current = true; }}
+            onConnected={(initialInviteEdges) => {
+              hasConnectedRef.current = true;
+              if (initialInviteEdges) setInviteEdges(initialInviteEdges);
+              const myChain = appendSelfToChain(selfChain, userId);
+              const edges = chainToEdges(myChain);
+              if (edges.length > 0) {
+                socketSendRef.current?.(JSON.stringify({ type: 'recordInvitations', edges }));
+              }
+            }}
             onRoomLabelsChange={handleRoomLabelsChange}
             onRoomAnchorsChange={setServerAnchors}
             onViewerCount={setViewerCount}
@@ -306,6 +328,7 @@ export default function ReactionCanvasAppV4() {
             onActivityChange={handleActivityChange}
             onSocialConfigChange={setServerSocialConfig}
             onNowLabelChange={setNowLabel}
+            onInviteEdges={(edges) => setInviteEdges(prev => ({ ...prev, ...edges }))}
             debug={debug}
           />
           {nowLabel && (

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -1,18 +1,27 @@
 import { useState } from "react";
 import { QRCodeSVG } from "qrcode.react";
+import { appendSelfToChain } from "../utils/inviteChain";
 
-function getShareUrl(): string {
+function getShareUrl(selfId?: string, selfChain?: string[]): string {
   const p = new URLSearchParams(window.location.search);
   p.delete('forceView');
   p.delete('interface');
   p.delete('admin');
+  if (selfId && selfChain !== undefined) {
+    p.set('inviteChain', appendSelfToChain(selfChain, selfId).join(','));
+  }
   const qs = p.toString();
   return `${window.location.origin}${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
 }
 
-export default function ShareQRButton() {
+interface ShareQRButtonProps {
+  selfId?: string;
+  selfChain?: string[];
+}
+
+export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps = {}) {
   const [isOpen, setIsOpen] = useState(false);
-  const url = getShareUrl();
+  const url = getShareUrl(selfId, selfChain);
 
   return (
     <>

--- a/app/components/Treevites.tsx
+++ b/app/components/Treevites.tsx
@@ -1,0 +1,82 @@
+import type { ReactNode } from "react";
+
+interface TreevitesProps {
+  selfId: string;
+  inviteEdges: Record<string, string>; // inviteeId -> inviterId
+}
+
+interface TreeNode {
+  id: string;
+  children: TreeNode[];
+}
+
+function buildTree(inviteEdges: Record<string, string>): TreeNode[] {
+  const allIds = new Set<string>();
+  const hasParent = new Set<string>();
+  for (const [inviteeId, inviterId] of Object.entries(inviteEdges)) {
+    allIds.add(inviteeId);
+    allIds.add(inviterId);
+    hasParent.add(inviteeId);
+  }
+  const roots = [...allIds].filter(id => !hasParent.has(id));
+
+  function buildNode(id: string): TreeNode {
+    const children = Object.entries(inviteEdges)
+      .filter(([, parentId]) => parentId === id)
+      .map(([childId]) => buildNode(childId));
+    return { id, children };
+  }
+
+  return roots.map(buildNode);
+}
+
+function countDescendants(node: TreeNode): number {
+  return node.children.reduce((sum, child) => sum + 1 + countDescendants(child), 0);
+}
+
+function TreeNodeRow({ node, selfId, depth }: { node: TreeNode; selfId: string; depth: number }): ReactNode {
+  const isSelf = node.id === selfId;
+  const score = countDescendants(node);
+  return (
+    <li>
+      <div
+        className={`treevites-row${isSelf ? ' treevites-row--self' : ''}`}
+        style={{ paddingLeft: depth * 20 }}
+      >
+        <span className="treevites-id">{node.id}</span>
+        {isSelf && <span className="treevites-you"> (you)</span>}
+        {score > 0 && <span className="treevites-score">{score}</span>}
+      </div>
+      {node.children.length > 0 && (
+        <ul className="treevites-children">
+          {node.children.map(child => (
+            <TreeNodeRow key={child.id} node={child} selfId={selfId} depth={depth + 1} />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+export default function Treevites({ selfId, inviteEdges }: TreevitesProps) {
+  const roots = buildTree(inviteEdges);
+  const isEmpty = Object.keys(inviteEdges).length === 0;
+
+  return (
+    <div className="treevites-container">
+      <div className="treevites-header">
+        <h2 className="treevites-title">Treevites</h2>
+        <p className="treevites-subtitle">Invite leaderboard — numbers show transitive reach</p>
+      </div>
+      {isEmpty ? (
+        <p className="treevites-empty">No invite chains recorded yet. Share your QR code to start the tree.</p>
+      ) : (
+        <ul className="treevites-tree">
+          {roots.map(root => (
+            <TreeNodeRow key={root.id} node={root} selfId={selfId} depth={0} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/components/Treevites.tsx
+++ b/app/components/Treevites.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import type { ReactNode } from "react";
 
 interface TreevitesProps {
@@ -34,23 +35,23 @@ function countDescendants(node: TreeNode): number {
   return node.children.reduce((sum, child) => sum + 1 + countDescendants(child), 0);
 }
 
-function TreeNodeRow({ node, selfId, depth }: { node: TreeNode; selfId: string; depth: number }): ReactNode {
+function TreeNodeRow({ node, selfId, depth, showIndent }: { node: TreeNode; selfId: string; depth: number; showIndent: boolean }): ReactNode {
   const isSelf = node.id === selfId;
   const score = countDescendants(node);
   return (
     <li>
       <div
         className={`treevites-row${isSelf ? ' treevites-row--self' : ''}`}
-        style={{ paddingLeft: depth * 20 }}
+        style={showIndent && depth > 0 ? { paddingLeft: `${depth}ch` } : undefined}
       >
         <span className="treevites-id">{node.id}</span>
         {isSelf && <span className="treevites-you"> (you)</span>}
-        {score > 0 && <span className="treevites-score">{score}</span>}
+        <span className="treevites-score">{score}</span>
       </div>
       {node.children.length > 0 && (
         <ul className="treevites-children">
           {node.children.map(child => (
-            <TreeNodeRow key={child.id} node={child} selfId={selfId} depth={depth + 1} />
+            <TreeNodeRow key={child.id} node={child} selfId={selfId} depth={depth + 1} showIndent={showIndent} />
           ))}
         </ul>
       )}
@@ -59,21 +60,30 @@ function TreeNodeRow({ node, selfId, depth }: { node: TreeNode; selfId: string; 
 }
 
 export default function Treevites({ selfId, inviteEdges }: TreevitesProps) {
+  const [showIndent, setShowIndent] = useState(false);
   const roots = buildTree(inviteEdges);
   const isEmpty = Object.keys(inviteEdges).length === 0;
 
   return (
     <div className="treevites-container">
       <div className="treevites-header">
-        <h2 className="treevites-title">Treevites</h2>
-        <p className="treevites-subtitle">Invite leaderboard — numbers show transitive reach</p>
+        <h2 className="treevites-title">Leaderboard</h2>
+        <p className="treevites-subtitle">Invite stats — numbers show downstream invites</p>
       </div>
+      <label className="treevites-indent-toggle">
+        <input
+          type="checkbox"
+          checked={showIndent}
+          onChange={e => setShowIndent(e.target.checked)}
+        />
+        {' '}Show tree indentation
+      </label>
       {isEmpty ? (
         <p className="treevites-empty">No invite chains recorded yet. Share your QR code to start the tree.</p>
       ) : (
         <ul className="treevites-tree">
           {roots.map(root => (
-            <TreeNodeRow key={root.id} node={root} selfId={selfId} depth={0} />
+            <TreeNodeRow key={root.id} node={root} selfId={selfId} depth={0} showIndent={showIndent} />
           ))}
         </ul>
       )}

--- a/app/styles.css
+++ b/app/styles.css
@@ -1737,6 +1737,16 @@ body {
   margin: 0;
 }
 
+.treevites-indent-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #666;
+  cursor: pointer;
+  margin-bottom: 16px;
+}
+
 .treevites-empty {
   color: #555;
   font-size: 13px;

--- a/app/styles.css
+++ b/app/styles.css
@@ -1707,3 +1707,79 @@ body {
   border-color: #4a7acf;
   color: #e8f0ff;
 }
+
+/* ── Treevites leaderboard ── */
+.treevites-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #0f0f0e;
+  color: #c8c6be;
+  padding: 24px 20px;
+  overflow-y: auto;
+  font-family: 'DM Mono', monospace;
+}
+
+.treevites-header {
+  margin-bottom: 20px;
+}
+
+.treevites-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #eee;
+  margin: 0 0 4px;
+}
+
+.treevites-subtitle {
+  font-size: 12px;
+  color: #666;
+  margin: 0;
+}
+
+.treevites-empty {
+  color: #555;
+  font-size: 13px;
+}
+
+.treevites-tree,
+.treevites-children {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.treevites-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 0;
+  border-bottom: 1px solid #1e1e1e;
+  font-size: 13px;
+}
+
+.treevites-row--self {
+  color: #7eb8f7;
+}
+
+.treevites-id {
+  font-family: monospace;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.treevites-you {
+  font-size: 11px;
+  color: #4a7acf;
+}
+
+.treevites-score {
+  font-size: 12px;
+  color: #888;
+  background: #1e1e1e;
+  border-radius: 4px;
+  padding: 1px 6px;
+  flex-shrink: 0;
+}

--- a/app/types.ts
+++ b/app/types.ts
@@ -28,7 +28,7 @@ export interface Statement {
   text: string;
 }
 
-export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social' | 'mood-tones';
+export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social' | 'mood-tones' | 'treevites';
 
 export interface SocialConfig {
   default: string;

--- a/app/utils/inviteChain.ts
+++ b/app/utils/inviteChain.ts
@@ -1,0 +1,43 @@
+export function parseInviteChain(search: string): string[] {
+  const raw = new URLSearchParams(search).get('inviteChain');
+  if (!raw) return [];
+  return raw.split(',').filter(Boolean);
+}
+
+export function appendSelfToChain(chain: string[], selfId: string): string[] {
+  if (chain.includes(selfId)) return chain;
+  return [...chain, selfId];
+}
+
+export function chainToEdges(chain: string[]): Array<[string, string]> {
+  const edges: Array<[string, string]> = [];
+  for (let i = 0; i < chain.length - 1; i++) {
+    edges.push([chain[i], chain[i + 1]]);
+  }
+  return edges;
+}
+
+export function getStoredChain(room: string): string[] {
+  try {
+    const raw = localStorage.getItem(`treevites-chain-${room}`);
+    if (!raw) return [];
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+}
+
+export function storeChain(room: string, chain: string[]): void {
+  try {
+    localStorage.setItem(`treevites-chain-${room}`, JSON.stringify(chain));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function buildInviteChainUrl(baseSearch: string, selfId: string, selfChain: string[]): string {
+  const p = new URLSearchParams(baseSearch);
+  const outgoing = appendSelfToChain(selfChain, selfId);
+  p.set('inviteChain', outgoing.join(','));
+  return p.toString();
+}

--- a/party/server.ts
+++ b/party/server.ts
@@ -196,7 +196,12 @@ interface SetNowLabelEvent {
   label: string;
 }
 
-type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent;
+interface RecordInvitationsEvent {
+  type: 'recordInvitations';
+  edges: Array<[string, string]>; // [inviterId, inviteeId]
+}
+
+type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent;
 
 // ===== REACTION REGION HELPER (mirrors app/utils/voteRegion.ts) =====
 const DEFAULT_ANCHORS = {
@@ -258,6 +263,7 @@ export default class Server implements Party.Server {
   private githubSubmissions: { username: string; displayName: string | null; avatarUrl: string | null; timestamp: number }[] = [];
   private soccerInterval?: NodeJS.Timeout;
   private cursorPositions = new Map<string, { x: number; y: number }>();
+  private inviteEdges = new Map<string, string>(); // inviteeId -> inviterId
 
   // ===== GHOST CURSOR DEMO CODE (can be easily removed) =====
   private ghostCursorsEnabled: boolean = false;
@@ -378,6 +384,7 @@ export default class Server implements Party.Server {
       userCap: this.userCap,
       viewerCount: vCount,
       connectedUserIds,
+      inviteEdges: Object.fromEntries(this.inviteEdges),
     }));
   }
 
@@ -552,6 +559,17 @@ export default class Server implements Party.Server {
         const msg = JSON.stringify({ type: 'interfaceAccepted', userId, interfaceName: event.interfaceName });
         for (const conn of this.room.getConnections()) {
           if (this.adminConnectionIds.has(conn.id)) conn.send(msg);
+        }
+      } else if (event.type === 'recordInvitations') {
+        const newEdges: Array<[string, string]> = [];
+        for (const [inviterId, inviteeId] of event.edges) {
+          if (!this.inviteEdges.has(inviteeId)) {
+            this.inviteEdges.set(inviteeId, inviterId);
+            newEdges.push([inviterId, inviteeId]);
+          }
+        }
+        if (newEdges.length > 0) {
+          this.room.broadcast(JSON.stringify({ type: 'inviteEdges', edges: newEdges }));
         }
       }
     } catch (e) {


### PR DESCRIPTION
## Summary

|   |   |
|---|---|
| <img width="1080" height="2400" alt="Screenshot_20260429-010630" src="https://github.com/user-attachments/assets/b08a16d7-2237-4fc6-85df-2965639619a7" /> | <img width="1080" height="2400" alt="Screenshot_20260429-010648" src="https://github.com/user-attachments/assets/47fb37ad-42e7-44bf-9e2f-f3bcfe7d8db6" /> |

- Adds a new **Treevites** participant interface: an indented live leaderboard showing who invited whom, transitively. Score = number of descendants.
- Every shareable room QR (and per-interface "Share" QR) now encodes the current user's ancestor invite chain (`?inviteChain=<csv>`). The tree builds passively in the background even when Treevites isn't the active interface.
- The leaderboard UI is gated like `social`/`mood-tones`: only visible to participants pushed the interface from the People tab, or who scan the Interfaces "Share" QR. Everyone contributes to the tree regardless.

## Protocol

Each user's URL carries the full ancestor chain (`?inviteChain=A,B,C`). On connect, the client derives edges (`A→B`, `B→C`, `C→self`) and sends them to the server as `recordInvitations`. The server stores edges idempotently and broadcasts new ones. New joiners receive the full edge map in the `connected` payload. Chain is persisted in `localStorage` so server restarts are recovered automatically when clients reconnect.

## Test plan

- [ ] Open the app with two browser windows (or tabs on different devices)
- [ ] Copy the room QR URL from one window, append yourself to the chain manually, open that URL in a second window
- [ ] Push the `treevites` interface to the second window from the People tab
- [ ] Verify the second window shows an indented tree with the first user as root and themselves as a child
- [ ] Open a third window using the second window's QR; verify the first window now shows a two-level tree
- [ ] Kill and restart the local dev server; reload all windows; verify the tree rebuilds from localStorage chains

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~300 words of PR description from ~300 words of human prompts across this session)