### PR TITLE
feat: Greeter interface with Guild event attendee list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 23 (2026-04-27)
 
 ### Added
-- V4: new **Greeter** interface — emcee configures a Guild event URL in the Interfaces tab; the panel fetches and displays in-person attendees (photo + name) from the Guild GraphQL API. Patchable via QR and pushable to participants from the People tab.
+- V4: new **Greeter** interface — emcee configures a Guild event or group URL in the Interfaces tab; the panel fetches and displays attendees (photo + name) from the Guild GraphQL API with in-person/online/all filter, first/last name sort, and ← → event navigation. Defaults to the current day's event until midnight. Patchable via QR and pushable to participants from the People tab. ([#73](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/73))
 - Server: **Brigade Bat-Signal** — when a room's participant count crosses 3, a Telegram message is sent to a configured group with a direct link to the room. Fires on every upward crossing (intentionally noisy). Requires `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` PartyKit secrets; silent no-op if absent. Closes [#23](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/23). ([#72](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/72))
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 23 (2026-04-27)
 
 ### Added
+- V4: new **Greeter** interface — emcee configures a Guild event URL in the Interfaces tab; the panel fetches and displays in-person attendees (photo + name) from the Guild GraphQL API. Patchable via QR and pushable to participants from the People tab.
 - Server: **Brigade Bat-Signal** — when a room's participant count crosses 3, a Telegram message is sent to a configured group with a direct link to the room. Fires on every upward crossing (intentionally noisy). Requires `TELEGRAM_BOT_TOKEN` and `TELEGRAM_CHAT_ID` PartyKit secrets; silent no-op if absent. Closes [#23](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/23). ([#72](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/72))
 
 ### Added

--- a/app/components/AdminPanelV4/OfferInterfaceModal.tsx
+++ b/app/components/AdminPanelV4/OfferInterfaceModal.tsx
@@ -54,6 +54,7 @@ export default function OfferInterfaceModal({
           <option value="social">social</option>
           <option value="mood-tones">mood-tones</option>
           <option value="treevites">treevites</option>
+          <option value="greeter">greeter</option>
           <option value="emcee">emcee</option>
         </select>
         <div style={{ display: 'flex', gap: 8 }}>

--- a/app/components/AdminPanelV4/hooks/useRoomConfig.ts
+++ b/app/components/AdminPanelV4/hooks/useRoomConfig.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { ActivityMode, SocialConfig } from "../../../types";
+import type { ActivityMode, GreeterConfig, SocialConfig } from "../../../types";
 import type PartySocket from "partysocket";
 
 export function useRoomConfig(socket: PartySocket) {
@@ -14,6 +14,8 @@ export function useRoomConfig(socket: PartySocket) {
     localStorage.getItem('v4-showNowLabelOnCanvas') === 'true'
   );
   const [roomSocialConfig, setRoomSocialConfig] = useState<SocialConfig | null>(null);
+  const [greeterConfig, setGreeterConfig]     = useState<GreeterConfig | null>(null);
+  const [greeterConfigOpen, setGreeterConfigOpen] = useState(false);
   const [userCap, setUserCap]                 = useState<number | null>(null);
   const [capInput, setCapInput]               = useState<string>('');
 
@@ -37,6 +39,11 @@ export function useRoomConfig(socket: PartySocket) {
     socket.send(JSON.stringify({ type: 'setSocialConfig', config }));
   };
 
+  const sendGreeterConfig = (config: GreeterConfig) => {
+    setGreeterConfig(config);
+    socket.send(JSON.stringify({ type: 'setGreeterConfig', config }));
+  };
+
   const resetSoccerScore = () => {
     socket.send(JSON.stringify({ type: 'resetSoccerScore' }));
   };
@@ -52,6 +59,7 @@ export function useRoomConfig(socket: PartySocket) {
     if ('currentActivity' in data) setActivity((data.currentActivity as ActivityMode) ?? 'canvas');
     if ('roomImageUrl' in data) setRoomImageUrl((data.roomImageUrl as string) ?? '');
     if ('roomSocialConfig' in data) setRoomSocialConfig((data.roomSocialConfig as SocialConfig | null) ?? null);
+    if ('greeterConfig' in data) setGreeterConfig((data.greeterConfig as GreeterConfig | null) ?? null);
     if ('soccerScore' in data && data.soccerScore) setSoccerScore(data.soccerScore as { left: number; right: number });
     if (data.userCap !== undefined) {
       setUserCap(data.userCap as number | null);
@@ -68,6 +76,8 @@ export function useRoomConfig(socket: PartySocket) {
       setRoomImageUrl((data.url as string) ?? '');
     } else if (data.type === 'socialConfigChanged') {
       setRoomSocialConfig((data.config as SocialConfig | null) ?? null);
+    } else if (data.type === 'greeterConfigChanged') {
+      setGreeterConfig((data.config as GreeterConfig | null) ?? null);
     } else if (data.type === 'goalScored') {
       setSoccerScore(data.score as { left: number; right: number });
     } else if (data.type === 'userCapChanged') {
@@ -90,6 +100,9 @@ export function useRoomConfig(socket: PartySocket) {
     sendActivity,
     sendImageUrl,
     sendSocialConfig,
+    greeterConfig, setGreeterConfig,
+    greeterConfigOpen, setGreeterConfigOpen,
+    sendGreeterConfig,
     resetSoccerScore,
     sendUserCap,
     applyConnected,

--- a/app/components/AdminPanelV4/index.tsx
+++ b/app/components/AdminPanelV4/index.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import usePartySocket from "partysocket/react";
 import ImageConfigModal from "../ImageConfigModal";
 import SocialConfigModal from "../SocialConfigModal";
+import GreeterConfigModal from "../GreeterConfigModal";
 import { useAnchors } from "./hooks/useAnchors";
 import { useLabels } from "./hooks/useLabels";
 import { useRoomConfig } from "./hooks/useRoomConfig";
@@ -289,6 +290,7 @@ export default function AdminPanelV4({ room, selfUserId, selfChain }: AdminPanel
             resetSoccerScore={roomConfig.resetSoccerScore}
             setImageConfigOpen={roomConfig.setImageConfigOpen}
             setSocialConfigOpen={roomConfig.setSocialConfigOpen}
+            setGreeterConfigOpen={roomConfig.setGreeterConfigOpen}
             setCanvasSettingsOpen={roomConfig.setCanvasSettingsOpen}
             onClearRoleAssignments={() => socket.send(JSON.stringify({ type: 'clearPushedInterfaces' }))}
             selfId={selfUserId}
@@ -454,6 +456,13 @@ export default function AdminPanelV4({ room, selfUserId, selfChain }: AdminPanel
           current={roomConfig.roomSocialConfig}
           onSubmit={roomConfig.sendSocialConfig}
           onClose={() => roomConfig.setSocialConfigOpen(false)}
+        />
+      )}
+      {roomConfig.greeterConfigOpen && (
+        <GreeterConfigModal
+          current={roomConfig.greeterConfig}
+          onSubmit={roomConfig.sendGreeterConfig}
+          onClose={() => roomConfig.setGreeterConfigOpen(false)}
         />
       )}
     </div>

--- a/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
+++ b/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
@@ -11,6 +11,7 @@ interface InterfacesTabProps {
   resetSoccerScore: () => void;
   setImageConfigOpen: (v: boolean) => void;
   setSocialConfigOpen: (v: boolean) => void;
+  setGreeterConfigOpen: (v: boolean) => void;
   setCanvasSettingsOpen: (v: boolean) => void;
   onClearRoleAssignments: () => void;
   selfId?: string;
@@ -43,12 +44,13 @@ const ROWS: { id: string; label: string; desc: string; patchable: boolean; activ
   { id: 'social',       label: 'Social Sharing',  desc: 'Bluesky · Twitter / X · Mastodon',              patchable: true,  activityMode: true  },
   { id: 'mood-tones',   label: 'Mood Tones',      desc: 'Generative audio keyed to audience reactions',  patchable: true,  activityMode: true  },
   { id: 'treevites',    label: 'Leaderboard',      desc: 'Invite stats — who invited whom',                patchable: true, activityMode: true  },
+  { id: 'greeter',     label: 'Greeter',          desc: 'Guild event attendee welcome list',              patchable: true,  activityMode: true  },
 ];
 
 export default function InterfacesTab({
   activity, soccerScore,
   sendActivity, resetSoccerScore,
-  setImageConfigOpen, setSocialConfigOpen, setCanvasSettingsOpen,
+  setImageConfigOpen, setSocialConfigOpen, setGreeterConfigOpen, setCanvasSettingsOpen,
   onClearRoleAssignments, selfId, selfChain,
 }: InterfacesTabProps) {
   const [patchInterface, setPatchInterface] = useState<string | null>(null);
@@ -86,6 +88,9 @@ export default function InterfacesTab({
                     )}
                     {id === 'social' && (
                       <button className="image-canvas-config-link" onClick={e => { e.preventDefault(); setSocialConfigOpen(true); }}><IoMdSettings /></button>
+                    )}
+                    {id === 'greeter' && (
+                      <button className="image-canvas-config-link" onClick={e => { e.preventDefault(); setGreeterConfigOpen(true); }}><IoMdSettings /></button>
                     )}
                   </label>
                 </td>

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -3,7 +3,7 @@ import usePartySocket from "partysocket/react";
 import * as d3 from "d3";
 import { computeReactionRegion, DEFAULT_ANCHORS } from "../utils/voteRegion";
 import type { ReactionAnchors } from "../utils/voteRegion";
-import type { ActivityMode } from "../types";
+import type { ActivityMode, GreeterConfig } from "../types";
 
 interface CursorPosition {
   x: number; // Normalized coordinates (0-100)
@@ -48,6 +48,7 @@ interface CanvasProps {
   onRoomImageUrlChange?: (url: string) => void;
   onActivityChange?: (activity: ActivityMode) => void;
   onSocialConfigChange?: (config: { default: string; twitter: string; bluesky: string; mastodon: string; instagram: string } | null) => void;
+  onGreeterConfigChange?: (config: GreeterConfig | null) => void;
   onConnected?: (initialInviteEdges?: Record<string, string>) => void;
   onNowLabelChange?: (label: string) => void;
   onInviteEdges?: (edges: Record<string, string>) => void;
@@ -74,7 +75,7 @@ function clipLineToRect(
   return [px + tMin * dx, py + tMin * dy, px + tMax * dx, py + tMax * dy];
 }
 
-export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onInterfacePushed, onPushedInterfacesCleared, onHapticPushed, onRoomImageUrlChange, onActivityChange, onSocialConfigChange, onConnected, onNowLabelChange, onInviteEdges, debug = false }: CanvasProps) {
+export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onInterfacePushed, onPushedInterfacesCleared, onHapticPushed, onRoomImageUrlChange, onActivityChange, onSocialConfigChange, onGreeterConfigChange, onConnected, onNowLabelChange, onInviteEdges, debug = false }: CanvasProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [cursors, setCursors] = useState<Map<string, CursorPosition>>(new Map());
   const [anchors, setAnchors] = useState<ReactionAnchors>(DEFAULT_ANCHORS);
@@ -150,6 +151,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
           if ('ballState' in data && data.ballState) setBallPos({ x: data.ballState.x, y: data.ballState.y });
           if ('soccerScore' in data && data.soccerScore) setSoccerScore(data.soccerScore);
           if ('roomSocialConfig' in data) onSocialConfigChange?.(data.roomSocialConfig ?? null);
+          if ('greeterConfig' in data) onGreeterConfigChange?.(data.greeterConfig ?? null);
           onConnectedAsViewer?.(data.isViewer ?? false, data.userCap ?? null);
           onViewerCount?.(data.viewerCount ?? 0);
           onConnected?.(data.inviteEdges ?? undefined);
@@ -231,6 +233,11 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
 
         if (data.type === 'socialConfigChanged') {
           onSocialConfigChange?.(data.config ?? null);
+          return;
+        }
+
+        if (data.type === 'greeterConfigChanged') {
+          onGreeterConfigChange?.(data.config ?? null);
           return;
         }
 

--- a/app/components/GreeterConfigModal.tsx
+++ b/app/components/GreeterConfigModal.tsx
@@ -19,7 +19,7 @@ export default function GreeterConfigModal({ onSubmit, onClose, current }: Greet
     <div className="github-modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose(); }}>
       <div className="github-modal">
         <p className="github-modal-title">Greeter config</p>
-        <p className="github-modal-body">Set the Guild event URL to show in-person attendees.</p>
+        <p className="github-modal-body">Set a Guild event URL, or a group URL to auto-use the next upcoming event.</p>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
           <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
             <span style={{ fontSize: 12, color: '#aaa' }}>Guild event URL</span>
@@ -28,7 +28,7 @@ export default function GreeterConfigModal({ onSubmit, onClose, current }: Greet
               type="text"
               value={eventUrl}
               onChange={e => setEventUrl(e.target.value)}
-              placeholder="https://guild.host/events/your-event-slug"
+              placeholder="https://guild.host/events/… or https://guild.host/your-group"
               autoFocus
             />
           </label>

--- a/app/components/GreeterConfigModal.tsx
+++ b/app/components/GreeterConfigModal.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import type { GreeterConfig } from "../types";
+
+interface GreeterConfigModalProps {
+  onSubmit: (config: GreeterConfig) => void;
+  onClose: () => void;
+  current?: GreeterConfig | null;
+}
+
+export default function GreeterConfigModal({ onSubmit, onClose, current }: GreeterConfigModalProps) {
+  const [eventUrl, setEventUrl] = useState(current?.eventUrl ?? '');
+
+  const handleSave = () => {
+    onSubmit({ eventUrl });
+    onClose();
+  };
+
+  return (
+    <div className="github-modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="github-modal">
+        <p className="github-modal-title">Greeter config</p>
+        <p className="github-modal-body">Set the Guild event URL to show in-person attendees.</p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span style={{ fontSize: 12, color: '#aaa' }}>Guild event URL</span>
+            <input
+              className="github-modal-input"
+              type="text"
+              value={eventUrl}
+              onChange={e => setEventUrl(e.target.value)}
+              placeholder="https://guild.host/events/your-event-slug"
+              autoFocus
+            />
+          </label>
+        </div>
+        <button className="github-modal-btn-primary" onClick={handleSave} style={{ marginTop: 16 }}>
+          Save
+        </button>
+        <button className="github-modal-btn-dismiss" onClick={onClose}>Cancel</button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/GreeterConfigModal.tsx
+++ b/app/components/GreeterConfigModal.tsx
@@ -29,7 +29,7 @@ export default function GreeterConfigModal({ onSubmit, onClose, current }: Greet
               value={eventUrl}
               onChange={e => setEventUrl(e.target.value)}
               placeholder="https://guild.host/events/… or https://guild.host/your-group"
-              autoFocus
+
             />
           </label>
         </div>

--- a/app/components/GreeterPanel.tsx
+++ b/app/components/GreeterPanel.tsx
@@ -12,87 +12,101 @@ interface GreeterPanelProps {
   greeterConfig: GreeterConfig | null;
 }
 
-const GRAPHQL_URL = 'https://guild.host/graphql/ab910738acdb79ffade614553f55523137c6968924e004a2e789faef52c0c081';
+const GRAPHQL_SLUG_URL = 'https://guild.host/graphql/ab910738acdb79ffade614553f55523137c6968924e004a2e789faef52c0c081';
+const GRAPHQL_ATTENDEES_URL = 'https://guild.host/graphql/f0f0595e0c3bc689857cd75b6e3d1e32de52fa6aeeb3671a69aa1b9e0986c5e0';
 
-function extractSlug(eventUrl: string): string | null {
+type ParsedUrl =
+  | { type: 'event'; slug: string }
+  | { type: 'group'; groupSlug: string };
+
+function parseGuildUrl(url: string): ParsedUrl | null {
   try {
-    const path = new URL(eventUrl).pathname;
-    const segments = path.split('/').filter(Boolean);
-    const lastSegment = segments[segments.length - 1];
-    if (!lastSegment) return null;
-    // The API slug is the last hyphen-separated token (e.g. "civic-meetup-540-numbers-3onf9n" → "3onf9n")
-    const parts = lastSegment.split('-');
-    return parts[parts.length - 1] ?? null;
+    const segments = new URL(url).pathname.split('/').filter(Boolean);
+    if (segments[0] === 'events' && segments[1]) {
+      // e.g. /events/civic-meetup-540-numbers-3onf9n → slug = "3onf9n"
+      const parts = segments[1].split('-');
+      return { type: 'event', slug: parts[parts.length - 1] };
+    }
+    if (segments.length === 1) {
+      // e.g. /civic-tech-toronto
+      return { type: 'group', groupSlug: segments[0] };
+    }
+    return null;
   } catch {
     return null;
   }
 }
 
-type AttendeeEdge = {
-  cursor: string;
-  node: {
-    user: {
-      slugId: string;
-      firstName: string;
-      lastName: string;
-      primaryPhoto: { transformUrl: string } | null;
-      defaultAvatarUrl: string;
-    };
-  };
-};
+async function resolveEventNodeId(parsed: ParsedUrl): Promise<string | null> {
+  if (parsed.type === 'event') {
+    const res = await fetch(GRAPHQL_SLUG_URL, {
+      headers: { 'x-gqlvars': JSON.stringify({ slug: parsed.slug }) },
+    });
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json?.data?.event?.id ?? null;
+  } else {
+    const res = await fetch(`https://guild.host/api/next/${parsed.groupSlug}/events/upcoming`);
+    if (!res.ok) return null;
+    const json = await res.json();
+    return json?.events?.edges?.[0]?.node?.id ?? null;
+  }
+}
 
-async function fetchPage(slug: string, after?: string): Promise<{ edges: AttendeeEdge[]; hasNextPage: boolean }> {
-  const vars: Record<string, unknown> = { slug };
-  if (after) vars.after = after;
-  const res = await fetch(GRAPHQL_URL, {
-    headers: { 'x-gqlvars': JSON.stringify(vars) },
+async function fetchAttendees(nodeId: string): Promise<Attendee[]> {
+  const res = await fetch(GRAPHQL_ATTENDEES_URL, {
+    headers: {
+      'content-type': 'application/json',
+      'x-gqlvars': JSON.stringify({ id: nodeId, count: 200 }),
+    },
   });
   if (!res.ok) throw new Error(`Guild API returned ${res.status}`);
   const json = await res.json();
-  const attendees = json?.data?.event?.inPersonAttendees;
-  const edges: AttendeeEdge[] = attendees?.edges ?? [];
-  const hasNextPage: boolean = attendees?.pageInfo?.hasNextPage ?? (edges.length > 0 && edges.length === 10);
-  return { edges, hasNextPage };
-}
-
-async function fetchAttendees(slug: string): Promise<Attendee[]> {
-  const all: Attendee[] = [];
-  let after: string | undefined;
-
-  for (;;) {
-    const { edges, hasNextPage } = await fetchPage(slug, after);
-    for (const { cursor, node: { user } } of edges) {
-      all.push({
-        slugId: user.slugId,
-        firstName: user.firstName,
-        lastName: user.lastName,
-        photoUrl: user.primaryPhoto?.transformUrl ?? user.defaultAvatarUrl,
-      });
-      after = cursor;
-    }
-    if (!hasNextPage || edges.length === 0) break;
-  }
-
-  return all;
+  const edges: { node: { user: { slugId: string; firstName: string; lastName: string; primaryPhoto: { transformUrl: string } | null; defaultAvatarUrl: string } } }[] =
+    json?.data?.node?.inPersonAttendees?.edges ?? [];
+  return edges.map(({ node: { user } }) => ({
+    slugId: user.slugId,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    photoUrl: user.primaryPhoto?.transformUrl ?? user.defaultAvatarUrl,
+  }));
 }
 
 export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
   const [attendees, setAttendees] = useState<Attendee[]>([]);
-  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'no-event' | 'error'>('idle');
 
-  const slug = greeterConfig ? extractSlug(greeterConfig.eventUrl) : null;
+  const eventUrl = greeterConfig?.eventUrl ?? null;
 
   useEffect(() => {
-    if (!slug) {
+    if (!eventUrl) {
       setAttendees([]);
       setStatus('idle');
       return;
     }
+
+    const parsed = parseGuildUrl(eventUrl);
+    if (!parsed) {
+      setAttendees([]);
+      setStatus('idle');
+      return;
+    }
+
+    let cancelled = false;
     setStatus('loading');
-    fetchAttendees(slug)
-      .then(list => { setAttendees(list); setStatus('idle'); })
-      .catch(() => setStatus('error'));
-  }, [slug]);
+
+    resolveEventNodeId(parsed)
+      .then(nodeId => {
+        if (cancelled) return;
+        if (!nodeId) { setStatus('no-event'); return; }
+        return fetchAttendees(nodeId).then(list => {
+          if (!cancelled) { setAttendees(list); setStatus('idle'); }
+        });
+      })
+      .catch(() => { if (!cancelled) setStatus('error'); });
+
+    return () => { cancelled = true; };
+  }, [eventUrl]);
 
   return (
     <div style={{
@@ -112,10 +126,12 @@ export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
       </div>
 
       <div style={{ flex: 1, overflowY: 'auto', padding: '8px 0' }}>
-        {!greeterConfig || !slug ? (
-          <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>No event URL configured yet.</p>
+        {!greeterConfig || !eventUrl ? (
+          <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>No URL configured yet.</p>
         ) : status === 'loading' ? (
           <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>Loading attendees…</p>
+        ) : status === 'no-event' ? (
+          <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>No upcoming event found for this group.</p>
         ) : status === 'error' ? (
           <p style={{ color: '#a44', fontSize: 13, padding: '16px 20px' }}>Failed to load attendees.</p>
         ) : attendees.length === 0 ? (

--- a/app/components/GreeterPanel.tsx
+++ b/app/components/GreeterPanel.tsx
@@ -199,6 +199,16 @@ export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
   const currentEvent = events[currentIndex] ?? null;
   const isGroupMode = groupSlug !== null;
 
+  type SortMode = 'none' | 'first' | 'last';
+  const [sortMode, setSortMode] = useState<SortMode>('none');
+  const SORT_LABELS: Record<SortMode, string> = { none: 'Sort', first: 'First', last: 'Last' };
+  const SORT_CYCLE: SortMode[] = ['none', 'first', 'last'];
+
+  const sortedAttendees = sortMode === 'none' ? attendees : [...attendees].sort((a, b) => {
+    const key = sortMode === 'first' ? 'firstName' : 'lastName';
+    return a[key].localeCompare(b[key]);
+  });
+
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: '#0f0f0e', color: '#ccc', fontFamily: 'monospace', overflow: 'hidden' }}>
 
@@ -232,9 +242,16 @@ export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
               →
             </button>
           )}
-          {attendees.length > 0 && attendeeStatus === 'idle' && (
+          {attendees.length > 0 && attendeeStatus === 'idle' && (<>
+            <button
+              onClick={() => setSortMode(m => SORT_CYCLE[(SORT_CYCLE.indexOf(m) + 1) % SORT_CYCLE.length])}
+              style={{ background: 'none', border: 'none', color: sortMode === 'none' ? '#555' : '#aaa', cursor: 'pointer', fontSize: 11, padding: '2px 4px', flexShrink: 0 }}
+              title="Toggle sort order"
+            >
+              {SORT_LABELS[sortMode]} ↑
+            </button>
             <span style={{ fontSize: 12, color: '#555', flexShrink: 0 }}>{attendees.length}</span>
-          )}
+          </>)}
         </div>
       </div>
 
@@ -254,7 +271,7 @@ export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
         ) : attendees.length === 0 ? (
           <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>No in-person attendees found.</p>
         ) : (
-          attendees.map(a => (
+          sortedAttendees.map(a => (
             <div key={a.slugId} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 20px' }}>
               <img
                 src={a.photoUrl}

--- a/app/components/GreeterPanel.tsx
+++ b/app/components/GreeterPanel.tsx
@@ -268,19 +268,19 @@ export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
           <div style={{ display: 'flex', alignItems: 'center', paddingBottom: 8, borderTop: '1px solid #1a1a1a' }}>
             <button
               onClick={() => setSortMode(m => SORT_CYCLE[(SORT_CYCLE.indexOf(m) + 1) % SORT_CYCLE.length])}
-              style={{ background: 'none', border: 'none', color: sortMode === 'none' ? '#555' : '#aaa', cursor: 'pointer', fontSize: 11, padding: '6px 8px', flexShrink: 0 }}
+              style={{ background: 'none', border: 'none', color: sortMode === 'none' ? '#555' : '#aaa', cursor: 'pointer', fontSize: 11, padding: '6px 8px', flexShrink: 0, minWidth: 64, textAlign: 'center', marginLeft: 'auto' }}
               title="Toggle sort order"
             >
               {SORT_LABELS[sortMode]} ↑
             </button>
             <button
               onClick={() => setFilterMode(m => FILTER_CYCLE[(FILTER_CYCLE.indexOf(m) + 1) % FILTER_CYCLE.length])}
-              style={{ background: 'none', border: 'none', color: filterMode === 'all' ? '#555' : '#aaa', cursor: 'pointer', fontSize: 11, padding: '6px 8px', flexShrink: 0 }}
+              style={{ background: 'none', border: 'none', color: filterMode === 'all' ? '#555' : '#aaa', cursor: 'pointer', fontSize: 11, padding: '6px 8px', flexShrink: 0, minWidth: 80, textAlign: 'center' }}
               title="Toggle attendance filter"
             >
               {FILTER_LABELS[filterMode]}
             </button>
-            <span style={{ marginLeft: 'auto', fontSize: 12, color: '#555', padding: '6px 0' }}>{filteredAttendees.length}</span>
+            <span style={{ fontSize: 12, color: '#555', padding: '6px 8px', minWidth: 36, textAlign: 'right', display: 'inline-block' }}>{filteredAttendees.length}</span>
           </div>
         )}
       </div>

--- a/app/components/GreeterPanel.tsx
+++ b/app/components/GreeterPanel.tsx
@@ -1,0 +1,111 @@
+import { useState, useEffect } from "react";
+import type { GreeterConfig } from "../types";
+
+interface Attendee {
+  slugId: string;
+  firstName: string;
+  lastName: string;
+  photoUrl: string;
+}
+
+interface GreeterPanelProps {
+  greeterConfig: GreeterConfig | null;
+}
+
+const GRAPHQL_URL = 'https://guild.host/graphql/ab910738acdb79ffade614553f55523137c6968924e004a2e789faef52c0c081';
+
+function extractSlug(eventUrl: string): string | null {
+  try {
+    const path = new URL(eventUrl).pathname;
+    const segments = path.split('/').filter(Boolean);
+    const lastSegment = segments[segments.length - 1];
+    if (!lastSegment) return null;
+    // The API slug is the last hyphen-separated token (e.g. "civic-meetup-540-numbers-3onf9n" → "3onf9n")
+    const parts = lastSegment.split('-');
+    return parts[parts.length - 1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function fetchAttendees(slug: string): Promise<Attendee[]> {
+  const res = await fetch(GRAPHQL_URL, {
+    headers: { 'x-gqlvars': JSON.stringify({ slug }) },
+  });
+  if (!res.ok) throw new Error(`Guild API returned ${res.status}`);
+  const json = await res.json();
+  const edges: { node: { user: { slugId: string; firstName: string; lastName: string; primaryPhoto: { transformUrl: string } | null; defaultAvatarUrl: string } } }[] =
+    json?.data?.event?.inPersonAttendees?.edges ?? [];
+  return edges.map(({ node: { user } }) => ({
+    slugId: user.slugId,
+    firstName: user.firstName,
+    lastName: user.lastName,
+    photoUrl: user.primaryPhoto?.transformUrl ?? user.defaultAvatarUrl,
+  }));
+}
+
+export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
+  const [attendees, setAttendees] = useState<Attendee[]>([]);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error'>('idle');
+
+  const slug = greeterConfig ? extractSlug(greeterConfig.eventUrl) : null;
+
+  useEffect(() => {
+    if (!slug) {
+      setAttendees([]);
+      setStatus('idle');
+      return;
+    }
+    setStatus('loading');
+    fetchAttendees(slug)
+      .then(list => { setAttendees(list); setStatus('idle'); })
+      .catch(() => setStatus('error'));
+  }, [slug]);
+
+  return (
+    <div style={{
+      flex: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      background: '#0f0f0e',
+      color: '#ccc',
+      fontFamily: 'monospace',
+      overflow: 'hidden',
+    }}>
+      <div style={{ padding: '16px 20px 8px', borderBottom: '1px solid #222', flexShrink: 0 }}>
+        <span style={{ fontSize: 14, fontWeight: 600, color: '#eee' }}>In-Person Attendees</span>
+        {attendees.length > 0 && (
+          <span style={{ fontSize: 12, color: '#555', marginLeft: 8 }}>{attendees.length}</span>
+        )}
+      </div>
+
+      <div style={{ flex: 1, overflowY: 'auto', padding: '8px 0' }}>
+        {!greeterConfig || !slug ? (
+          <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>No event URL configured yet.</p>
+        ) : status === 'loading' ? (
+          <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>Loading attendees…</p>
+        ) : status === 'error' ? (
+          <p style={{ color: '#a44', fontSize: 13, padding: '16px 20px' }}>Failed to load attendees.</p>
+        ) : attendees.length === 0 ? (
+          <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>No in-person attendees found.</p>
+        ) : (
+          attendees.map(a => (
+            <div
+              key={a.slugId}
+              style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 20px' }}
+            >
+              <img
+                src={a.photoUrl}
+                alt={`${a.firstName} ${a.lastName}`}
+                width={36}
+                height={36}
+                style={{ borderRadius: '50%', flexShrink: 0, background: '#222' }}
+              />
+              <span style={{ fontSize: 14, color: '#ddd' }}>{a.firstName} {a.lastName}</span>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/GreeterPanel.tsx
+++ b/app/components/GreeterPanel.tsx
@@ -8,6 +8,12 @@ interface Attendee {
   photoUrl: string;
 }
 
+interface EventInfo {
+  id: string;
+  name: string;
+  startAt: string;
+}
+
 interface GreeterPanelProps {
   greeterConfig: GreeterConfig | null;
 }
@@ -23,12 +29,10 @@ function parseGuildUrl(url: string): ParsedUrl | null {
   try {
     const segments = new URL(url).pathname.split('/').filter(Boolean);
     if (segments[0] === 'events' && segments[1]) {
-      // e.g. /events/civic-meetup-540-numbers-3onf9n → slug = "3onf9n"
       const parts = segments[1].split('-');
       return { type: 'event', slug: parts[parts.length - 1] };
     }
     if (segments.length === 1) {
-      // e.g. /civic-tech-toronto
       return { type: 'group', groupSlug: segments[0] };
     }
     return null;
@@ -37,20 +41,31 @@ function parseGuildUrl(url: string): ParsedUrl | null {
   }
 }
 
-async function resolveEventNodeId(parsed: ParsedUrl): Promise<string | null> {
-  if (parsed.type === 'event') {
-    const res = await fetch(GRAPHQL_SLUG_URL, {
-      headers: { 'x-gqlvars': JSON.stringify({ slug: parsed.slug }) },
-    });
-    if (!res.ok) return null;
-    const json = await res.json();
-    return json?.data?.event?.id ?? null;
-  } else {
-    const res = await fetch(`https://guild.host/api/next/${parsed.groupSlug}/events/upcoming`);
-    if (!res.ok) return null;
-    const json = await res.json();
-    return json?.events?.edges?.[0]?.node?.id ?? null;
-  }
+async function fetchEventBySlug(slug: string): Promise<EventInfo | null> {
+  const res = await fetch(GRAPHQL_SLUG_URL, {
+    headers: { 'x-gqlvars': JSON.stringify({ slug }) },
+  });
+  if (!res.ok) return null;
+  const json = await res.json();
+  const e = json?.data?.event;
+  if (!e?.id) return null;
+  return { id: e.id, name: e.name ?? '', startAt: e.startAt ?? '' };
+}
+
+type EventsPage = { events: EventInfo[]; hasMore: boolean; endCursor: string | null };
+
+async function fetchEventsList(groupSlug: string, endpoint: 'upcoming' | 'past', after?: string): Promise<EventsPage> {
+  const url = new URL(`https://guild.host/api/next/${groupSlug}/events/${endpoint}`);
+  if (after) url.searchParams.set('after', after);
+  const res = await fetch(url.toString());
+  if (!res.ok) return { events: [], hasMore: false, endCursor: null };
+  const json = await res.json();
+  const edges: { node: { id: string; name: string; startAt: string } }[] = json?.events?.edges ?? [];
+  return {
+    events: edges.map(e => ({ id: e.node.id, name: e.node.name, startAt: e.node.startAt })),
+    hasMore: json?.events?.pageInfo?.hasNextPage ?? false,
+    endCursor: json?.events?.pageInfo?.endCursor ?? null,
+  };
 }
 
 async function fetchAttendees(nodeId: string): Promise<Attendee[]> {
@@ -72,76 +87,175 @@ async function fetchAttendees(nodeId: string): Promise<Attendee[]> {
   }));
 }
 
+function formatDate(iso: string): string {
+  if (!iso) return '';
+  try {
+    return new Date(iso).toLocaleDateString('en-CA', { month: 'short', day: 'numeric', year: 'numeric' });
+  } catch {
+    return '';
+  }
+}
+
 export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
+  const [events, setEvents] = useState<EventInfo[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [hasMorePast, setHasMorePast] = useState(false);
+  const [pastEndCursor, setPastEndCursor] = useState<string | null>(null);
+  const [groupSlug, setGroupSlug] = useState<string | null>(null);
   const [attendees, setAttendees] = useState<Attendee[]>([]);
-  const [status, setStatus] = useState<'idle' | 'loading' | 'no-event' | 'error'>('idle');
+  const [listStatus, setListStatus] = useState<'idle' | 'loading' | 'no-event' | 'error'>('idle');
+  const [attendeeStatus, setAttendeeStatus] = useState<'idle' | 'loading' | 'error'>('idle');
 
   const eventUrl = greeterConfig?.eventUrl ?? null;
 
+  // Load event list when URL changes
   useEffect(() => {
     if (!eventUrl) {
-      setAttendees([]);
-      setStatus('idle');
+      setEvents([]); setCurrentIndex(0); setGroupSlug(null); setListStatus('idle');
       return;
     }
-
     const parsed = parseGuildUrl(eventUrl);
     if (!parsed) {
-      setAttendees([]);
-      setStatus('idle');
+      setEvents([]); setCurrentIndex(0); setGroupSlug(null); setListStatus('idle');
       return;
     }
 
     let cancelled = false;
-    setStatus('loading');
+    setListStatus('loading');
+    setEvents([]);
+    setGroupSlug(null);
 
-    resolveEventNodeId(parsed)
-      .then(nodeId => {
+    if (parsed.type === 'event') {
+      fetchEventBySlug(parsed.slug).then(event => {
         if (cancelled) return;
-        if (!nodeId) { setStatus('no-event'); return; }
-        return fetchAttendees(nodeId).then(list => {
-          if (!cancelled) { setAttendees(list); setStatus('idle'); }
-        });
-      })
-      .catch(() => { if (!cancelled) setStatus('error'); });
+        if (!event) { setListStatus('no-event'); return; }
+        setEvents([event]);
+        setCurrentIndex(0);
+        setListStatus('idle');
+      }).catch(() => { if (!cancelled) setListStatus('error'); });
+    } else {
+      const slug = parsed.groupSlug;
+      Promise.all([
+        fetchEventsList(slug, 'upcoming'),
+        fetchEventsList(slug, 'past'),
+      ]).then(([upcoming, past]) => {
+        if (cancelled) return;
+        // past is newest-first; reverse to get chronological order for merging
+        const allEvents = [...[...past.events].reverse(), ...upcoming.events];
+        // Deduplicate by id in case cursors overlap
+        const seen = new Set<string>();
+        const deduped = allEvents.filter(e => { if (seen.has(e.id)) return false; seen.add(e.id); return true; });
+        if (deduped.length === 0) { setListStatus('no-event'); return; }
+        setEvents(deduped);
+        setHasMorePast(past.hasMore);
+        setPastEndCursor(past.endCursor);
+        setGroupSlug(slug);
+        // Default to first upcoming; fall back to most recent past
+        const idx = upcoming.events.length > 0 ? past.events.length : past.events.length - 1;
+        setCurrentIndex(Math.max(0, idx));
+        setListStatus('idle');
+      }).catch(() => { if (!cancelled) setListStatus('error'); });
+    }
 
     return () => { cancelled = true; };
-  }, [eventUrl]);
+  }, [eventUrl]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Fetch attendees when current event changes
+  const currentEventId = events[currentIndex]?.id ?? null;
+  useEffect(() => {
+    if (!currentEventId) { setAttendees([]); return; }
+    let cancelled = false;
+    setAttendeeStatus('loading');
+    fetchAttendees(currentEventId)
+      .then(list => { if (!cancelled) { setAttendees(list); setAttendeeStatus('idle'); } })
+      .catch(() => { if (!cancelled) setAttendeeStatus('error'); });
+    return () => { cancelled = true; };
+  }, [currentEventId]);
+
+  const handlePrev = async () => {
+    if (currentIndex > 0) {
+      setCurrentIndex(i => i - 1);
+    } else if (hasMorePast && groupSlug && pastEndCursor) {
+      const more = await fetchEventsList(groupSlug, 'past', pastEndCursor);
+      const reversed = [...more.events].reverse();
+      if (reversed.length === 0) return;
+      setEvents(prev => {
+        const seen = new Set(prev.map(e => e.id));
+        const fresh = reversed.filter(e => !seen.has(e.id));
+        return [...fresh, ...prev];
+      });
+      setHasMorePast(more.hasMore);
+      setPastEndCursor(more.endCursor);
+      setCurrentIndex(reversed.length - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (currentIndex < events.length - 1) setCurrentIndex(i => i + 1);
+  };
+
+  const canGoPrev = currentIndex > 0 || hasMorePast;
+  const canGoNext = currentIndex < events.length - 1;
+  const currentEvent = events[currentIndex] ?? null;
+  const isGroupMode = groupSlug !== null;
 
   return (
-    <div style={{
-      flex: 1,
-      display: 'flex',
-      flexDirection: 'column',
-      background: '#0f0f0e',
-      color: '#ccc',
-      fontFamily: 'monospace',
-      overflow: 'hidden',
-    }}>
-      <div style={{ padding: '16px 20px 8px', borderBottom: '1px solid #222', flexShrink: 0 }}>
-        <span style={{ fontSize: 14, fontWeight: 600, color: '#eee' }}>In-Person Attendees</span>
-        {attendees.length > 0 && (
-          <span style={{ fontSize: 12, color: '#555', marginLeft: 8 }}>{attendees.length}</span>
-        )}
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: '#0f0f0e', color: '#ccc', fontFamily: 'monospace', overflow: 'hidden' }}>
+
+      <div style={{ padding: '12px 20px 8px', borderBottom: '1px solid #222', flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          {isGroupMode && (
+            <button
+              onClick={handlePrev}
+              disabled={!canGoPrev}
+              style={{ background: 'none', border: 'none', color: canGoPrev ? '#aaa' : '#333', cursor: canGoPrev ? 'pointer' : 'default', padding: '0 4px', fontSize: 16, lineHeight: 1, flexShrink: 0 }}
+              aria-label="Previous event"
+            >
+              ←
+            </button>
+          )}
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, color: '#eee', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {currentEvent?.name || 'In-Person Attendees'}
+            </div>
+            {currentEvent?.startAt && (
+              <div style={{ fontSize: 11, color: '#666', marginTop: 1 }}>{formatDate(currentEvent.startAt)}</div>
+            )}
+          </div>
+          {isGroupMode && (
+            <button
+              onClick={handleNext}
+              disabled={!canGoNext}
+              style={{ background: 'none', border: 'none', color: canGoNext ? '#aaa' : '#333', cursor: canGoNext ? 'pointer' : 'default', padding: '0 4px', fontSize: 16, lineHeight: 1, flexShrink: 0 }}
+              aria-label="Next event"
+            >
+              →
+            </button>
+          )}
+          {attendees.length > 0 && attendeeStatus === 'idle' && (
+            <span style={{ fontSize: 12, color: '#555', flexShrink: 0 }}>{attendees.length}</span>
+          )}
+        </div>
       </div>
 
       <div style={{ flex: 1, overflowY: 'auto', padding: '8px 0' }}>
         {!greeterConfig || !eventUrl ? (
           <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>No URL configured yet.</p>
-        ) : status === 'loading' ? (
+        ) : listStatus === 'loading' ? (
+          <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>Loading…</p>
+        ) : listStatus === 'no-event' ? (
+          <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>No events found.</p>
+        ) : listStatus === 'error' ? (
+          <p style={{ color: '#a44', fontSize: 13, padding: '16px 20px' }}>Failed to load events.</p>
+        ) : attendeeStatus === 'loading' ? (
           <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>Loading attendees…</p>
-        ) : status === 'no-event' ? (
-          <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>No upcoming event found for this group.</p>
-        ) : status === 'error' ? (
+        ) : attendeeStatus === 'error' ? (
           <p style={{ color: '#a44', fontSize: 13, padding: '16px 20px' }}>Failed to load attendees.</p>
         ) : attendees.length === 0 ? (
           <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>No in-person attendees found.</p>
         ) : (
           attendees.map(a => (
-            <div
-              key={a.slugId}
-              style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 20px' }}
-            >
+            <div key={a.slugId} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '8px 20px' }}>
               <img
                 src={a.photoUrl}
                 alt={`${a.firstName} ${a.lastName}`}

--- a/app/components/GreeterPanel.tsx
+++ b/app/components/GreeterPanel.tsx
@@ -163,8 +163,18 @@ export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
         setHasMorePast(past.hasMore);
         setPastEndCursor(past.endCursor);
         setGroupSlug(slug);
-        // Default to first upcoming; fall back to most recent past
-        const idx = upcoming.events.length > 0 ? past.events.length : past.events.length - 1;
+        // Default: first upcoming, or most recent past if none
+        let idx = upcoming.events.length > 0 ? past.events.length : past.events.length - 1;
+        // Override: if any event starts today, prefer the last such event (stays "current" until midnight)
+        const today = new Date().toLocaleDateString('en-CA');
+        for (let i = deduped.length - 1; i >= 0; i--) {
+          try {
+            if (deduped[i].startAt && new Date(deduped[i].startAt).toLocaleDateString('en-CA') === today) {
+              idx = i;
+              break;
+            }
+          } catch { /* skip */ }
+        }
         setCurrentIndex(Math.max(0, idx));
         setListStatus('idle');
       }).catch(() => { if (!cancelled) setListStatus('error'); });

--- a/app/components/GreeterPanel.tsx
+++ b/app/components/GreeterPanel.tsx
@@ -28,20 +28,52 @@ function extractSlug(eventUrl: string): string | null {
   }
 }
 
-async function fetchAttendees(slug: string): Promise<Attendee[]> {
+type AttendeeEdge = {
+  cursor: string;
+  node: {
+    user: {
+      slugId: string;
+      firstName: string;
+      lastName: string;
+      primaryPhoto: { transformUrl: string } | null;
+      defaultAvatarUrl: string;
+    };
+  };
+};
+
+async function fetchPage(slug: string, after?: string): Promise<{ edges: AttendeeEdge[]; hasNextPage: boolean }> {
+  const vars: Record<string, unknown> = { slug };
+  if (after) vars.after = after;
   const res = await fetch(GRAPHQL_URL, {
-    headers: { 'x-gqlvars': JSON.stringify({ slug }) },
+    headers: { 'x-gqlvars': JSON.stringify(vars) },
   });
   if (!res.ok) throw new Error(`Guild API returned ${res.status}`);
   const json = await res.json();
-  const edges: { node: { user: { slugId: string; firstName: string; lastName: string; primaryPhoto: { transformUrl: string } | null; defaultAvatarUrl: string } } }[] =
-    json?.data?.event?.inPersonAttendees?.edges ?? [];
-  return edges.map(({ node: { user } }) => ({
-    slugId: user.slugId,
-    firstName: user.firstName,
-    lastName: user.lastName,
-    photoUrl: user.primaryPhoto?.transformUrl ?? user.defaultAvatarUrl,
-  }));
+  const attendees = json?.data?.event?.inPersonAttendees;
+  const edges: AttendeeEdge[] = attendees?.edges ?? [];
+  const hasNextPage: boolean = attendees?.pageInfo?.hasNextPage ?? (edges.length > 0 && edges.length === 10);
+  return { edges, hasNextPage };
+}
+
+async function fetchAttendees(slug: string): Promise<Attendee[]> {
+  const all: Attendee[] = [];
+  let after: string | undefined;
+
+  for (;;) {
+    const { edges, hasNextPage } = await fetchPage(slug, after);
+    for (const { cursor, node: { user } } of edges) {
+      all.push({
+        slugId: user.slugId,
+        firstName: user.firstName,
+        lastName: user.lastName,
+        photoUrl: user.primaryPhoto?.transformUrl ?? user.defaultAvatarUrl,
+      });
+      after = cursor;
+    }
+    if (!hasNextPage || edges.length === 0) break;
+  }
+
+  return all;
 }
 
 export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {

--- a/app/components/GreeterPanel.tsx
+++ b/app/components/GreeterPanel.tsx
@@ -6,6 +6,7 @@ interface Attendee {
   firstName: string;
   lastName: string;
   photoUrl: string;
+  attendance: 'in-person' | 'online';
 }
 
 interface EventInfo {
@@ -19,7 +20,8 @@ interface GreeterPanelProps {
 }
 
 const GRAPHQL_SLUG_URL = 'https://guild.host/graphql/ab910738acdb79ffade614553f55523137c6968924e004a2e789faef52c0c081';
-const GRAPHQL_ATTENDEES_URL = 'https://guild.host/graphql/f0f0595e0c3bc689857cd75b6e3d1e32de52fa6aeeb3671a69aa1b9e0986c5e0';
+const GRAPHQL_IN_PERSON_URL = 'https://guild.host/graphql/f0f0595e0c3bc689857cd75b6e3d1e32de52fa6aeeb3671a69aa1b9e0986c5e0';
+const GRAPHQL_ONLINE_URL = 'https://guild.host/graphql/1214f0d979f864bf430feb6f62c155cd533b3c8084ade0e530f31c1d76cf4ac4';
 
 type ParsedUrl =
   | { type: 'event'; slug: string }
@@ -68,8 +70,9 @@ async function fetchEventsList(groupSlug: string, endpoint: 'upcoming' | 'past',
   };
 }
 
-async function fetchAttendees(nodeId: string): Promise<Attendee[]> {
-  const res = await fetch(GRAPHQL_ATTENDEES_URL, {
+async function fetchAttendeesByType(nodeId: string, attendance: Attendee['attendance']): Promise<Attendee[]> {
+  const url = attendance === 'in-person' ? GRAPHQL_IN_PERSON_URL : GRAPHQL_ONLINE_URL;
+  const res = await fetch(url, {
     headers: {
       'content-type': 'application/json',
       'x-gqlvars': JSON.stringify({ id: nodeId, count: 200 }),
@@ -77,14 +80,24 @@ async function fetchAttendees(nodeId: string): Promise<Attendee[]> {
   });
   if (!res.ok) throw new Error(`Guild API returned ${res.status}`);
   const json = await res.json();
+  const key = attendance === 'in-person' ? 'inPersonAttendees' : 'onlineAttendees';
   const edges: { node: { user: { slugId: string; firstName: string; lastName: string; primaryPhoto: { transformUrl: string } | null; defaultAvatarUrl: string } } }[] =
-    json?.data?.node?.inPersonAttendees?.edges ?? [];
+    json?.data?.node?.[key]?.edges ?? [];
   return edges.map(({ node: { user } }) => ({
     slugId: user.slugId,
     firstName: user.firstName,
     lastName: user.lastName,
     photoUrl: user.primaryPhoto?.transformUrl ?? user.defaultAvatarUrl,
+    attendance,
   }));
+}
+
+async function fetchAllAttendees(nodeId: string): Promise<Attendee[]> {
+  const [inPerson, online] = await Promise.all([
+    fetchAttendeesByType(nodeId, 'in-person'),
+    fetchAttendeesByType(nodeId, 'online'),
+  ]);
+  return [...inPerson, ...online];
 }
 
 function formatDate(iso: string): string {
@@ -160,13 +173,18 @@ export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
     return () => { cancelled = true; };
   }, [eventUrl]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  type FilterMode = 'in-person' | 'online' | 'all';
+  const [filterMode, setFilterMode] = useState<FilterMode>('in-person');
+  const FILTER_LABELS: Record<FilterMode, string> = { 'in-person': 'In-person', 'online': 'Online', 'all': 'All' };
+  const FILTER_CYCLE: FilterMode[] = ['in-person', 'online', 'all'];
+
   // Fetch attendees when current event changes
   const currentEventId = events[currentIndex]?.id ?? null;
   useEffect(() => {
     if (!currentEventId) { setAttendees([]); return; }
     let cancelled = false;
     setAttendeeStatus('loading');
-    fetchAttendees(currentEventId)
+    fetchAllAttendees(currentEventId)
       .then(list => { if (!cancelled) { setAttendees(list); setAttendeeStatus('idle'); } })
       .catch(() => { if (!cancelled) setAttendeeStatus('error'); });
     return () => { cancelled = true; };
@@ -204,7 +222,8 @@ export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
   const SORT_LABELS: Record<SortMode, string> = { none: 'Sort', first: 'First', last: 'Last' };
   const SORT_CYCLE: SortMode[] = ['none', 'first', 'last'];
 
-  const sortedAttendees = sortMode === 'none' ? attendees : [...attendees].sort((a, b) => {
+  const filteredAttendees = filterMode === 'all' ? attendees : attendees.filter(a => a.attendance === filterMode);
+  const sortedAttendees = sortMode === 'none' ? filteredAttendees : [...filteredAttendees].sort((a, b) => {
     const key = sortMode === 'first' ? 'firstName' : 'lastName';
     return a[key].localeCompare(b[key]);
   });
@@ -244,13 +263,20 @@ export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
           )}
           {attendees.length > 0 && attendeeStatus === 'idle' && (<>
             <button
+              onClick={() => setFilterMode(m => FILTER_CYCLE[(FILTER_CYCLE.indexOf(m) + 1) % FILTER_CYCLE.length])}
+              style={{ background: 'none', border: 'none', color: filterMode === 'all' ? '#555' : '#aaa', cursor: 'pointer', fontSize: 11, padding: '2px 4px', flexShrink: 0 }}
+              title="Toggle attendance filter"
+            >
+              {FILTER_LABELS[filterMode]}
+            </button>
+            <button
               onClick={() => setSortMode(m => SORT_CYCLE[(SORT_CYCLE.indexOf(m) + 1) % SORT_CYCLE.length])}
               style={{ background: 'none', border: 'none', color: sortMode === 'none' ? '#555' : '#aaa', cursor: 'pointer', fontSize: 11, padding: '2px 4px', flexShrink: 0 }}
               title="Toggle sort order"
             >
               {SORT_LABELS[sortMode]} ↑
             </button>
-            <span style={{ fontSize: 12, color: '#555', flexShrink: 0 }}>{attendees.length}</span>
+            <span style={{ fontSize: 12, color: '#555', flexShrink: 0 }}>{filteredAttendees.length}</span>
           </>)}
         </div>
       </div>

--- a/app/components/GreeterPanel.tsx
+++ b/app/components/GreeterPanel.tsx
@@ -231,8 +231,9 @@ export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
   return (
     <div style={{ flex: 1, display: 'flex', flexDirection: 'column', background: '#0f0f0e', color: '#ccc', fontFamily: 'monospace', overflow: 'hidden' }}>
 
-      <div style={{ padding: '12px 20px 8px', borderBottom: '1px solid #222', flexShrink: 0 }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <div style={{ padding: '12px 20px 0', borderBottom: '1px solid #222', flexShrink: 0 }}>
+        {/* Row 1: event navigator */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingBottom: 8 }}>
           {isGroupMode && (
             <button
               onClick={handlePrev}
@@ -261,24 +262,27 @@ export default function GreeterPanel({ greeterConfig }: GreeterPanelProps) {
               →
             </button>
           )}
-          {attendees.length > 0 && attendeeStatus === 'idle' && (<>
-            <button
-              onClick={() => setFilterMode(m => FILTER_CYCLE[(FILTER_CYCLE.indexOf(m) + 1) % FILTER_CYCLE.length])}
-              style={{ background: 'none', border: 'none', color: filterMode === 'all' ? '#555' : '#aaa', cursor: 'pointer', fontSize: 11, padding: '2px 4px', flexShrink: 0 }}
-              title="Toggle attendance filter"
-            >
-              {FILTER_LABELS[filterMode]}
-            </button>
+        </div>
+        {/* Row 2: sort · filter · count */}
+        {attendees.length > 0 && attendeeStatus === 'idle' && (
+          <div style={{ display: 'flex', alignItems: 'center', paddingBottom: 8, borderTop: '1px solid #1a1a1a' }}>
             <button
               onClick={() => setSortMode(m => SORT_CYCLE[(SORT_CYCLE.indexOf(m) + 1) % SORT_CYCLE.length])}
-              style={{ background: 'none', border: 'none', color: sortMode === 'none' ? '#555' : '#aaa', cursor: 'pointer', fontSize: 11, padding: '2px 4px', flexShrink: 0 }}
+              style={{ background: 'none', border: 'none', color: sortMode === 'none' ? '#555' : '#aaa', cursor: 'pointer', fontSize: 11, padding: '6px 8px', flexShrink: 0 }}
               title="Toggle sort order"
             >
               {SORT_LABELS[sortMode]} ↑
             </button>
-            <span style={{ fontSize: 12, color: '#555', flexShrink: 0 }}>{filteredAttendees.length}</span>
-          </>)}
-        </div>
+            <button
+              onClick={() => setFilterMode(m => FILTER_CYCLE[(FILTER_CYCLE.indexOf(m) + 1) % FILTER_CYCLE.length])}
+              style={{ background: 'none', border: 'none', color: filterMode === 'all' ? '#555' : '#aaa', cursor: 'pointer', fontSize: 11, padding: '6px 8px', flexShrink: 0 }}
+              title="Toggle attendance filter"
+            >
+              {FILTER_LABELS[filterMode]}
+            </button>
+            <span style={{ marginLeft: 'auto', fontSize: 12, color: '#555', padding: '6px 0' }}>{filteredAttendees.length}</span>
+          </div>
+        )}
       </div>
 
       <div style={{ flex: 1, overflowY: 'auto', padding: '8px 0' }}>

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -6,7 +6,8 @@ import AdminPanelV4 from "./AdminPanelV4";
 import InterfaceChipBar from "./InterfaceChipBar";
 import SocialPanel from "./SocialPanel";
 import MoodTonesPanel from "./MoodTonesPanel";
-import type { ActivityMode, SocialConfig } from "../types";
+import GreeterPanel from "./GreeterPanel";
+import type { ActivityMode, GreeterConfig, SocialConfig } from "../types";
 import GithubUsernameModal from "./GithubUsernameModal";
 import FeedbackStarsModal from "./FeedbackStarsModal";
 import InterfacePushModal from "./InterfacePushModal";
@@ -59,6 +60,7 @@ function getUnlockedInterfaces(): string[] {
   if (p.get('interface') === 'social') interfaces.push('social');
   if (p.get('interface') === 'mood-tones') interfaces.push('mood-tones');
   if (p.get('interface') === 'treevites') interfaces.push('treevites');
+  if (p.get('interface') === 'greeter') interfaces.push('greeter');
   try {
     const stored = JSON.parse(localStorage.getItem(PUSHED_INTERFACES_KEY) ?? '[]');
     if (Array.isArray(stored)) {
@@ -133,6 +135,7 @@ export default function ReactionCanvasAppV4() {
   const [serverAnchors, setServerAnchors] = useState<ReactionAnchors | null>(null);
   const [serverImageUrl, setServerImageUrl] = useState('');
   const [serverSocialConfig, setServerSocialConfig] = useState<SocialConfig | null>(null);
+  const [serverGreeterConfig, setServerGreeterConfig] = useState<GreeterConfig | null>(null);
   const [nowLabel, setNowLabel] = useState('');
   const [activity, setActivity] = useState<ActivityMode>('canvas');
   const [debug, setDebug] = useState(() => new URLSearchParams(window.location.search).get('debug') === '1');
@@ -209,7 +212,7 @@ export default function ReactionCanvasAppV4() {
 
   const showChipBar = unlockedInterfaces.length >= 2;
   const chipBarOffset = showChipBar ? CHIP_BAR_HEIGHT : 0;
-  const KNOWN_CHIPS: Record<string, string> = { canvas: 'Canvas', emcee: 'Emcee', social: 'Social', 'mood-tones': 'Mood Tones', treevites: 'Leaderboard' };
+  const KNOWN_CHIPS: Record<string, string> = { canvas: 'Canvas', emcee: 'Emcee', social: 'Social', 'mood-tones': 'Mood Tones', treevites: 'Leaderboard', greeter: 'Greeter' };
   const INTERFACE_CHIPS = unlockedInterfaces.map(key => ({
     key,
     label: KNOWN_CHIPS[key] ?? (key.charAt(0).toUpperCase() + key.slice(1)),
@@ -232,6 +235,8 @@ export default function ReactionCanvasAppV4() {
         <MoodTonesPanel room={room} />
       ) : activeInterface === 'treevites' ? (
         <Treevites selfId={userId} inviteEdges={inviteEdges} />
+      ) : activeInterface === 'greeter' ? (
+        <GreeterPanel greeterConfig={serverGreeterConfig} />
       ) : null}
       {/* When activity is 'social', show SocialPanel as a flex sibling (fills the
           remaining height below the chip bar, same as the chip-based case).
@@ -245,8 +250,11 @@ export default function ReactionCanvasAppV4() {
       {activeInterface === 'canvas' && activity === 'treevites' && (
         <Treevites selfId={userId} inviteEdges={inviteEdges} />
       )}
+      {activeInterface === 'canvas' && activity === 'greeter' && (
+        <GreeterPanel greeterConfig={serverGreeterConfig} />
+      )}
       {/* Canvas is always mounted to keep the WebSocket alive for all interfaces */}
-      <div className="v2-vote-canvas-container" style={{ flex: 1, display: (activeInterface === 'canvas' && activity !== 'social' && activity !== 'mood-tones' && activity !== 'treevites') ? undefined : 'none' }}>
+      <div className="v2-vote-canvas-container" style={{ flex: 1, display: (activeInterface === 'canvas' && activity !== 'social' && activity !== 'mood-tones' && activity !== 'treevites' && activity !== 'greeter') ? undefined : 'none' }}>
           {activity === 'image-canvas' && serverImageUrl && (
             <img
               src={serverImageUrl}
@@ -339,6 +347,7 @@ export default function ReactionCanvasAppV4() {
             onRoomImageUrlChange={handleRoomImageUrlChange}
             onActivityChange={handleActivityChange}
             onSocialConfigChange={setServerSocialConfig}
+            onGreeterConfigChange={setServerGreeterConfig}
             onNowLabelChange={setNowLabel}
             onInviteEdges={(edges) => setInviteEdges(prev => ({ ...prev, ...edges }))}
             debug={debug}
@@ -351,7 +360,7 @@ export default function ReactionCanvasAppV4() {
               {nowLabel}
             </div>
           )}
-          {!isViewer && activity !== 'social' && (
+          {!isViewer && activity !== 'social' && activity !== 'greeter' && (
             <TouchLayer
               room={room}
               userId={userId}

--- a/app/components/SocialConfigModal.tsx
+++ b/app/components/SocialConfigModal.tsx
@@ -33,7 +33,7 @@ export default function SocialConfigModal({ onSubmit, onClose, current }: Social
               value={defaultText}
               onChange={e => setDefaultText(e.target.value)}
               placeholder="some text and #hashtag"
-              autoFocus
+
             />
           </label>
           <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>

--- a/app/types.ts
+++ b/app/types.ts
@@ -28,7 +28,11 @@ export interface Statement {
   text: string;
 }
 
-export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social' | 'mood-tones' | 'treevites';
+export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social' | 'mood-tones' | 'treevites' | 'greeter';
+
+export interface GreeterConfig {
+  eventUrl: string;
+}
 
 export interface SocialConfig {
   default: string;

--- a/party/server.ts
+++ b/party/server.ts
@@ -141,6 +141,11 @@ interface SetSocialConfigEvent {
   config: { default: string; twitter: string; bluesky: string; mastodon: string } | null;
 }
 
+interface SetGreeterConfigEvent {
+  type: 'setGreeterConfig';
+  config: { eventUrl: string } | null;
+}
+
 interface SubmitGithubUsernameEvent {
   type: 'submitGithubUsername';
   username: string;
@@ -201,7 +206,7 @@ interface RecordInvitationsEvent {
   edges: Array<[string, string]>; // [inviterId, inviteeId]
 }
 
-type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent;
+type ClientEvent = CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | SetGreeterConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent;
 
 // ===== REACTION REGION HELPER (mirrors app/utils/voteRegion.ts) =====
 const DEFAULT_ANCHORS = {
@@ -258,6 +263,7 @@ export default class Server implements Party.Server {
   private roomImageUrl: string = '';
   private nowLabel: string = '';
   private roomSocialConfig: { default: string; twitter: string; bluesky: string; mastodon: string } | null = null;
+  private greeterConfig: { eventUrl: string } | null = null;
   private ballState = { x: 50, y: 50, vx: 2, vy: 1 };
   private soccerScore = { left: 0, right: 0 };
   private githubSubmissions: { username: string; displayName: string | null; avatarUrl: string | null; timestamp: number }[] = [];
@@ -418,6 +424,7 @@ export default class Server implements Party.Server {
       roomImageUrl: this.roomImageUrl,
       nowLabel: this.nowLabel,
       roomSocialConfig: this.roomSocialConfig,
+      greeterConfig: this.greeterConfig,
       ballState: this.currentActivity === 'soccer' ? this.ballState : null,
       soccerScore: this.soccerScore,
       isViewer,
@@ -568,6 +575,9 @@ export default class Server implements Party.Server {
       } else if (event.type === 'setSocialConfig') {
         this.roomSocialConfig = event.config;
         this.room.broadcast(JSON.stringify({ type: 'socialConfigChanged', config: this.roomSocialConfig }));
+      } else if (event.type === 'setGreeterConfig') {
+        this.greeterConfig = event.config;
+        this.room.broadcast(JSON.stringify({ type: 'greeterConfigChanged', config: this.greeterConfig }));
       } else if (event.type === 'requestJoin') {
         if (!this.viewerConnectionIds.has(sender.id)) return;
         if (this.userCap !== null && this.participantCount() >= this.userCap) {


### PR DESCRIPTION
## Summary

- New **Greeter** interface: emcee configures a Guild event URL via a gear-icon modal in the Interfaces tab (same UX as Social Sharing)
- `GreeterPanel` extracts the event slug from the URL, fetches in-person attendees from the Guild GraphQL API, and renders a scrollable list with each person's photo and name
- Patchable via QR code in the Interfaces tab "Share" column; pushable to participants from the People tab (`OfferInterfaceModal` now includes `greeter` as an option)
- Follows the exact same data-flow pattern as `social`/`mood-tones`/`treevites`: server stores config, broadcasts `greeterConfigChanged`, included in initial `connected` message

## Test plan

- [ ] Open `localhost:1999#v4?interface=emcee` → Interfaces tab → verify **Greeter** row appears with gear icon
- [ ] Click gear → enter a Guild event URL (e.g. `https://guild.host/events/civic-meetup-540-numbers-3onf9n`) → Save
- [ ] Select Greeter radio → verify participants on other tabs/windows switch to Greeter mode showing the attendee list
- [ ] Open `localhost:1999#v4?interface=greeter` → verify attendee list loads with photos and names
- [ ] From People tab → offer interface to a participant → verify `greeter` appears in the select dropdown
- [ ] `pnpm tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~120 words of PR description from ~200 words of human prompts across this session)