### PR TITLE
feat: QR copy button everywhere + Share/Scan tab in V4 canvas popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ### Fixed
 - V4: admin-triggered popups (interface offer, GitHub username, feedback stars, haptic modal) now appear for participants even when they are viewing a non-canvas interface (Social, Greeter, etc.) — modals were previously hidden because they rendered inside a `display: none` canvas container.
+- V4: stray haptic buzz no longer fires when a tab wakes from sleep or the server restarts — the `connected` re-sync no longer routes through `onActivityChange`; only genuine `activityChanged` events from the server trigger a buzz.
 
 ### Added
 - Greeter Quiz: **Reversed mode** — a "Reversed" checkbox flips which side is the prompt vs. the answer (name → photo for Image/Name; first name → last name for Last/First). Progress is tracked separately for each direction, so memorizing forward does not count as memorizing reversed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 23 (2026-04-27)
 
 ### Added
+- All QR displays: **copy-to-clipboard button** beside the URL text — one tap copies the URL with a 2-second checkmark confirmation; falls back to `execCommand` for iOS Safari / HTTP contexts.
+- V4 canvas QR popup: **Share / Scan tab switcher** — Share tab shows the existing QR code and copy button; Scan tab opens the device camera to scan a QR code and navigate to the scanned URL in-place. Camera permission is requested lazily when the Scan tab is opened and released on close.
 - Server: **persistent social config** — `roomSocialConfig` is now saved to PartyKit durable storage and restored on worker restart. Opt out per deployment with `DISABLE_STORAGE_PERSISTENCE=true`.
 - Greeter config modal now pre-fills with `https://guild.host/civic-tech-toronto` when no config is set.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ If the user says "push" or "commit" right after one was already done, treat it a
 
 **Always merge PRs with** `gh pr merge --merge --delete-branch` to delete both the local and remote branch automatically after merging. Only skip `--delete-branch` if explicitly asked to keep the branch.
 
-**Always update `CHANGELOG.md`** when making any user-facing change (features, fixes, behaviour changes, config changes). Do this in the same commit as the code change. Add entries under the current week's section (e.g. `## Week 22 (2026-04-20)`); if it doesn't exist yet, create it at the top. Week 0 starts Mon 2025-11-17; each week is +7 days (the date in the header is the Monday the week starts on). Releases cut every Monday morning ET — start a new week section on each Monday. Link each entry to the relevant PR, issue, or commit (in that priority order).
+**Always update `CHANGELOG.md`** when making any user-facing change (features, fixes, behaviour changes, config changes). Do this in the same commit as the code change. Add entries under the current week's section (e.g. `## Week 22 (2026-04-20)`); if it doesn't exist yet, create it at the top. Week 0 starts Mon 2025-11-17; each week is +7 days (the date in the header is the Monday the week starts on). Releases cut every Monday morning ET — start a new week section on each Monday at **7am ET** (not midnight; before 7am Monday still belongs to the previous week's section). Link each entry to the relevant PR, issue, or commit (in that priority order).
 
 ## Dev commands
 

--- a/app/client.tsx
+++ b/app/client.tsx
@@ -2,8 +2,8 @@ import "./styles.css";
 declare const PARTYKIT_EVENT_BUILD: boolean;
 import { createRoot } from "react-dom/client";
 import { useState, useEffect } from "react";
-import { QRCodeSVG } from "qrcode.react";
 import SimpleReactionCanvasAppV1 from "./components/SimpleReactionCanvasAppV1";
+import QRWithCopy from "./components/QRWithCopy";
 import ReactionCanvasAppV2 from "./components/ReactionCanvasAppV2";
 import ReactionCanvasAppV4 from "./components/ReactionCanvasAppV4";
 import ReactionCanvasAppV5 from "./components/ReactionCanvasAppV5";
@@ -15,8 +15,7 @@ function IndexApp() {
     <div className="index-app">
       <h1 className="index-title">Polislike Reaction Canvas Apps</h1>
       <div className="index-qr">
-        <QRCodeSVG value={pageUrl} size={120} />
-        <p className="index-qr-label">{pageUrl}</p>
+        <QRWithCopy url={pageUrl} size={120} urlClassName="index-qr-label" qrClassName="index-qr-code" />
       </div>
       <div className="app-cards">
         <a href="?room=irc6creOFGs#v5" className="app-card app-card--youtube">

--- a/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
+++ b/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { QRCodeSVG } from "qrcode.react";
 import { IoMdSettings } from "react-icons/io";
+import QRWithCopy from '../../QRWithCopy';
 import type { ActivityMode } from "../../../types";
 import { appendSelfToChain } from "../../../utils/inviteChain";
 
@@ -160,10 +160,7 @@ export default function InterfacesTab({
         <div className="share-qr-modal" onClick={() => setPatchInterface(null)}>
           <div className="share-qr-modal-card" onClick={e => e.stopPropagation()}>
             <p className="share-qr-modal-title">{ROWS.find(r => r.id === patchInterface)?.label} — add without push</p>
-            <div className="v2-mobile-gate-qr">
-              <QRCodeSVG value={patchUrl} size={220} />
-            </div>
-            <p className="share-qr-modal-url">{patchUrl}</p>
+            <QRWithCopy url={patchUrl} />
             <button className="share-qr-modal-close" onClick={() => setPatchInterface(null)}>Close</button>
           </div>
         </div>

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -49,7 +49,7 @@ interface CanvasProps {
   onActivityChange?: (activity: ActivityMode) => void;
   onSocialConfigChange?: (config: { default: string; twitter: string; bluesky: string; mastodon: string; instagram: string } | null) => void;
   onGreeterConfigChange?: (config: GreeterConfig | null) => void;
-  onConnected?: (initialInviteEdges?: Record<string, string>) => void;
+  onConnected?: (initialInviteEdges?: Record<string, string>, currentActivity?: ActivityMode) => void;
   onNowLabelChange?: (label: string) => void;
   onInviteEdges?: (edges: Record<string, string>) => void;
 }
@@ -136,7 +136,6 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
           if ('currentActivity' in data) {
             const act = data.currentActivity ?? 'canvas';
             setActivity(act);
-            onActivityChange?.(act);
           }
           if ('roomImageUrl' in data) {
             const url = data.roomImageUrl ?? '';
@@ -154,7 +153,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
           if ('greeterConfig' in data) onGreeterConfigChange?.(data.greeterConfig ?? null);
           onConnectedAsViewer?.(data.isViewer ?? false, data.userCap ?? null);
           onViewerCount?.(data.viewerCount ?? 0);
-          onConnected?.(data.inviteEdges ?? undefined);
+          onConnected?.(data.inviteEdges ?? undefined, 'currentActivity' in data ? (data.currentActivity ?? 'canvas') : undefined);
           return;
         }
 

--- a/app/components/QRWithCopy.tsx
+++ b/app/components/QRWithCopy.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+
+interface QRWithCopyProps {
+  url: string;
+  size?: number;
+  urlClassName?: string;
+  qrClassName?: string;
+}
+
+export default function QRWithCopy({
+  url,
+  size = 220,
+  urlClassName = 'share-qr-modal-url',
+  qrClassName = 'v2-mobile-gate-qr',
+}: QRWithCopyProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch {
+      const el = document.createElement('textarea');
+      el.value = url;
+      el.style.cssText = 'position:fixed;opacity:0;top:0;left:0';
+      document.body.appendChild(el);
+      el.focus();
+      el.select();
+      document.execCommand('copy');
+      document.body.removeChild(el);
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <>
+      <div className={qrClassName}>
+        <QRCodeSVG value={url} size={size} />
+      </div>
+      <div className="qr-url-row">
+        <p className={urlClassName}>{url}</p>
+        <button
+          className={`qr-copy-btn${copied ? ' qr-copy-btn--copied' : ''}`}
+          onClick={handleCopy}
+          aria-label={copied ? "Copied!" : "Copy URL"}
+          title={copied ? "Copied!" : "Copy URL"}
+        >
+          {copied ? (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          ) : (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+          )}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/app/components/ReactionCanvasAppV2.tsx
+++ b/app/components/ReactionCanvasAppV2.tsx
@@ -8,6 +8,7 @@ import { DEFAULT_ANCHORS, reactionLabelStyle } from "../utils/voteRegion";
 import type { ReactionAnchors } from "../utils/voteRegion";
 import { getPersistentUserId } from "../utils/userId";
 import ShareQRButton from "./ShareQRButton";
+import QRWithCopy from "./QRWithCopy";
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
 
@@ -41,10 +42,7 @@ function MobileOnlyGate() {
       <div className="v2-mobile-gate-content">
         <p className="v2-mobile-gate-message">This experience is designed for mobile touch devices.</p>
         <p className="v2-mobile-gate-sub">Scan the QR code on your phone to open this page:</p>
-        <div className="v2-mobile-gate-qr">
-          <QRCodeSVG value={url} size={220} />
-        </div>
-        <p className="v2-mobile-gate-url">{url}</p>
+        <QRWithCopy url={url} urlClassName="v2-mobile-gate-url" />
       </div>
       <a href={bypassHref} className="v2-mobile-gate-bypass">bypass</a>
     </div>

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -1,5 +1,4 @@
 import { useState, useRef, useEffect, useCallback } from "react";
-import { QRCodeSVG } from "qrcode.react";
 import Canvas from "./Canvas";
 import TouchLayer from "./TouchLayer";
 import AdminPanelV4 from "./AdminPanelV4";
@@ -20,6 +19,7 @@ import { getReactionLabelSet } from "../voteLabels";
 import type { ReactionLabelSet } from "../voteLabels";
 import { getPersistentUserId } from "../utils/userId";
 import ShareQRButton from "./ShareQRButton";
+import QRWithCopy from "./QRWithCopy";
 import { parseInviteChain, appendSelfToChain, chainToEdges, storeChain, getStoredChain } from "../utils/inviteChain";
 import HapticIndicatorButton from "./HapticIndicatorButton";
 import Treevites from "./Treevites";
@@ -84,10 +84,7 @@ function MobileOnlyGate() {
       <div className="v2-mobile-gate-content">
         <p className="v2-mobile-gate-message">This experience is designed for mobile touch devices.</p>
         <p className="v2-mobile-gate-sub">Scan the QR code on your phone to open this page:</p>
-        <div className="v2-mobile-gate-qr">
-          <QRCodeSVG value={url} size={220} />
-        </div>
-        <p className="v2-mobile-gate-url">{url}</p>
+        <QRWithCopy url={url} urlClassName="v2-mobile-gate-url" />
       </div>
       <a href={bypassHref} className="v2-mobile-gate-bypass">bypass</a>
     </div>

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -302,8 +302,9 @@ export default function ReactionCanvasAppV4() {
             onActiveCursorCountChange={setActiveCursorCount}
             onSimulatedCursorCountChange={setSimulatedCursorCount}
             onRecordingStateChange={setIsRecording}
-            onConnected={(initialInviteEdges) => {
+            onConnected={(initialInviteEdges, currentActivity) => {
               hasConnectedRef.current = true;
+              if (currentActivity) setActivity(currentActivity);
               if (initialInviteEdges) setInviteEdges(initialInviteEdges);
               const myChain = appendSelfToChain(selfChain, userId);
               const edges = chainToEdges(myChain);

--- a/app/components/ReactionCanvasAppV5.tsx
+++ b/app/components/ReactionCanvasAppV5.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from "react";
-import { QRCodeSVG } from "qrcode.react";
 import Canvas from "./Canvas";
 import TouchLayer from "./TouchLayer";
 import AdminPanelV5 from "./AdminPanelV5";
@@ -12,6 +11,7 @@ import { insertEvent, fetchEvents, isSupabaseConfigured, testConnection } from "
 import type { ReactionEvent } from "../lib/supabase";
 import { getPersistentUserId } from "../utils/userId";
 import ShareQRButton from "./ShareQRButton";
+import QRWithCopy from "./QRWithCopy";
 
 declare global {
   interface Window {
@@ -74,10 +74,7 @@ function MobileOnlyGate() {
       <div className="v2-mobile-gate-content">
         <p className="v2-mobile-gate-message">This experience is designed for mobile touch devices.</p>
         <p className="v2-mobile-gate-sub">Scan the QR code on your phone to open this page:</p>
-        <div className="v2-mobile-gate-qr">
-          <QRCodeSVG value={url} size={220} />
-        </div>
-        <p className="v2-mobile-gate-url">{url}</p>
+        <QRWithCopy url={url} urlClassName="v2-mobile-gate-url" />
       </div>
       <a href={bypassHref} className="v2-mobile-gate-bypass">bypass</a>
     </div>

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Scanner } from "@yudiel/react-qr-scanner";
+import { WebHaptics } from "web-haptics";
 import { useWebHaptics } from "web-haptics/react";
 import { appendSelfToChain } from "../utils/inviteChain";
 import QRWithCopy from "./QRWithCopy";
@@ -26,7 +27,8 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
   const [activeTab, setActiveTab] = useState<'share' | 'scan'>('share');
   const [cameraState, setCameraState] = useState<'idle' | 'active' | 'error'>('idle');
   const [foreignDomain, setForeignDomain] = useState<string | null>(null);
-  const { trigger: triggerHaptic } = useWebHaptics({ debug: navigator.maxTouchPoints === 0 });
+  // Enable audio fallback on desktop (no touch) and Apple devices (no navigator.vibrate API)
+  const { trigger: triggerHaptic } = useWebHaptics({ debug: navigator.maxTouchPoints === 0 || !WebHaptics.isSupported });
   const url = getShareUrl(selfId, selfChain);
 
   const handleTabChange = (tab: 'share' | 'scan') => {

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { Scanner } from "@yudiel/react-qr-scanner";
 import { appendSelfToChain } from "../utils/inviteChain";
 import QRWithCopy from "./QRWithCopy";
@@ -15,6 +15,34 @@ function getShareUrl(selfId?: string, selfChain?: string[]): string {
   return `${window.location.origin}${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
 }
 
+// Short filtered noise burst — same technique as web-haptics desktop audio fallback.
+// AudioContext must already be initialized (within a prior user gesture).
+function playConfirmClick(ctx: AudioContext) {
+  const duration = 0.004;
+  const buffer = ctx.createBuffer(1, Math.ceil(ctx.sampleRate * duration), ctx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < data.length; i++) {
+    data[i] = (Math.random() * 2 - 1) * Math.exp(-i / 25);
+  }
+
+  const filter = ctx.createBiquadFilter();
+  filter.type = 'bandpass';
+  filter.frequency.value = 3000 + Math.random() * 500;
+  filter.Q.value = 8;
+
+  const gain = ctx.createGain();
+  gain.gain.value = 0.4;
+
+  filter.connect(gain);
+  gain.connect(ctx.destination);
+
+  const source = ctx.createBufferSource();
+  source.buffer = buffer;
+  source.connect(filter);
+  source.onended = () => source.disconnect();
+  source.start();
+}
+
 interface ShareQRButtonProps {
   selfId?: string;
   selfChain?: string[];
@@ -24,11 +52,23 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
   const [isOpen, setIsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<'share' | 'scan'>('share');
   const [cameraState, setCameraState] = useState<'idle' | 'active' | 'error'>('idle');
+  // Initialized within the Scan tab click gesture so it's unlocked for later playback
+  const audioCtxRef = useRef<AudioContext | null>(null);
   const url = getShareUrl(selfId, selfChain);
 
   const handleTabChange = (tab: 'share' | 'scan') => {
     setActiveTab(tab);
-    setCameraState(tab === 'scan' ? 'active' : 'idle');
+    if (tab === 'scan') {
+      setCameraState('active');
+      // Initialize AudioContext within the user gesture so it's pre-unlocked for scan feedback
+      if (!audioCtxRef.current && typeof AudioContext !== 'undefined') {
+        audioCtxRef.current = new AudioContext();
+      } else if (audioCtxRef.current?.state === 'suspended') {
+        audioCtxRef.current.resume();
+      }
+    } else {
+      setCameraState('idle');
+    }
   };
 
   const handleClose = () => {
@@ -42,10 +82,17 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
     if (!raw) return;
     try {
       const scanned = new URL(raw);
-      if (scanned.protocol === 'http:' || scanned.protocol === 'https:') {
-        window.location.href = raw;
-      }
-    } catch { /* not a URL */ }
+      if (scanned.protocol !== 'http:' && scanned.protocol !== 'https:') return;
+    } catch { return; }
+
+    // Haptic on mobile; subtle click sound on desktop (web-haptics fallback technique)
+    if (navigator.vibrate) {
+      navigator.vibrate([50]);
+    } else if (audioCtxRef.current) {
+      playConfirmClick(audioCtxRef.current);
+    }
+
+    window.location.href = raw;
   };
 
   return (
@@ -84,6 +131,7 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
                 <Scanner
                   onScan={handleScanResult}
                   onError={() => setCameraState('error')}
+                  sound={false}
                   styles={{ container: { width: '100%', borderRadius: 12 } }}
                 />
               </div>

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -133,38 +133,41 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
               </button>
             </div>
             {activeTab === 'share' && (
-              <QRWithCopy url={url} />
+              <QRWithCopy url={url} qrClassName="share-qr-code-wrap" />
             )}
             {activeTab === 'scan' && (
-              <div className="share-qr-scanner-wrap">
-                {cameraState === 'active' && !foreignDomain && (
-                  <Scanner
-                    onScan={handleScanResult}
-                    onError={() => setCameraState('error')}
-                    sound={false}
-                    styles={{ container: { width: '100%', borderRadius: 12 } }}
-                  />
-                )}
-                {foreignDomain && (
-                  <div className="share-qr-foreign-warn">
-                    <p className="share-qr-foreign-warn-text">
-                      This QR code points to a different site:
-                    </p>
-                    <p className="share-qr-foreign-warn-domain">{foreignDomain}</p>
-                    <button
-                      className="share-qr-modal-close"
-                      onClick={() => setForeignDomain(null)}
-                    >
-                      Scan again
-                    </button>
-                  </div>
-                )}
-                {cameraState === 'error' && (
-                  <div className="share-qr-foreign-warn">
-                    <p className="share-qr-scan-error">Camera unavailable. Check permissions.</p>
-                  </div>
-                )}
-              </div>
+              <>
+                <div className="share-qr-scanner-wrap">
+                  {cameraState === 'active' && !foreignDomain && (
+                    <Scanner
+                      onScan={handleScanResult}
+                      onError={() => setCameraState('error')}
+                      sound={false}
+                      styles={{ container: { width: '100%', borderRadius: 12 } }}
+                    />
+                  )}
+                  {foreignDomain && (
+                    <div className="share-qr-foreign-warn">
+                      <p className="share-qr-foreign-warn-text">
+                        This QR code points to a different site:
+                      </p>
+                      <p className="share-qr-foreign-warn-domain">{foreignDomain}</p>
+                      <button
+                        className="share-qr-modal-close"
+                        onClick={() => setForeignDomain(null)}
+                      >
+                        Scan again
+                      </button>
+                    </div>
+                  )}
+                  {cameraState === 'error' && (
+                    <div className="share-qr-foreign-warn">
+                      <p className="share-qr-scan-error">Camera unavailable. Check permissions.</p>
+                    </div>
+                  )}
+                </div>
+                <div className="qr-url-row" aria-hidden="true" />
+              </>
             )}
             <button className="share-qr-modal-close" onClick={handleClose}>Close</button>
           </div>

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef } from "react";
+import { useState } from "react";
 import { Scanner } from "@yudiel/react-qr-scanner";
+import { useWebHaptics } from "web-haptics/react";
 import { appendSelfToChain } from "../utils/inviteChain";
 import QRWithCopy from "./QRWithCopy";
 
@@ -15,34 +16,6 @@ function getShareUrl(selfId?: string, selfChain?: string[]): string {
   return `${window.location.origin}${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
 }
 
-// Short filtered noise burst — same technique as web-haptics desktop audio fallback.
-// AudioContext must already be initialized (within a prior user gesture).
-function playConfirmClick(ctx: AudioContext) {
-  const duration = 0.004;
-  const buffer = ctx.createBuffer(1, Math.ceil(ctx.sampleRate * duration), ctx.sampleRate);
-  const data = buffer.getChannelData(0);
-  for (let i = 0; i < data.length; i++) {
-    data[i] = (Math.random() * 2 - 1) * Math.exp(-i / 25);
-  }
-
-  const filter = ctx.createBiquadFilter();
-  filter.type = 'bandpass';
-  filter.frequency.value = 3000 + Math.random() * 500;
-  filter.Q.value = 8;
-
-  const gain = ctx.createGain();
-  gain.gain.value = 0.4;
-
-  filter.connect(gain);
-  gain.connect(ctx.destination);
-
-  const source = ctx.createBufferSource();
-  source.buffer = buffer;
-  source.connect(filter);
-  source.onended = () => source.disconnect();
-  source.start();
-}
-
 interface ShareQRButtonProps {
   selfId?: string;
   selfChain?: string[];
@@ -53,8 +26,7 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
   const [activeTab, setActiveTab] = useState<'share' | 'scan'>('share');
   const [cameraState, setCameraState] = useState<'idle' | 'active' | 'error'>('idle');
   const [foreignDomain, setForeignDomain] = useState<string | null>(null);
-  // Initialized within the Scan tab click gesture so it's unlocked for later playback
-  const audioCtxRef = useRef<AudioContext | null>(null);
+  const { trigger: triggerHaptic } = useWebHaptics();
   const url = getShareUrl(selfId, selfChain);
 
   const handleTabChange = (tab: 'share' | 'scan') => {
@@ -62,12 +34,6 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
     setForeignDomain(null);
     if (tab === 'scan') {
       setCameraState('active');
-      // Initialize AudioContext within the user gesture so it's pre-unlocked for scan feedback
-      if (!audioCtxRef.current && typeof AudioContext !== 'undefined') {
-        audioCtxRef.current = new AudioContext();
-      } else if (audioCtxRef.current?.state === 'suspended') {
-        audioCtxRef.current.resume();
-      }
     } else {
       setCameraState('idle');
     }
@@ -91,15 +57,11 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
 
     if (scanned.hostname !== window.location.hostname) {
       setForeignDomain(scanned.hostname);
+      triggerHaptic('error');
       return;
     }
 
-    // Haptic on mobile; subtle click sound on desktop (web-haptics fallback technique)
-    if (navigator.vibrate) {
-      navigator.vibrate([50]);
-    } else if (audioCtxRef.current) {
-      playConfirmClick(audioCtxRef.current);
-    }
+    triggerHaptic('nudge');
 
     window.location.href = raw;
   };
@@ -138,27 +100,14 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
             {activeTab === 'scan' && (
               <>
                 <div className="share-qr-scanner-wrap">
-                  {cameraState === 'active' && !foreignDomain && (
+                  {cameraState === 'active' && (
                     <Scanner
                       onScan={handleScanResult}
                       onError={() => setCameraState('error')}
                       sound={false}
+                      components={{ torch: false }}
                       styles={{ container: { width: '100%', borderRadius: 12 } }}
                     />
-                  )}
-                  {foreignDomain && (
-                    <div className="share-qr-foreign-warn">
-                      <p className="share-qr-foreign-warn-text">
-                        This QR code points to a different site:
-                      </p>
-                      <p className="share-qr-foreign-warn-domain">{foreignDomain}</p>
-                      <button
-                        className="share-qr-modal-close"
-                        onClick={() => setForeignDomain(null)}
-                      >
-                        Scan again
-                      </button>
-                    </div>
                   )}
                   {cameraState === 'error' && (
                     <div className="share-qr-foreign-warn">
@@ -166,7 +115,14 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
                     </div>
                   )}
                 </div>
-                <div className="qr-url-row" aria-hidden="true" />
+                {foreignDomain ? (
+                  <div className="qr-url-row">
+                    <p className="share-qr-foreign-warn-text">scanned domain mismatch</p>
+                    <button className="qr-copy-btn" onClick={() => setForeignDomain(null)} aria-label="Dismiss">✕</button>
+                  </div>
+                ) : (
+                  <div className="qr-url-row" aria-hidden="true" />
+                )}
               </>
             )}
             <button className="share-qr-modal-close" onClick={handleClose}>Close</button>

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Scanner } from "@yudiel/react-qr-scanner";
+import { WebHaptics } from "web-haptics";
 import { useWebHaptics } from "web-haptics/react";
 import { appendSelfToChain } from "../utils/inviteChain";
 import QRWithCopy from "./QRWithCopy";
@@ -26,7 +27,7 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
   const [activeTab, setActiveTab] = useState<'share' | 'scan'>('share');
   const [cameraState, setCameraState] = useState<'idle' | 'active' | 'error'>('idle');
   const [foreignDomain, setForeignDomain] = useState<string | null>(null);
-  const { trigger: triggerHaptic } = useWebHaptics({ debug: true });
+  const { trigger: triggerHaptic } = useWebHaptics({ debug: !WebHaptics.isSupported });
   const url = getShareUrl(selfId, selfChain);
 
   const handleTabChange = (tab: 'share' | 'scan') => {
@@ -47,6 +48,7 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
   };
 
   const handleScanResult = (codes: { rawValue: string }[]) => {
+    if (foreignDomain) return;
     const raw = codes[0]?.rawValue;
     if (!raw) return;
     let scanned: URL;

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -34,6 +34,7 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
     setForeignDomain(null);
     if (tab === 'scan') {
       setCameraState('active');
+      triggerHaptic(0); // pre-warm AudioContext within the user gesture
     } else {
       setCameraState('idle');
     }

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
-import { QRCodeSVG } from "qrcode.react";
+import { Scanner } from "@yudiel/react-qr-scanner";
 import { appendSelfToChain } from "../utils/inviteChain";
+import QRWithCopy from "./QRWithCopy";
 
 function getShareUrl(selfId?: string, selfChain?: string[]): string {
   const p = new URLSearchParams(window.location.search);
@@ -21,7 +22,31 @@ interface ShareQRButtonProps {
 
 export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps = {}) {
   const [isOpen, setIsOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState<'share' | 'scan'>('share');
+  const [cameraState, setCameraState] = useState<'idle' | 'active' | 'error'>('idle');
   const url = getShareUrl(selfId, selfChain);
+
+  const handleTabChange = (tab: 'share' | 'scan') => {
+    setActiveTab(tab);
+    setCameraState(tab === 'scan' ? 'active' : 'idle');
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setActiveTab('share');
+    setCameraState('idle');
+  };
+
+  const handleScanResult = (codes: { rawValue: string }[]) => {
+    const raw = codes[0]?.rawValue;
+    if (!raw) return;
+    try {
+      const scanned = new URL(raw);
+      if (scanned.protocol === 'http:' || scanned.protocol === 'https:') {
+        window.location.href = raw;
+      }
+    } catch { /* not a URL */ }
+  };
 
   return (
     <>
@@ -32,14 +57,41 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
         </svg>
       </button>
       {isOpen && (
-        <div className="share-qr-modal" onClick={() => setIsOpen(false)}>
+        <div className="share-qr-modal" onClick={handleClose}>
           <div className="share-qr-modal-card" onClick={e => e.stopPropagation()}>
-            <p className="share-qr-modal-title">Share this page</p>
-            <div className="v2-mobile-gate-qr">
-              <QRCodeSVG value={url} size={220} />
+            <p className="share-qr-modal-title">
+              {activeTab === 'share' ? 'Share this page' : 'Scan QR Code'}
+            </p>
+            <div className="share-qr-tab-bar">
+              <button
+                className={`share-qr-tab-btn${activeTab === 'share' ? ' share-qr-tab-btn--active' : ''}`}
+                onClick={() => handleTabChange('share')}
+              >
+                Share
+              </button>
+              <button
+                className={`share-qr-tab-btn${activeTab === 'scan' ? ' share-qr-tab-btn--active' : ''}`}
+                onClick={() => handleTabChange('scan')}
+              >
+                Scan
+              </button>
             </div>
-            <p className="share-qr-modal-url">{url}</p>
-            <button className="share-qr-modal-close" onClick={() => setIsOpen(false)}>Close</button>
+            {activeTab === 'share' && (
+              <QRWithCopy url={url} />
+            )}
+            {activeTab === 'scan' && cameraState === 'active' && (
+              <div className="share-qr-scanner-wrap">
+                <Scanner
+                  onScan={handleScanResult}
+                  onError={() => setCameraState('error')}
+                  styles={{ container: { width: '100%', borderRadius: 12 } }}
+                />
+              </div>
+            )}
+            {activeTab === 'scan' && cameraState === 'error' && (
+              <p className="share-qr-scan-error">Camera unavailable. Check permissions.</p>
+            )}
+            <button className="share-qr-modal-close" onClick={handleClose}>Close</button>
           </div>
         </div>
       )}

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -135,32 +135,36 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
             {activeTab === 'share' && (
               <QRWithCopy url={url} />
             )}
-            {activeTab === 'scan' && cameraState === 'active' && !foreignDomain && (
+            {activeTab === 'scan' && (
               <div className="share-qr-scanner-wrap">
-                <Scanner
-                  onScan={handleScanResult}
-                  onError={() => setCameraState('error')}
-                  sound={false}
-                  styles={{ container: { width: '100%', borderRadius: 12 } }}
-                />
+                {cameraState === 'active' && !foreignDomain && (
+                  <Scanner
+                    onScan={handleScanResult}
+                    onError={() => setCameraState('error')}
+                    sound={false}
+                    styles={{ container: { width: '100%', borderRadius: 12 } }}
+                  />
+                )}
+                {foreignDomain && (
+                  <div className="share-qr-foreign-warn">
+                    <p className="share-qr-foreign-warn-text">
+                      This QR code points to a different site:
+                    </p>
+                    <p className="share-qr-foreign-warn-domain">{foreignDomain}</p>
+                    <button
+                      className="share-qr-modal-close"
+                      onClick={() => setForeignDomain(null)}
+                    >
+                      Scan again
+                    </button>
+                  </div>
+                )}
+                {cameraState === 'error' && (
+                  <div className="share-qr-foreign-warn">
+                    <p className="share-qr-scan-error">Camera unavailable. Check permissions.</p>
+                  </div>
+                )}
               </div>
-            )}
-            {activeTab === 'scan' && foreignDomain && (
-              <div className="share-qr-foreign-warn">
-                <p className="share-qr-foreign-warn-text">
-                  This QR code points to a different site:
-                </p>
-                <p className="share-qr-foreign-warn-domain">{foreignDomain}</p>
-                <button
-                  className="share-qr-modal-close"
-                  onClick={() => setForeignDomain(null)}
-                >
-                  Scan again
-                </button>
-              </div>
-            )}
-            {activeTab === 'scan' && cameraState === 'error' && (
-              <p className="share-qr-scan-error">Camera unavailable. Check permissions.</p>
             )}
             <button className="share-qr-modal-close" onClick={handleClose}>Close</button>
           </div>

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -52,12 +52,14 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
   const [isOpen, setIsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<'share' | 'scan'>('share');
   const [cameraState, setCameraState] = useState<'idle' | 'active' | 'error'>('idle');
+  const [foreignDomain, setForeignDomain] = useState<string | null>(null);
   // Initialized within the Scan tab click gesture so it's unlocked for later playback
   const audioCtxRef = useRef<AudioContext | null>(null);
   const url = getShareUrl(selfId, selfChain);
 
   const handleTabChange = (tab: 'share' | 'scan') => {
     setActiveTab(tab);
+    setForeignDomain(null);
     if (tab === 'scan') {
       setCameraState('active');
       // Initialize AudioContext within the user gesture so it's pre-unlocked for scan feedback
@@ -75,15 +77,22 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
     setIsOpen(false);
     setActiveTab('share');
     setCameraState('idle');
+    setForeignDomain(null);
   };
 
   const handleScanResult = (codes: { rawValue: string }[]) => {
     const raw = codes[0]?.rawValue;
     if (!raw) return;
+    let scanned: URL;
     try {
-      const scanned = new URL(raw);
+      scanned = new URL(raw);
       if (scanned.protocol !== 'http:' && scanned.protocol !== 'https:') return;
     } catch { return; }
+
+    if (scanned.hostname !== window.location.hostname) {
+      setForeignDomain(scanned.hostname);
+      return;
+    }
 
     // Haptic on mobile; subtle click sound on desktop (web-haptics fallback technique)
     if (navigator.vibrate) {
@@ -126,7 +135,7 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
             {activeTab === 'share' && (
               <QRWithCopy url={url} />
             )}
-            {activeTab === 'scan' && cameraState === 'active' && (
+            {activeTab === 'scan' && cameraState === 'active' && !foreignDomain && (
               <div className="share-qr-scanner-wrap">
                 <Scanner
                   onScan={handleScanResult}
@@ -134,6 +143,20 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
                   sound={false}
                   styles={{ container: { width: '100%', borderRadius: 12 } }}
                 />
+              </div>
+            )}
+            {activeTab === 'scan' && foreignDomain && (
+              <div className="share-qr-foreign-warn">
+                <p className="share-qr-foreign-warn-text">
+                  This QR code points to a different site:
+                </p>
+                <p className="share-qr-foreign-warn-domain">{foreignDomain}</p>
+                <button
+                  className="share-qr-modal-close"
+                  onClick={() => setForeignDomain(null)}
+                >
+                  Scan again
+                </button>
               </div>
             )}
             {activeTab === 'scan' && cameraState === 'error' && (

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Scanner } from "@yudiel/react-qr-scanner";
-import { WebHaptics } from "web-haptics";
 import { useWebHaptics } from "web-haptics/react";
 import { appendSelfToChain } from "../utils/inviteChain";
 import QRWithCopy from "./QRWithCopy";
@@ -27,7 +26,7 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
   const [activeTab, setActiveTab] = useState<'share' | 'scan'>('share');
   const [cameraState, setCameraState] = useState<'idle' | 'active' | 'error'>('idle');
   const [foreignDomain, setForeignDomain] = useState<string | null>(null);
-  const { trigger: triggerHaptic } = useWebHaptics({ debug: !WebHaptics.isSupported });
+  const { trigger: triggerHaptic } = useWebHaptics({ debug: navigator.maxTouchPoints === 0 });
   const url = getShareUrl(selfId, selfChain);
 
   const handleTabChange = (tab: 'share' | 'scan') => {

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -66,7 +66,9 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
 
     triggerHaptic('nudge');
 
-    window.location.href = raw;
+    const forceView = new URLSearchParams(window.location.search).get('forceView');
+    if (forceView) scanned.searchParams.set('forceView', forceView);
+    window.location.href = scanned.toString();
   };
 
   return (

--- a/app/components/ShareQRButton.tsx
+++ b/app/components/ShareQRButton.tsx
@@ -26,7 +26,7 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
   const [activeTab, setActiveTab] = useState<'share' | 'scan'>('share');
   const [cameraState, setCameraState] = useState<'idle' | 'active' | 'error'>('idle');
   const [foreignDomain, setForeignDomain] = useState<string | null>(null);
-  const { trigger: triggerHaptic } = useWebHaptics();
+  const { trigger: triggerHaptic } = useWebHaptics({ debug: true });
   const url = getShareUrl(selfId, selfChain);
 
   const handleTabChange = (tab: 'share' | 'scan') => {
@@ -34,7 +34,6 @@ export default function ShareQRButton({ selfId, selfChain }: ShareQRButtonProps 
     setForeignDomain(null);
     if (tab === 'scan') {
       setCameraState('active');
-      triggerHaptic(0); // pre-warm AudioContext within the user gesture
     } else {
       setCameraState('idle');
     }

--- a/app/styles.css
+++ b/app/styles.css
@@ -1638,6 +1638,7 @@ body {
   align-items: center;
   gap: 6px;
   width: 100%;
+  min-height: 26px;
 }
 
 .qr-url-row p {
@@ -1714,9 +1715,20 @@ body {
   color: #fff;
 }
 
+/* Same as .v2-mobile-gate-qr but without the margin-bottom that fights the modal flex gap */
+.share-qr-code-wrap {
+  background: #fff;
+  padding: 16px;
+  border-radius: 12px;
+  line-height: 0;
+}
+
+
 .share-qr-scanner-wrap {
-  width: 100%;
-  aspect-ratio: 1;
+  width: 252px;
+  height: 252px;
+  max-width: 100%;
+  flex-shrink: 0;
   border-radius: 12px;
   overflow: hidden;
   background: #000;

--- a/app/styles.css
+++ b/app/styles.css
@@ -1635,6 +1635,90 @@ body {
   color: #fff;
 }
 
+.qr-url-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  justify-content: center;
+}
+
+.qr-copy-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: #555;
+  padding: 2px 4px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  transition: color 0.15s ease;
+}
+
+.qr-copy-btn:hover {
+  color: #aaa;
+}
+
+.qr-copy-btn--copied {
+  color: #4caf50;
+}
+
+.index-qr .qr-copy-btn {
+  color: #bbb;
+}
+
+.index-qr .qr-copy-btn:hover {
+  color: #666;
+}
+
+.share-qr-tab-bar {
+  display: flex;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid #333;
+  width: 100%;
+}
+
+.share-qr-tab-btn {
+  flex: 1;
+  background: transparent;
+  border: none;
+  color: #888;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 8px 0;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+  font-family: monospace;
+}
+
+.share-qr-tab-btn:hover {
+  background: rgba(255, 255, 255, 0.05);
+  color: #ccc;
+}
+
+.share-qr-tab-btn--active {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+}
+
+.share-qr-scanner-wrap {
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #000;
+}
+
+.share-qr-scan-error {
+  color: #e57373;
+  font-size: 13px;
+  text-align: center;
+  padding: 16px 0;
+  font-family: monospace;
+}
+
 .github-modal-login {
   color: #888;
   font-size: 13px;

--- a/app/styles.css
+++ b/app/styles.css
@@ -1638,7 +1638,7 @@ body {
   align-items: center;
   gap: 6px;
   width: 100%;
-  min-height: 26px;
+  min-height: 18px;
 }
 
 .qr-url-row p {
@@ -1726,14 +1726,10 @@ body {
 
 .share-qr-scanner-wrap {
   width: 252px;
-  height: 252px;
-  max-width: 100%;
-  flex-shrink: 0;
+  aspect-ratio: 1;
   border-radius: 12px;
   overflow: hidden;
   background: #000;
-  display: flex;
-  align-items: stretch;
 }
 
 .share-qr-scan-error {

--- a/app/styles.css
+++ b/app/styles.css
@@ -1719,6 +1719,36 @@ body {
   font-family: monospace;
 }
 
+.share-qr-foreign-warn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 16px 0;
+  width: 100%;
+}
+
+.share-qr-foreign-warn-text {
+  color: #e57373;
+  font-size: 13px;
+  text-align: center;
+  margin: 0;
+  font-family: monospace;
+}
+
+.share-qr-foreign-warn-domain {
+  color: #888;
+  font-size: 12px;
+  font-family: monospace;
+  word-break: break-all;
+  text-align: center;
+  margin: 0;
+  padding: 6px 12px;
+  background: rgba(229, 115, 115, 0.1);
+  border-radius: 6px;
+  border: 1px solid rgba(229, 115, 115, 0.25);
+}
+
 .github-modal-login {
   color: #888;
   font-size: 13px;

--- a/app/styles.css
+++ b/app/styles.css
@@ -1709,6 +1709,8 @@ body {
   border-radius: 12px;
   overflow: hidden;
   background: #000;
+  display: flex;
+  align-items: stretch;
 }
 
 .share-qr-scan-error {
@@ -1723,9 +1725,11 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
-  padding: 16px 0;
+  justify-content: center;
+  gap: 12px;
   width: 100%;
+  padding: 16px;
+  box-sizing: border-box;
 }
 
 .share-qr-foreign-warn-text {

--- a/app/styles.css
+++ b/app/styles.css
@@ -763,7 +763,6 @@ body {
 .v2-mobile-gate-url {
   font-size: 12px;
   color: #666;
-  word-break: break-all;
   font-family: monospace;
 }
 
@@ -1614,7 +1613,6 @@ body {
 .share-qr-modal-url {
   font-size: 11px;
   color: #666;
-  word-break: break-all;
   font-family: monospace;
   margin: 0;
 }
@@ -1640,7 +1638,20 @@ body {
   align-items: center;
   gap: 6px;
   width: 100%;
-  justify-content: center;
+}
+
+.qr-url-row p {
+  flex: 1;
+  min-width: 0;
+  overflow-x: auto;
+  white-space: nowrap;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  margin: 0;
+}
+
+.qr-url-row p::-webkit-scrollbar {
+  display: none;
 }
 
 .qr-copy-btn {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@supabase/supabase-js": "^2.98.0",
     "@types/d3": "^7.4.3",
+    "@yudiel/react-qr-scanner": "^2.5.1",
     "d3": "^7.9.0",
     "ghost-cursor": "^1.4.1",
     "partysocket": "^1.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/d3':
         specifier: ^7.4.3
         version: 7.4.3
+      '@yudiel/react-qr-scanner':
+        specifier: ^2.5.1
+        version: 2.5.1(@types/emscripten@1.41.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       d3:
         specifier: ^7.9.0
         version: 7.9.0
@@ -937,6 +940,9 @@ packages:
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
+  '@types/emscripten@1.41.5':
+    resolution: {integrity: sha512-cMQm7pxu6BxtHyqJ7mQZ2kXWV5SLmugybFdHCBbJ5eHzOo6VhBckEgAT3//rP5FwPHNPeEiq4SmQ5ucBwsOo4Q==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1042,6 +1048,12 @@ packages:
   '@webgpu/types@0.1.69':
     resolution: {integrity: sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==}
 
+  '@yudiel/react-qr-scanner@2.5.1':
+    resolution: {integrity: sha512-FWzHaCneu30mQpE80VNWx4IPtBjXFEiTzhwWunZy3afvvAy/x0aVIgYijJKEbROoaAeDfcJ/gIyUCqPBP7bMOw==}
+    peerDependencies:
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
     engines: {node: '>=0.4.0'}
@@ -1091,6 +1103,9 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  barcode-detector@3.0.8:
+    resolution: {integrity: sha512-Z9jzzE8ngEDyN9EU7lWdGgV07mcnEQnrX8W9WecXDqD2v+5CcVjt9+a134a5zb+kICvpsrDx6NYA6ay4LGFs8A==}
 
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
@@ -1839,6 +1854,9 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  sdp@3.2.2:
+    resolution: {integrity: sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -1932,6 +1950,10 @@ packages:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
     engines: {node: '>=18'}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   three@0.183.2:
     resolution: {integrity: sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==}
 
@@ -1975,6 +1997,10 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -2111,6 +2137,10 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
+  webrtc-adapter@9.0.3:
+    resolution: {integrity: sha512-5fALBcroIl31OeXAdd1YUntxiZl1eHlZZWzNg3U4Fn+J9/cGL3eT80YlrsWGvj2ojuz1rZr2OXkgCzIxAZ7vRQ==}
+    engines: {node: '>=6.0.0', npm: '>=3.10.0'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2153,6 +2183,11 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zxing-wasm@2.2.4:
+    resolution: {integrity: sha512-1gq5zs4wuNTs5umWLypzNNeuJoluFvwmvjiiT3L9z/TMlVveeJRWy7h90xyUqCe+Qq0zL0w7o5zkdDMWDr9aZA==}
+    peerDependencies:
+      '@types/emscripten': '>=1.39.6'
 
 snapshots:
 
@@ -2901,6 +2936,8 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
+  '@types/emscripten@1.41.5': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/geojson@7946.0.16': {}
@@ -3055,6 +3092,15 @@ snapshots:
 
   '@webgpu/types@0.1.69': {}
 
+  '@yudiel/react-qr-scanner@2.5.1(@types/emscripten@1.41.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      barcode-detector: 3.0.8(@types/emscripten@1.41.5)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      webrtc-adapter: 9.0.3
+    transitivePeerDependencies:
+      - '@types/emscripten'
+
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.16.0
@@ -3092,6 +3138,12 @@ snapshots:
   axe-core@4.11.3: {}
 
   balanced-match@4.0.4: {}
+
+  barcode-detector@3.0.8(@types/emscripten@1.41.5):
+    dependencies:
+      zxing-wasm: 2.2.4(@types/emscripten@1.41.5)
+    transitivePeerDependencies:
+      - '@types/emscripten'
 
   baseline-browser-mapping@2.10.20: {}
 
@@ -3843,6 +3895,8 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  sdp@3.2.2: {}
+
   semver@6.3.1: {}
 
   semver@7.7.4: {}
@@ -3924,6 +3978,8 @@ snapshots:
 
   system-architecture@0.1.0: {}
 
+  tagged-tag@1.0.0: {}
+
   three@0.183.2: {}
 
   tiny-invariant@1.3.3: {}
@@ -3954,6 +4010,10 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
 
@@ -4030,6 +4090,10 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
+  webrtc-adapter@9.0.3:
+    dependencies:
+      sdp: 3.2.2
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -4064,3 +4128,8 @@ snapshots:
       stacktracey: 2.2.0
 
   zod@3.25.76: {}
+
+  zxing-wasm@2.2.4(@types/emscripten@1.41.5):
+    dependencies:
+      '@types/emscripten': 1.41.5
+      type-fest: 5.6.0


### PR DESCRIPTION
## Summary

- Adds a one-tap **copy-to-clipboard button** beside the URL text under every QR code in the app (V2/V4/V5 mobile gate, V4 canvas share popup, InterfacesTab patch dialog, landing page). Extracts a shared `QRWithCopy` component to avoid duplication. Falls back to `execCommand('copy')` for iOS Safari and HTTP contexts.
- Adds a **Share / Scan tab switcher** to the V4 canvas QR popup (`ShareQRButton`): the Share tab shows the current QR + copy button; the Scan tab opens the device camera and navigates to any scanned URL in-place — no camera app, no new tab. Camera permission is lazy (only requested when Scan tab is opened) and released when switching away or closing the modal.

## Test plan

- [ ] Open V4 canvas on desktop with `?forceView=mobile` — mobile gate QR shows copy button; tapping it copies the URL with a 2s checkmark
- [ ] Open V4 canvas on mobile — tap share (QR icon) button → Share tab visible with QR + copy button
- [ ] Switch to Scan tab → browser prompts for camera permission → camera feed appears
- [ ] Scan a QR code → page navigates to the scanned URL
- [ ] Close modal → reopen → should default back to Share tab
- [ ] Open landing page → copy button appears beside the small QR
- [ ] Open InterfacesTab, click Share QR for Social interface → copy button appears
- [ ] `pnpm tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~120 words of PR description from ~90 words of human prompts across this session)