### PR TITLE
feat: add orientation-based valence input modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 25 (2026-05-11)
 
 ### Added
-- Canvas settings modal: **Valence Input tab** — emcee can now switch participants between Touch (default), Orientation (Horizontal), and Orientation (Vertical) input modes. In orientation modes the cursor travels along the disagree → pass → agree path based on phone tilt angle. Requires HTTPS (works on deployed app; blocked by Chrome on local-network HTTP). iOS prompts for permission; Android and other platforms require no permission.
+- Canvas settings modal: **Valence Input tab** — emcee can now switch participants between four input modes ([#82](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/82)):
+  - **Touch** (default) — finger position on canvas
+  - **Orientation (Horizontal)** — phone face-up = agree, face-down = disagree; works for any flip direction or combination (`cos β · cos γ`)
+  - **Orientation (Vertical)** — phone upright = agree, flat = pass, upside-down = disagree (`sin β`)
+  - **Orientation (Rotation)** — steering-wheel from landscape: rotate right toward portrait = agree, rotate left toward upside-down = disagree (`cos(atan2(γ, β))`)
+- In orientation modes the cursor travels through the triangle centroid (barycentric centre) rather than along the edges, giving a direct disagree → centre → agree path.
+- Orientation modes require HTTPS; blocked by Chrome on plain HTTP LAN. iOS prompts for `DeviceOrientationEvent` permission on first tap; Android and other platforms require no permission.
+- `pnpm dev-https` script — runs `partykit dev --live --https` for local HTTPS testing of orientation APIs on LAN devices.
+
+### Fixed
+- WebSocket connections now use `wss://` when the page is served over HTTPS, preventing mixed-content errors on LAN addresses (`192.168.x.x`). Extracted shared `getPartySocketConfig()` utility (`app/utils/partyHost.ts`) used by all six socket-holding components. ([#82](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/82))
 
 ## Week 24 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. Releases cut every Monday morning ET; each section header is `## Week N (YYYY-MM-DD)` where the date is the Monday that week starts on, and Week 0 = 2025-11-17.
 
+## Week 25 (2026-05-11)
+
+### Added
+- Canvas settings modal: **Valence Input tab** — emcee can now switch participants between Touch (default), Orientation (Horizontal), and Orientation (Vertical) input modes. In orientation modes the cursor travels along the disagree → pass → agree path based on phone tilt angle. Requires HTTPS (works on deployed app; blocked by Chrome on local-network HTTP). iOS prompts for permission; Android and other platforms require no permission.
+
 ## Week 24 (2026-05-04)
 
 ### Added

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,0 @@
-:1443 {
-	tls internal
-	reverse_proxy localhost:1999
-}

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,4 @@
 :1443 {
+	tls internal
 	reverse_proxy localhost:1999
 }

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,3 @@
+:1443 {
+	reverse_proxy localhost:1999
+}

--- a/app/components/AdminPanel.tsx
+++ b/app/components/AdminPanel.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import usePartySocket from "partysocket/react";
-import { getPartyHost } from "../utils/partyHost";
+import { getPartySocketConfig } from "../utils/partyHost";
 import CountdownTimer from "./CountdownTimer";
 import type { PolisStatement, QueueItem, Statement } from "../types";
 
@@ -27,7 +27,7 @@ export default function AdminPanel({ room }: AdminPanelProps) {
   const [ghostCursorsEnabled, setGhostCursorsEnabled] = useState(false);
 
   const socket = usePartySocket({
-    host: getPartyHost(),
+    ...getPartySocketConfig(),
     room: room,
     query: { isAdmin: 'true' },
     onMessage(evt) {

--- a/app/components/AdminPanel.tsx
+++ b/app/components/AdminPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import usePartySocket from "partysocket/react";
+import { getPartyHost } from "../utils/partyHost";
 import CountdownTimer from "./CountdownTimer";
 import type { PolisStatement, QueueItem, Statement } from "../types";
 
@@ -26,7 +27,7 @@ export default function AdminPanel({ room }: AdminPanelProps) {
   const [ghostCursorsEnabled, setGhostCursorsEnabled] = useState(false);
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : window.location.hostname,
+    host: getPartyHost(),
     room: room,
     query: { isAdmin: 'true' },
     onMessage(evt) {

--- a/app/components/AdminPanelV4/CanvasSettingsModal.tsx
+++ b/app/components/AdminPanelV4/CanvasSettingsModal.tsx
@@ -21,7 +21,7 @@ const VALENCE_INPUT_OPTIONS: { value: ValenceInputMode; label: string; descripti
   { value: 'touch', label: 'Touch', description: 'Move your finger across the canvas to express your reaction' },
   { value: 'orientation-horizontal', label: 'Orientation (Horizontal)', description: 'Face-up = agree, face-down = disagree — works for any flip direction or combination' },
   { value: 'orientation-vertical', label: 'Orientation (Vertical)', description: 'Phone upright = agree, phone flat = pass, phone upside-down = disagree' },
-  { value: 'orientation-rotation', label: 'Orientation (Rotation)', description: 'Steering wheel — phone upright portrait = pass, rotate clockwise = agree, counter-clockwise = disagree' },
+  { value: 'orientation-rotation', label: 'Orientation (Rotation)', description: 'Steering wheel — landscape = pass, rotate right toward portrait = agree, rotate left toward upside-down = disagree' },
 ];
 
 export default function CanvasSettingsModal({ showNowLabel, onChangeShowNowLabel, ownValenceDisplay, onChangeOwnValenceDisplay, valenceInputMode, onChangeValenceInputMode, onClose }: CanvasSettingsModalProps) {

--- a/app/components/AdminPanelV4/CanvasSettingsModal.tsx
+++ b/app/components/AdminPanelV4/CanvasSettingsModal.tsx
@@ -19,7 +19,7 @@ const OWN_VALENCE_OPTIONS: { value: 'background' | 'labels' | 'none'; label: str
 
 const VALENCE_INPUT_OPTIONS: { value: ValenceInputMode; label: string; description: string }[] = [
   { value: 'touch', label: 'Touch', description: 'Move your finger across the canvas to express your reaction' },
-  { value: 'orientation-horizontal', label: 'Orientation (Horizontal)', description: 'Phone face-up = agree, edge-on = pass, face-down = disagree' },
+  { value: 'orientation-horizontal', label: 'Orientation (Horizontal)', description: 'Flip phone sideways on table — face-up = agree, edge-on = pass, face-down = disagree' },
   { value: 'orientation-vertical', label: 'Orientation (Vertical)', description: 'Phone upright = agree, phone flat = pass, phone upside-down = disagree' },
 ];
 

--- a/app/components/AdminPanelV4/CanvasSettingsModal.tsx
+++ b/app/components/AdminPanelV4/CanvasSettingsModal.tsx
@@ -21,6 +21,7 @@ const VALENCE_INPUT_OPTIONS: { value: ValenceInputMode; label: string; descripti
   { value: 'touch', label: 'Touch', description: 'Move your finger across the canvas to express your reaction' },
   { value: 'orientation-horizontal', label: 'Orientation (Horizontal)', description: 'Face-up = agree, face-down = disagree — works for any flip direction or combination' },
   { value: 'orientation-vertical', label: 'Orientation (Vertical)', description: 'Phone upright = agree, phone flat = pass, phone upside-down = disagree' },
+  { value: 'orientation-rotation', label: 'Orientation (Rotation)', description: 'Steering wheel — phone upright portrait = pass, rotate clockwise = agree, counter-clockwise = disagree' },
 ];
 
 export default function CanvasSettingsModal({ showNowLabel, onChangeShowNowLabel, ownValenceDisplay, onChangeOwnValenceDisplay, valenceInputMode, onChangeValenceInputMode, onClose }: CanvasSettingsModalProps) {
@@ -104,11 +105,9 @@ export default function CanvasSettingsModal({ showNowLabel, onChangeShowNowLabel
                 </label>
               ))}
             </div>
-            {valenceInputMode !== 'touch' && (
-              <p style={{ color: '#666', fontSize: 12, marginBottom: 20 }}>
-                In orientation mode, the cursor moves along the disagree → pass → agree path based on phone tilt. Participants will be prompted to grant orientation permission on iOS.
-              </p>
-            )}
+            <p style={{ color: '#666', fontSize: 12, marginBottom: 20, visibility: valenceInputMode === 'touch' ? 'hidden' : 'visible' }}>
+              In orientation mode, the cursor moves along the disagree → pass → agree path based on phone tilt. Participants will be prompted to grant orientation permission on iOS.
+            </p>
           </>
         )}
 

--- a/app/components/AdminPanelV4/CanvasSettingsModal.tsx
+++ b/app/components/AdminPanelV4/CanvasSettingsModal.tsx
@@ -1,8 +1,13 @@
+import { useState } from "react";
+import type { ValenceInputMode } from "../../types";
+
 interface CanvasSettingsModalProps {
   showNowLabel: boolean;
   onChangeShowNowLabel: (v: boolean) => void;
   ownValenceDisplay: 'background' | 'labels' | 'none';
   onChangeOwnValenceDisplay: (mode: 'background' | 'labels' | 'none') => void;
+  valenceInputMode: ValenceInputMode;
+  onChangeValenceInputMode: (mode: ValenceInputMode) => void;
   onClose: () => void;
 }
 
@@ -12,43 +17,100 @@ const OWN_VALENCE_OPTIONS: { value: 'background' | 'labels' | 'none'; label: str
   { value: 'none', label: 'None', description: 'No visual feedback for your own position' },
 ];
 
-export default function CanvasSettingsModal({ showNowLabel, onChangeShowNowLabel, ownValenceDisplay, onChangeOwnValenceDisplay, onClose }: CanvasSettingsModalProps) {
+const VALENCE_INPUT_OPTIONS: { value: ValenceInputMode; label: string; description: string }[] = [
+  { value: 'touch', label: 'Touch', description: 'Move your finger across the canvas to express your reaction' },
+  { value: 'orientation-horizontal', label: 'Orientation (Horizontal)', description: 'Phone face-up = agree, edge-on = pass, face-down = disagree' },
+  { value: 'orientation-vertical', label: 'Orientation (Vertical)', description: 'Phone upright = agree, phone flat = pass, phone upside-down = disagree' },
+];
+
+export default function CanvasSettingsModal({ showNowLabel, onChangeShowNowLabel, ownValenceDisplay, onChangeOwnValenceDisplay, valenceInputMode, onChangeValenceInputMode, onClose }: CanvasSettingsModalProps) {
+  const [activeTab, setActiveTab] = useState<'display' | 'input'>('display');
+
   return (
     <div className="github-modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose(); }}>
       <div className="github-modal">
         <p className="github-modal-title">Reaction Canvas settings</p>
-        <label style={{ display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer', color: '#ccc', fontSize: 14, marginBottom: 8 }}>
-          <input
-            type="checkbox"
-            checked={showNowLabel}
-            onChange={e => onChangeShowNowLabel(e.target.checked)}
-            style={{ width: 16, height: 16, cursor: 'pointer' }}
-          />
-          Show "Now" label on canvas
-        </label>
-        <p style={{ color: '#666', fontSize: 12, marginBottom: 20 }}>
-          Displays the current moment label at the top of the canvas for all participants. Clears when the moment is snapped.
-        </p>
 
-        <p style={{ color: '#ccc', fontSize: 14, fontWeight: 600, marginBottom: 8 }}>Display own valence via</p>
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 20 }}>
-          {OWN_VALENCE_OPTIONS.map(({ value, label, description }) => (
-            <label key={value} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}>
-              <input
-                type="radio"
-                name="ownValenceDisplay"
-                value={value}
-                checked={ownValenceDisplay === value}
-                onChange={() => onChangeOwnValenceDisplay(value)}
-                style={{ marginTop: 2, cursor: 'pointer', flexShrink: 0 }}
-              />
-              <span>
-                <span style={{ color: '#ccc', fontSize: 14 }}>{label}</span>
-                <span style={{ display: 'block', color: '#666', fontSize: 12 }}>{description}</span>
-              </span>
-            </label>
-          ))}
+        <div className="share-qr-tab-bar" style={{ marginBottom: 16 }}>
+          <button
+            className={`share-qr-tab-btn${activeTab === 'display' ? ' share-qr-tab-btn--active' : ''}`}
+            onClick={() => setActiveTab('display')}
+          >
+            Valence Display
+          </button>
+          <button
+            className={`share-qr-tab-btn${activeTab === 'input' ? ' share-qr-tab-btn--active' : ''}`}
+            onClick={() => setActiveTab('input')}
+          >
+            Valence Input
+          </button>
         </div>
+
+        {activeTab === 'display' && (
+          <>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer', color: '#ccc', fontSize: 14, marginBottom: 8 }}>
+              <input
+                type="checkbox"
+                checked={showNowLabel}
+                onChange={e => onChangeShowNowLabel(e.target.checked)}
+                style={{ width: 16, height: 16, cursor: 'pointer' }}
+              />
+              Show "Now" label on canvas
+            </label>
+            <p style={{ color: '#666', fontSize: 12, marginBottom: 20 }}>
+              Displays the current moment label at the top of the canvas for all participants. Clears when the moment is snapped.
+            </p>
+
+            <p style={{ color: '#ccc', fontSize: 14, fontWeight: 600, marginBottom: 8 }}>Display own valence via</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 20 }}>
+              {OWN_VALENCE_OPTIONS.map(({ value, label, description }) => (
+                <label key={value} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}>
+                  <input
+                    type="radio"
+                    name="ownValenceDisplay"
+                    value={value}
+                    checked={ownValenceDisplay === value}
+                    onChange={() => onChangeOwnValenceDisplay(value)}
+                    style={{ marginTop: 2, cursor: 'pointer', flexShrink: 0 }}
+                  />
+                  <span>
+                    <span style={{ color: '#ccc', fontSize: 14 }}>{label}</span>
+                    <span style={{ display: 'block', color: '#666', fontSize: 12 }}>{description}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          </>
+        )}
+
+        {activeTab === 'input' && (
+          <>
+            <p style={{ color: '#ccc', fontSize: 14, fontWeight: 600, marginBottom: 8 }}>Detect valence via</p>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 20 }}>
+              {VALENCE_INPUT_OPTIONS.map(({ value, label, description }) => (
+                <label key={value} style={{ display: 'flex', alignItems: 'flex-start', gap: 10, cursor: 'pointer' }}>
+                  <input
+                    type="radio"
+                    name="valenceInputMode"
+                    value={value}
+                    checked={valenceInputMode === value}
+                    onChange={() => onChangeValenceInputMode(value)}
+                    style={{ marginTop: 2, cursor: 'pointer', flexShrink: 0 }}
+                  />
+                  <span>
+                    <span style={{ color: '#ccc', fontSize: 14 }}>{label}</span>
+                    <span style={{ display: 'block', color: '#666', fontSize: 12 }}>{description}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+            {valenceInputMode !== 'touch' && (
+              <p style={{ color: '#666', fontSize: 12, marginBottom: 20 }}>
+                In orientation mode, the cursor moves along the disagree → pass → agree path based on phone tilt. Participants will be prompted to grant orientation permission on iOS.
+              </p>
+            )}
+          </>
+        )}
 
         <button className="github-modal-btn-dismiss" onClick={onClose}>Close</button>
       </div>

--- a/app/components/AdminPanelV4/CanvasSettingsModal.tsx
+++ b/app/components/AdminPanelV4/CanvasSettingsModal.tsx
@@ -19,7 +19,7 @@ const OWN_VALENCE_OPTIONS: { value: 'background' | 'labels' | 'none'; label: str
 
 const VALENCE_INPUT_OPTIONS: { value: ValenceInputMode; label: string; description: string }[] = [
   { value: 'touch', label: 'Touch', description: 'Move your finger across the canvas to express your reaction' },
-  { value: 'orientation-horizontal', label: 'Orientation (Horizontal)', description: 'Flip phone sideways on table — face-up = agree, edge-on = pass, face-down = disagree' },
+  { value: 'orientation-horizontal', label: 'Orientation (Horizontal)', description: 'Face-up = agree, face-down = disagree — works for any flip direction or combination' },
   { value: 'orientation-vertical', label: 'Orientation (Vertical)', description: 'Phone upright = agree, phone flat = pass, phone upside-down = disagree' },
 ];
 

--- a/app/components/AdminPanelV4/hooks/useRoomConfig.ts
+++ b/app/components/AdminPanelV4/hooks/useRoomConfig.ts
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import type { ActivityMode, GreeterConfig, SocialConfig } from "../../../types";
+import type { ActivityMode, GreeterConfig, SocialConfig, ValenceInputMode } from "../../../types";
 import type PartySocket from "partysocket";
 
 export function useRoomConfig(socket: PartySocket) {
@@ -7,6 +7,7 @@ export function useRoomConfig(socket: PartySocket) {
   const [colorCursorsByVote, setColorCursorsByVote] = useState<boolean>(false);
   const [defaultCursorColor, setDefaultCursorColor] = useState<string>('#d4d4d4');
   const [ownValenceDisplay, setOwnValenceDisplay] = useState<'background' | 'labels' | 'none'>('labels');
+  const [valenceInputMode, setValenceInputMode] = useState<ValenceInputMode>('touch');
   const [activity, setActivity]               = useState<ActivityMode>('canvas');
   const [soccerScore, setSoccerScore]         = useState({ left: 0, right: 0 });
   const [imageConfigOpen, setImageConfigOpen] = useState(false);
@@ -40,6 +41,11 @@ export function useRoomConfig(socket: PartySocket) {
   const sendOwnValenceDisplay = (mode: 'background' | 'labels' | 'none') => {
     setOwnValenceDisplay(mode);
     socket.send(JSON.stringify({ type: 'setOwnValenceDisplay', mode }));
+  };
+
+  const sendValenceInputMode = (mode: ValenceInputMode) => {
+    setValenceInputMode(mode);
+    socket.send(JSON.stringify({ type: 'setValenceInputMode', mode }));
   };
 
   const sendActivity = (act: ActivityMode) => {
@@ -77,6 +83,7 @@ export function useRoomConfig(socket: PartySocket) {
     if ('colorCursorsByVote' in data) setColorCursorsByVote((data.colorCursorsByVote as boolean) ?? true);
     if ('defaultCursorColor' in data && data.defaultCursorColor) setDefaultCursorColor(data.defaultCursorColor as string);
     if ('ownValenceDisplay' in data && data.ownValenceDisplay) setOwnValenceDisplay(data.ownValenceDisplay as 'background' | 'labels' | 'none');
+    if ('valenceInputMode' in data && data.valenceInputMode) setValenceInputMode(data.valenceInputMode as ValenceInputMode);
     if ('currentActivity' in data) setActivity((data.currentActivity as ActivityMode) ?? 'canvas');
     if ('roomImageUrl' in data) setRoomImageUrl((data.roomImageUrl as string) ?? '');
     if ('roomSocialConfig' in data) setRoomSocialConfig((data.roomSocialConfig as SocialConfig | null) ?? null);
@@ -110,6 +117,8 @@ export function useRoomConfig(socket: PartySocket) {
       setCapInput(data.cap !== null ? String(data.cap) : '');
     } else if (data.type === 'ownValenceDisplayChanged') {
       setOwnValenceDisplay(data.ownValenceDisplay as 'background' | 'labels' | 'none');
+    } else if (data.type === 'valenceInputModeChanged') {
+      setValenceInputMode(data.valenceInputMode as ValenceInputMode);
     }
   };
 
@@ -142,5 +151,7 @@ export function useRoomConfig(socket: PartySocket) {
     showNowLabelOnCanvas, setShowNowLabelOnCanvas,
     ownValenceDisplay, setOwnValenceDisplay,
     sendOwnValenceDisplay,
+    valenceInputMode, setValenceInputMode,
+    sendValenceInputMode,
   };
 }

--- a/app/components/AdminPanelV4/index.tsx
+++ b/app/components/AdminPanelV4/index.tsx
@@ -454,6 +454,8 @@ export default function AdminPanelV4({ room, selfUserId, selfChain }: AdminPanel
           }}
           ownValenceDisplay={roomConfig.ownValenceDisplay}
           onChangeOwnValenceDisplay={roomConfig.sendOwnValenceDisplay}
+          valenceInputMode={roomConfig.valenceInputMode}
+          onChangeValenceInputMode={roomConfig.sendValenceInputMode}
           onClose={() => roomConfig.setCanvasSettingsOpen(false)}
         />
       )}

--- a/app/components/AdminPanelV4/index.tsx
+++ b/app/components/AdminPanelV4/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import usePartySocket from "partysocket/react";
-import { getPartyHost } from "../../utils/partyHost";
+import { getPartySocketConfig } from "../../utils/partyHost";
 import ImageConfigModal from "../ImageConfigModal";
 import SocialConfigModal from "../SocialConfigModal";
 import GreeterConfigModal from "../GreeterConfigModal";
@@ -93,7 +93,7 @@ export default function AdminPanelV4({ room, selfUserId, selfChain }: AdminPanel
   const dispatchRef = useRef<(data: Record<string, unknown>) => void>(() => {});
 
   const socket = usePartySocket({
-    host: getPartyHost(),
+    ...getPartySocketConfig(),
     room,
     query: { isAdmin: 'true' },
     onMessage(evt) {

--- a/app/components/AdminPanelV4/index.tsx
+++ b/app/components/AdminPanelV4/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import usePartySocket from "partysocket/react";
+import { getPartyHost } from "../../utils/partyHost";
 import ImageConfigModal from "../ImageConfigModal";
 import SocialConfigModal from "../SocialConfigModal";
 import GreeterConfigModal from "../GreeterConfigModal";
@@ -92,7 +93,7 @@ export default function AdminPanelV4({ room, selfUserId, selfChain }: AdminPanel
   const dispatchRef = useRef<(data: Record<string, unknown>) => void>(() => {});
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : window.location.hostname,
+    host: getPartyHost(),
     room,
     query: { isAdmin: 'true' },
     onMessage(evt) {

--- a/app/components/AdminPanelV5.tsx
+++ b/app/components/AdminPanelV5.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import usePartySocket from "partysocket/react";
+import { getPartyHost } from "../utils/partyHost";
 import { DEFAULT_ANCHORS } from "../utils/voteRegion";
 import type { ReactionAnchors } from "../utils/voteRegion";
 import { REACTION_LABEL_PRESETS } from "../voteLabels";
@@ -106,7 +107,7 @@ export default function AdminPanelV5({ room }: AdminPanelV5Props) {
   };
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : window.location.hostname,
+    host: getPartyHost(),
     room,
     query: { isAdmin: 'true' },
     onMessage(evt) {

--- a/app/components/AdminPanelV5.tsx
+++ b/app/components/AdminPanelV5.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from "react";
 import usePartySocket from "partysocket/react";
-import { getPartyHost } from "../utils/partyHost";
+import { getPartySocketConfig } from "../utils/partyHost";
 import { DEFAULT_ANCHORS } from "../utils/voteRegion";
 import type { ReactionAnchors } from "../utils/voteRegion";
 import { REACTION_LABEL_PRESETS } from "../voteLabels";
@@ -107,7 +107,7 @@ export default function AdminPanelV5({ room }: AdminPanelV5Props) {
   };
 
   const socket = usePartySocket({
-    host: getPartyHost(),
+    ...getPartySocketConfig(),
     room,
     query: { isAdmin: 'true' },
     onMessage(evt) {

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -55,6 +55,7 @@ interface CanvasProps {
   onNowLabelChange?: (label: string) => void;
   onInviteEdges?: (edges: Record<string, string>) => void;
   onOwnValenceDisplayChange?: (mode: 'background' | 'labels' | 'none') => void;
+  onValenceInputModeChange?: (mode: 'touch' | 'orientation-horizontal' | 'orientation-vertical') => void;
   onStrokeSegment?: (userId: string, strokeId: string, points: Array<{ x: number; y: number }>, isFinal: boolean) => void;
   onSignatureCleared?: (userId: string) => void;
   onConnectedUsers?: (ids: string[]) => void;
@@ -83,7 +84,7 @@ function clipLineToRect(
   return [px + tMin * dx, py + tMin * dy, px + tMax * dx, py + tMax * dy];
 }
 
-export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote: colorCursorsByVoteProp = false, disableCursorValence = false, disableBackgroundValence = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onInterfacePushed, onPushedInterfacesCleared, onHapticPushed, onRoomImageUrlChange, onActivityChange, onSocialConfigChange, onGreeterConfigChange, onConnected, onNowLabelChange, onInviteEdges, onOwnValenceDisplayChange, onStrokeSegment, onSignatureCleared, onConnectedUsers, onUserJoined, onUserLeft, debug = false }: CanvasProps) {
+export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote: colorCursorsByVoteProp = false, disableCursorValence = false, disableBackgroundValence = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onInterfacePushed, onPushedInterfacesCleared, onHapticPushed, onRoomImageUrlChange, onActivityChange, onSocialConfigChange, onGreeterConfigChange, onConnected, onNowLabelChange, onInviteEdges, onOwnValenceDisplayChange, onValenceInputModeChange, onStrokeSegment, onSignatureCleared, onConnectedUsers, onUserJoined, onUserLeft, debug = false }: CanvasProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const [cursors, setCursors] = useState<Map<string, CursorPosition>>(new Map());
   const [anchors, setAnchors] = useState<ReactionAnchors>(DEFAULT_ANCHORS);
@@ -154,6 +155,9 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
             const mode = data.ownValenceDisplay as 'background' | 'labels' | 'none';
             setOwnValenceDisplay(mode);
             onOwnValenceDisplayChange?.(mode);
+          }
+          if ('valenceInputMode' in data && data.valenceInputMode) {
+            onValenceInputModeChange?.(data.valenceInputMode as 'touch' | 'orientation-horizontal' | 'orientation-vertical');
           }
           if ('currentActivity' in data) {
             const act = data.currentActivity ?? 'canvas';
@@ -248,6 +252,11 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
           const mode = data.ownValenceDisplay as 'background' | 'labels' | 'none';
           setOwnValenceDisplay(mode);
           onOwnValenceDisplayChange?.(mode);
+          return;
+        }
+
+        if (data.type === 'valenceInputModeChanged') {
+          onValenceInputModeChange?.(data.valenceInputMode as 'touch' | 'orientation-horizontal' | 'orientation-vertical');
           return;
         }
 

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useState } from "react";
 import usePartySocket from "partysocket/react";
 import * as d3 from "d3";
 import { computeReactionRegion, DEFAULT_ANCHORS } from "../utils/voteRegion";
+import { getPartyHost } from "../utils/partyHost";
 import type { ReactionAnchors } from "../utils/voteRegion";
 import type { ActivityMode, GreeterConfig } from "../types";
 
@@ -120,7 +121,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   });
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.isSecureContext ? 'wss' : 'ws'}://${window.location.hostname}:1999` : window.location.hostname,
+    host: getPartyHost(),
     room: room,
     query: readOnly ? { isAdmin: 'true' } : { userId },
     onMessage(evt) {

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -120,7 +120,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   });
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : window.location.hostname,
+    host: ['1999', '1443'].includes(window.location.port) ? `${window.location.hostname}:${window.location.port}` : window.location.hostname,
     room: room,
     query: readOnly ? { isAdmin: 'true' } : { userId },
     onMessage(evt) {

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -120,7 +120,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   });
 
   const socket = usePartySocket({
-    host: ['1999', '1443'].includes(window.location.port) ? `${window.location.hostname}:${window.location.port}` : window.location.hostname,
+    host: window.location.port === '1999' ? `${window.isSecureContext ? 'wss' : 'ws'}://${window.location.hostname}:1999` : window.location.hostname,
     room: room,
     query: readOnly ? { isAdmin: 'true' } : { userId },
     onMessage(evt) {

--- a/app/components/Canvas.tsx
+++ b/app/components/Canvas.tsx
@@ -2,7 +2,7 @@ import { useRef, useEffect, useState } from "react";
 import usePartySocket from "partysocket/react";
 import * as d3 from "d3";
 import { computeReactionRegion, DEFAULT_ANCHORS } from "../utils/voteRegion";
-import { getPartyHost } from "../utils/partyHost";
+import { getPartySocketConfig } from "../utils/partyHost";
 import type { ReactionAnchors } from "../utils/voteRegion";
 import type { ActivityMode, GreeterConfig } from "../types";
 
@@ -121,7 +121,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   });
 
   const socket = usePartySocket({
-    host: getPartyHost(),
+    ...getPartySocketConfig(),
     room: room,
     query: readOnly ? { isAdmin: 'true' } : { userId },
     onMessage(evt) {

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import Canvas from "./Canvas";
 import TouchLayer from "./TouchLayer";
 import SignatureLayer from "./SignatureLayer";
@@ -8,14 +8,14 @@ import InterfaceChipBar from "./InterfaceChipBar";
 import SocialPanel from "./SocialPanel";
 import MoodTonesPanel from "./MoodTonesPanel";
 import GreeterPanel from "./GreeterPanel";
-import type { ActivityMode, GreeterConfig, SocialConfig } from "../types";
+import type { ActivityMode, GreeterConfig, SocialConfig, ValenceInputMode } from "../types";
 import GithubUsernameModal from "./GithubUsernameModal";
 import FeedbackStarsModal from "./FeedbackStarsModal";
 import InterfacePushModal from "./InterfacePushModal";
 import HapticPushModal from "./HapticPushModal";
 import { WebHaptics } from "web-haptics";
 import { useWebHaptics } from "web-haptics/react";
-import { DEFAULT_ANCHORS, reactionLabelStyle } from "../utils/voteRegion";
+import { DEFAULT_ANCHORS, reactionLabelStyle, valenceToPosition, computeReactionRegion } from "../utils/voteRegion";
 import type { ReactionAnchors } from "../utils/voteRegion";
 import { getReactionLabelSet } from "../voteLabels";
 import type { ReactionLabelSet } from "../voteLabels";
@@ -143,6 +143,8 @@ export default function ReactionCanvasAppV4() {
   const [nowLabel, setNowLabel] = useState('');
   const [activity, setActivity] = useState<ActivityMode>('canvas');
   const [ownValenceDisplay, setOwnValenceDisplay] = useState<'background' | 'labels' | 'none'>('labels');
+  const [valenceInputMode, setValenceInputMode] = useState<ValenceInputMode>('touch');
+  const [orientationPermission, setOrientationPermission] = useState<'unknown' | 'granted' | 'denied' | 'not-required'>('unknown');
   const [isPresenter, setIsPresenter] = useState(false);
   const [signatureStrokes, setSignatureStrokes] = useState<Record<string, Array<{ strokeId: string; points: Array<{ x: number; y: number }> }>>>({});
   const [connectedUserIds, setConnectedUserIds] = useState<string[]>([]);
@@ -201,6 +203,92 @@ export default function ReactionCanvasAppV4() {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
+
+  const requestOrientationPermission = useCallback(async () => {
+    if (typeof DeviceOrientationEvent !== 'undefined' &&
+        typeof (DeviceOrientationEvent as unknown as { requestPermission?: () => Promise<string> }).requestPermission === 'function') {
+      const result = await (DeviceOrientationEvent as unknown as { requestPermission: () => Promise<string> }).requestPermission();
+      setOrientationPermission(result === 'granted' ? 'granted' : 'denied');
+    } else {
+      setOrientationPermission('not-required');
+    }
+  }, []);
+
+  // When switching away from orientation mode, clear the cursor and touch indicator.
+  useEffect(() => {
+    if (valenceInputMode === 'touch') {
+      socketSendRef.current?.(JSON.stringify({
+        type: 'remove',
+        position: { x: 0, y: 0, timestamp: Date.now(), userId },
+      }));
+      setCanvasBackgroundReactionState(null);
+      setTouchPos(null);
+    }
+  }, [valenceInputMode]);
+
+  // Initialise permission state when entering an orientation mode.
+  useEffect(() => {
+    if (valenceInputMode === 'touch') return;
+    // Chrome 74+ blocks DeviceOrientationEvent on non-secure (non-HTTPS, non-localhost) pages.
+    if (!window.isSecureContext) {
+      setOrientationPermission('denied');
+      return;
+    }
+    if (typeof DeviceOrientationEvent === 'undefined') {
+      setOrientationPermission('not-required');
+      return;
+    }
+    if (typeof (DeviceOrientationEvent as unknown as { requestPermission?: unknown }).requestPermission !== 'function') {
+      // Non-iOS: no explicit permission needed.
+      setOrientationPermission('not-required');
+    }
+    // iOS: leave as 'unknown' so the permission banner is shown.
+  }, [valenceInputMode]);
+
+  const anchorsRef = useRef(serverAnchors ?? DEFAULT_ANCHORS);
+  anchorsRef.current = serverAnchors ?? DEFAULT_ANCHORS;
+
+  // Orientation → cursor send loop.
+  useEffect(() => {
+    if (valenceInputMode === 'touch') return;
+    if (orientationPermission !== 'granted' && orientationPermission !== 'not-required') return;
+
+    let lastSent = 0;
+
+    const handleOrientation = (e: DeviceOrientationEvent) => {
+      if (e.beta === null) return;
+      const beta = e.beta;
+      const rawValence = valenceInputMode === 'orientation-horizontal'
+        ? Math.cos(beta * Math.PI / 180)
+        : Math.sin(beta * Math.PI / 180);
+      const valence = Math.max(-1, Math.min(1, rawValence));
+      const pos = valenceToPosition(valence, anchorsRef.current);
+
+      const now = Date.now();
+      if (now - lastSent < 50) return;
+      lastSent = now;
+
+      socketSendRef.current?.(JSON.stringify({
+        type: 'touch',
+        position: { x: pos.x, y: pos.y, timestamp: now, userId },
+      }));
+
+      const reactionState = computeReactionRegion(pos.x, pos.y, anchorsRef.current);
+      setCanvasBackgroundReactionState(reactionState);
+      setTouchPos({ x: (pos.x / 100) * window.innerWidth, y: (pos.y / 100) * window.innerHeight });
+    };
+
+    window.addEventListener('deviceorientation', handleOrientation);
+    return () => {
+      window.removeEventListener('deviceorientation', handleOrientation);
+      socketSendRef.current?.(JSON.stringify({
+        type: 'remove',
+        position: { x: 0, y: 0, timestamp: Date.now(), userId },
+      }));
+      setCanvasBackgroundReactionState(null);
+      setTouchPos(null);
+    };
+  }, [valenceInputMode, orientationPermission, userId]);
 
   const roomHasSpace = userCap === null || presenceCount < userCap;
 
@@ -312,6 +400,7 @@ export default function ReactionCanvasAppV4() {
             disableCursorValence={activity === 'image-canvas'}
             disableBackgroundValence={activity === 'image-canvas'}
             onOwnValenceDisplayChange={setOwnValenceDisplay}
+            onValenceInputModeChange={setValenceInputMode}
             currentReactionState={canvasBackgroundReactionState}
             heightOffset={chipBarOffset}
             onPresenceCount={setPresenceCount}
@@ -392,6 +481,19 @@ export default function ReactionCanvasAppV4() {
               {nowLabel}
             </div>
           )}
+          {valenceInputMode !== 'touch' && orientationPermission === 'unknown' && (
+            <div className="viewer-mode-banner">
+              Tap to enable device orientation tracking
+              <button className="viewer-join-btn" onClick={requestOrientationPermission}>Enable</button>
+            </div>
+          )}
+          {valenceInputMode !== 'touch' && orientationPermission === 'denied' && (
+            <div className="viewer-mode-banner">
+              {!window.isSecureContext
+                ? 'Orientation needs HTTPS — works on the deployed app, not over local network HTTP.'
+                : 'Orientation permission denied — switch back to Touch mode to react.'}
+            </div>
+          )}
           {!isViewer && activity !== 'social' && activity !== 'greeter' && activity !== 'signature' && (
             <TouchLayer
               room={room}
@@ -404,6 +506,7 @@ export default function ReactionCanvasAppV4() {
               heightOffset={chipBarOffset}
               anchors={anchors}
               imageUrl={activity === 'image-canvas' ? (serverImageUrl || undefined) : undefined}
+              disabled={valenceInputMode !== 'touch'}
             />
           )}
           {activity === 'signature' && !isPresenter && !isViewer && (

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -259,11 +259,10 @@ export default function ReactionCanvasAppV4() {
       if (e.beta === null || e.gamma === null) return;
       let rawValence: number;
       if (valenceInputMode === 'orientation-horizontal') {
-        // Sideways flip on table: face-up = +1, edge-on = 0, face-down = -1.
-        // gamma saturates at ±90° so cos(gamma) alone can't reach -1 at face-down.
-        // When the phone passes edge-on, beta flips past ±90° — use that to negate.
-        const sign = Math.abs(e.beta) > 90 ? -1 : 1;
-        rawValence = sign * Math.cos(e.gamma * Math.PI / 180);
+        // Face-up = +1, edge-on (any axis) = 0, face-down = -1.
+        // cos(β)·cos(γ) is the z-component of the screen normal in world space —
+        // mathematically correct for any combination of forward/sideways tilt.
+        rawValence = Math.cos(e.beta * Math.PI / 180) * Math.cos(e.gamma * Math.PI / 180);
       } else {
         // Vertical: phone upright = +1, flat = 0, upside-down = -1
         rawValence = Math.sin(e.beta * Math.PI / 180);

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -256,11 +256,18 @@ export default function ReactionCanvasAppV4() {
     let lastSent = 0;
 
     const handleOrientation = (e: DeviceOrientationEvent) => {
-      if (e.beta === null) return;
-      const beta = e.beta;
-      const rawValence = valenceInputMode === 'orientation-horizontal'
-        ? Math.cos(beta * Math.PI / 180)
-        : Math.sin(beta * Math.PI / 180);
+      if (e.beta === null || e.gamma === null) return;
+      let rawValence: number;
+      if (valenceInputMode === 'orientation-horizontal') {
+        // Sideways flip on table: face-up = +1, edge-on = 0, face-down = -1.
+        // gamma saturates at ±90° so cos(gamma) alone can't reach -1 at face-down.
+        // When the phone passes edge-on, beta flips past ±90° — use that to negate.
+        const sign = Math.abs(e.beta) > 90 ? -1 : 1;
+        rawValence = sign * Math.cos(e.gamma * Math.PI / 180);
+      } else {
+        // Vertical: phone upright = +1, flat = 0, upside-down = -1
+        rawValence = Math.sin(e.beta * Math.PI / 180);
+      }
       const valence = Math.max(-1, Math.min(1, rawValence));
       const pos = valenceToPosition(valence, anchorsRef.current);
 

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -263,6 +263,9 @@ export default function ReactionCanvasAppV4() {
         // cos(β)·cos(γ) is the z-component of the screen normal in world space —
         // mathematically correct for any combination of forward/sideways tilt.
         rawValence = Math.cos(e.beta * Math.PI / 180) * Math.cos(e.gamma * Math.PI / 180);
+      } else if (valenceInputMode === 'orientation-rotation') {
+        // Steering wheel: portrait upright = 0, clockwise 90° = +1, counter-clockwise 90° = -1
+        rawValence = Math.sin(e.gamma * Math.PI / 180);
       } else {
         // Vertical: phone upright = +1, flat = 0, upside-down = -1
         rawValence = Math.sin(e.beta * Math.PI / 180);

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -264,8 +264,9 @@ export default function ReactionCanvasAppV4() {
         // mathematically correct for any combination of forward/sideways tilt.
         rawValence = Math.cos(e.beta * Math.PI / 180) * Math.cos(e.gamma * Math.PI / 180);
       } else if (valenceInputMode === 'orientation-rotation') {
-        // Steering wheel: portrait upright = 0, clockwise 90° = +1, counter-clockwise 90° = -1
-        rawValence = Math.sin(e.gamma * Math.PI / 180);
+        // Steering wheel relative to landscape: landscape = 0 (pass), rotate CW toward upside-down portrait = +1, CCW toward portrait = -1.
+        // cos(atan2(gamma, beta)) gives the correct quadrant-aware mapping through the full rotation.
+        rawValence = Math.cos(Math.atan2(e.gamma, e.beta));
       } else {
         // Vertical: phone upright = +1, flat = 0, upside-down = -1
         rawValence = Math.sin(e.beta * Math.PI / 180);

--- a/app/components/SimpleReactionCanvasAppV1.tsx
+++ b/app/components/SimpleReactionCanvasAppV1.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import usePartySocket from "partysocket/react";
-import { getPartyHost } from "../utils/partyHost";
+import { getPartySocketConfig } from "../utils/partyHost";
 import Canvas from "./Canvas";
 import TouchLayer from "./TouchLayer";
 import StatementPanel from "./StatementPanel";
@@ -53,7 +53,7 @@ export default function SimpleReactionCanvasAppV1() {
   }, []);
 
   const socket = usePartySocket({
-    host: getPartyHost(),
+    ...getPartySocketConfig(),
     room: room,
     onMessage(evt) {
       try {

--- a/app/components/SimpleReactionCanvasAppV1.tsx
+++ b/app/components/SimpleReactionCanvasAppV1.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import usePartySocket from "partysocket/react";
+import { getPartyHost } from "../utils/partyHost";
 import Canvas from "./Canvas";
 import TouchLayer from "./TouchLayer";
 import StatementPanel from "./StatementPanel";
@@ -52,7 +53,7 @@ export default function SimpleReactionCanvasAppV1() {
   }, []);
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : window.location.hostname,
+    host: getPartyHost(),
     room: room,
     onMessage(evt) {
       try {

--- a/app/components/TouchLayer.tsx
+++ b/app/components/TouchLayer.tsx
@@ -77,7 +77,7 @@ export default function TouchLayer({
   const lastPositionRef = useRef<CursorPosition | null>(null);
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.location.hostname}:1999` : window.location.hostname,
+    host: ['1999', '1443'].includes(window.location.port) ? `${window.location.hostname}:${window.location.port}` : window.location.hostname,
     room: room,
     query: { userId },
     onMessage(evt) {

--- a/app/components/TouchLayer.tsx
+++ b/app/components/TouchLayer.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect, useState } from "react";
 import usePartySocket from "partysocket/react";
 import { computeReactionRegion, DEFAULT_ANCHORS } from "../utils/voteRegion";
+import { getPartyHost } from "../utils/partyHost";
 import type { ReactionAnchors } from "../utils/voteRegion";
 
 interface CursorPosition {
@@ -77,7 +78,7 @@ export default function TouchLayer({
   const lastPositionRef = useRef<CursorPosition | null>(null);
 
   const socket = usePartySocket({
-    host: window.location.port === '1999' ? `${window.isSecureContext ? 'wss' : 'ws'}://${window.location.hostname}:1999` : window.location.hostname,
+    host: getPartyHost(),
     room: room,
     query: { userId },
     onMessage(evt) {

--- a/app/components/TouchLayer.tsx
+++ b/app/components/TouchLayer.tsx
@@ -1,7 +1,7 @@
 import { useRef, useEffect, useState } from "react";
 import usePartySocket from "partysocket/react";
 import { computeReactionRegion, DEFAULT_ANCHORS } from "../utils/voteRegion";
-import { getPartyHost } from "../utils/partyHost";
+import { getPartySocketConfig } from "../utils/partyHost";
 import type { ReactionAnchors } from "../utils/voteRegion";
 
 interface CursorPosition {
@@ -78,7 +78,7 @@ export default function TouchLayer({
   const lastPositionRef = useRef<CursorPosition | null>(null);
 
   const socket = usePartySocket({
-    host: getPartyHost(),
+    ...getPartySocketConfig(),
     room: room,
     query: { userId },
     onMessage(evt) {

--- a/app/components/TouchLayer.tsx
+++ b/app/components/TouchLayer.tsx
@@ -77,7 +77,7 @@ export default function TouchLayer({
   const lastPositionRef = useRef<CursorPosition | null>(null);
 
   const socket = usePartySocket({
-    host: ['1999', '1443'].includes(window.location.port) ? `${window.location.hostname}:${window.location.port}` : window.location.hostname,
+    host: window.location.port === '1999' ? `${window.isSecureContext ? 'wss' : 'ws'}://${window.location.hostname}:1999` : window.location.hostname,
     room: room,
     query: { userId },
     onMessage(evt) {

--- a/app/components/TouchLayer.tsx
+++ b/app/components/TouchLayer.tsx
@@ -37,6 +37,7 @@ interface TouchLayerProps {
   anchors?: ReactionAnchors;
   onCursorEvent?: (type: 'move' | 'touch' | 'remove', pos: { x: number; y: number }) => void;
   imageUrl?: string; // When set, normalize coordinates relative to displayed image bounds
+  disabled?: boolean; // When true, keeps socket alive but ignores all pointer events
 }
 
 export default function TouchLayer({
@@ -52,6 +53,7 @@ export default function TouchLayer({
   anchors,
   onCursorEvent,
   imageUrl,
+  disabled = false,
 }: TouchLayerProps) {
   const layerRef = useRef<HTMLDivElement>(null);
   const [userReactionState, setUserReactionState] = useState<ReactionState>(null);
@@ -296,15 +298,15 @@ export default function TouchLayer({
         zIndex: 10, // Higher z-index to capture events
         touchAction: 'none',
         cursor: 'default',
-        pointerEvents: 'auto',
+        pointerEvents: disabled ? 'none' : 'auto',
         backgroundColor: 'transparent' // Completely transparent
       }}
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
-      onTouchStart={handleTouchStart}
-      onTouchMove={handleTouchMove}
-      onTouchEnd={handleTouchEnd}
-      onTouchCancel={handleTouchEnd}
+      onMouseMove={disabled ? undefined : handleMouseMove}
+      onMouseLeave={disabled ? undefined : handleMouseLeave}
+      onTouchStart={disabled ? undefined : handleTouchStart}
+      onTouchMove={disabled ? undefined : handleTouchMove}
+      onTouchEnd={disabled ? undefined : handleTouchEnd}
+      onTouchCancel={disabled ? undefined : handleTouchEnd}
     />
   );
 }

--- a/app/types.ts
+++ b/app/types.ts
@@ -30,7 +30,7 @@ export interface Statement {
 
 export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social' | 'mood-tones' | 'treevites' | 'greeter' | 'signature';
 
-export type ValenceInputMode = 'touch' | 'orientation-horizontal' | 'orientation-vertical';
+export type ValenceInputMode = 'touch' | 'orientation-horizontal' | 'orientation-vertical' | 'orientation-rotation';
 
 export interface GreeterConfig {
   eventUrl: string;

--- a/app/types.ts
+++ b/app/types.ts
@@ -30,6 +30,8 @@ export interface Statement {
 
 export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social' | 'mood-tones' | 'treevites' | 'greeter' | 'signature';
 
+export type ValenceInputMode = 'touch' | 'orientation-horizontal' | 'orientation-vertical';
+
 export interface GreeterConfig {
   eventUrl: string;
 }

--- a/app/utils/partyHost.ts
+++ b/app/utils/partyHost.ts
@@ -1,0 +1,15 @@
+/**
+ * Returns the PartyKit host string for usePartySocket.
+ * On port 1999 (local partykit dev), connects to the local server,
+ * using wss:// when the page is served over HTTPS (e.g. pnpm dev-https)
+ * so browsers don't block the WebSocket as mixed content.
+ * On any other port, returns just the hostname so partysocket uses
+ * the deployed server with its own protocol detection.
+ */
+export function getPartyHost(): string {
+  if (window.location.port === '1999') {
+    const protocol = window.isSecureContext ? 'wss' : 'ws';
+    return `${protocol}://${window.location.hostname}:1999`;
+  }
+  return window.location.hostname;
+}

--- a/app/utils/partyHost.ts
+++ b/app/utils/partyHost.ts
@@ -1,15 +1,30 @@
 /**
- * Returns the PartyKit host string for usePartySocket.
- * On port 1999 (local partykit dev), connects to the local server,
- * using wss:// when the page is served over HTTPS (e.g. pnpm dev-https)
- * so browsers don't block the WebSocket as mixed content.
- * On any other port, returns just the hostname so partysocket uses
- * the deployed server with its own protocol detection.
+ * Returns host and protocol config for usePartySocket.
+ *
+ * partysocket strips any protocol prefix from `host` and then re-determines
+ * ws vs wss based on whether the hostname looks like a private/LAN address —
+ * so LAN IPs (192.168.x.x) always get ws:// regardless of the page protocol.
+ * Passing `protocol` explicitly overrides that detection.
+ *
+ * On port 1999 (local partykit dev) we connect to the local server and use
+ * wss when the page is on HTTPS (e.g. pnpm dev-https) to avoid mixed content.
+ * On any other port we return the deployed hostname; partysocket's default
+ * detection (non-LAN → wss) is correct there.
  */
-export function getPartyHost(): string {
+export function getPartySocketConfig(): { host: string; protocol: 'ws' | 'wss' } {
   if (window.location.port === '1999') {
-    const protocol = window.isSecureContext ? 'wss' : 'ws';
-    return `${protocol}://${window.location.hostname}:1999`;
+    return {
+      host: `${window.location.hostname}:1999`,
+      protocol: window.isSecureContext ? 'wss' : 'ws',
+    };
   }
-  return window.location.hostname;
+  return {
+    host: window.location.hostname,
+    protocol: 'wss',
+  };
+}
+
+/** @deprecated Use getPartySocketConfig() and spread both host and protocol. */
+export function getPartyHost(): string {
+  return getPartySocketConfig().host;
 }

--- a/app/utils/voteRegion.ts
+++ b/app/utils/voteRegion.ts
@@ -29,16 +29,20 @@ export function reactionLabelStyle(anchor: { x: number; y: number }): { position
 
 export function valenceToPosition(valence: number, anchors: ReactionAnchors): { x: number; y: number } {
   const clamped = Math.max(-1, Math.min(1, valence));
+  const centroid = {
+    x: (anchors.negative.x + anchors.neutral.x + anchors.positive.x) / 3,
+    y: (anchors.negative.y + anchors.neutral.y + anchors.positive.y) / 3,
+  };
   if (clamped <= 0) {
-    const t = clamped + 1;
+    const t = clamped + 1; // 0 at valence=-1, 1 at valence=0
     return {
-      x: anchors.negative.x + t * (anchors.neutral.x - anchors.negative.x),
-      y: anchors.negative.y + t * (anchors.neutral.y - anchors.negative.y),
+      x: anchors.negative.x + t * (centroid.x - anchors.negative.x),
+      y: anchors.negative.y + t * (centroid.y - anchors.negative.y),
     };
   } else {
     return {
-      x: anchors.neutral.x + clamped * (anchors.positive.x - anchors.neutral.x),
-      y: anchors.neutral.y + clamped * (anchors.positive.y - anchors.neutral.y),
+      x: centroid.x + clamped * (anchors.positive.x - centroid.x),
+      y: centroid.y + clamped * (anchors.positive.y - centroid.y),
     };
   }
 }

--- a/app/utils/voteRegion.ts
+++ b/app/utils/voteRegion.ts
@@ -27,6 +27,22 @@ export function reactionLabelStyle(anchor: { x: number; y: number }): { position
   };
 }
 
+export function valenceToPosition(valence: number, anchors: ReactionAnchors): { x: number; y: number } {
+  const clamped = Math.max(-1, Math.min(1, valence));
+  if (clamped <= 0) {
+    const t = clamped + 1;
+    return {
+      x: anchors.negative.x + t * (anchors.neutral.x - anchors.negative.x),
+      y: anchors.negative.y + t * (anchors.neutral.y - anchors.negative.y),
+    };
+  } else {
+    return {
+      x: anchors.neutral.x + clamped * (anchors.positive.x - anchors.neutral.x),
+      y: anchors.neutral.y + clamped * (anchors.positive.y - anchors.neutral.y),
+    };
+  }
+}
+
 export function computeReactionRegion(normalizedX: number, normalizedY: number, anchors: ReactionAnchors = DEFAULT_ANCHORS): ReactionRegion {
   const x = normalizedX / 100;
   const y = normalizedY / 100;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "packageManager": "pnpm@10.18.0",
   "scripts": {
     "dev": "partykit dev --live",
+    "https": "caddy run --config Caddyfile",
+    "dev-https": "trap 'kill 0' SIGINT SIGTERM; partykit dev --live & caddy run --config Caddyfile & wait",
     "deploy": "npm run cachebust && partykit deploy",
     "deploy:staging": "pnpm run cachebust && partykit deploy --preview staging",
     "cachebust": "node scripts/build-with-cachebust.js",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "packageManager": "pnpm@10.18.0",
   "scripts": {
     "dev": "partykit dev --live",
-    "https": "caddy run --config Caddyfile",
-    "dev-https": "trap 'kill 0' SIGINT SIGTERM; partykit dev --live & caddy run --config Caddyfile & wait",
+    "dev-https": "partykit dev --live --https",
     "deploy": "npm run cachebust && partykit deploy",
     "deploy:staging": "pnpm run cachebust && partykit deploy --preview staging",
     "cachebust": "node scripts/build-with-cachebust.js",

--- a/party/server.ts
+++ b/party/server.ts
@@ -229,7 +229,7 @@ interface SetOwnValenceDisplayEvent {
 
 interface SetValenceInputModeEvent {
   type: 'setValenceInputMode';
-  mode: 'touch' | 'orientation-horizontal' | 'orientation-vertical';
+  mode: 'touch' | 'orientation-horizontal' | 'orientation-vertical' | 'orientation-rotation';
 }
 
 interface StrokeSegmentEvent {
@@ -317,7 +317,7 @@ export default class Server implements Party.Server {
   private colorCursorsByVote: boolean = false;
   private defaultCursorColor: string = '#d4d4d4';
   private ownValenceDisplay: 'background' | 'labels' | 'none' = 'labels';
-  private valenceInputMode: 'touch' | 'orientation-horizontal' | 'orientation-vertical' = 'touch';
+  private valenceInputMode: 'touch' | 'orientation-horizontal' | 'orientation-vertical' | 'orientation-rotation' = 'touch';
   private roomHost: string | null = null;
   private readonly BAT_SIGNAL_THRESHOLD = 3;
   private seenUserIds = new Set<string>();

--- a/party/server.ts
+++ b/party/server.ts
@@ -227,6 +227,11 @@ interface SetOwnValenceDisplayEvent {
   mode: 'background' | 'labels' | 'none';
 }
 
+interface SetValenceInputModeEvent {
+  type: 'setValenceInputMode';
+  mode: 'touch' | 'orientation-horizontal' | 'orientation-vertical';
+}
+
 interface StrokeSegmentEvent {
   type: 'strokeSegment';
   userId: string;
@@ -244,7 +249,7 @@ interface PersistedState {
   roomSocialConfig: { default: string; twitter: string; bluesky: string; mastodon: string } | null;
 }
 
-type ClientEvent =CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | SetGreeterConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent | RegisterCustomAvatarEvent | SetColorCursorsByVoteEvent | SetDefaultCursorColorEvent | SetOwnValenceDisplayEvent | StrokeSegmentEvent | ClearSignatureEvent;
+type ClientEvent =CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | SetGreeterConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent | RegisterCustomAvatarEvent | SetColorCursorsByVoteEvent | SetDefaultCursorColorEvent | SetOwnValenceDisplayEvent | SetValenceInputModeEvent | StrokeSegmentEvent | ClearSignatureEvent;
 
 // ===== REACTION REGION HELPER (mirrors app/utils/voteRegion.ts) =====
 const DEFAULT_ANCHORS = {
@@ -312,6 +317,7 @@ export default class Server implements Party.Server {
   private colorCursorsByVote: boolean = false;
   private defaultCursorColor: string = '#d4d4d4';
   private ownValenceDisplay: 'background' | 'labels' | 'none' = 'labels';
+  private valenceInputMode: 'touch' | 'orientation-horizontal' | 'orientation-vertical' = 'touch';
   private roomHost: string | null = null;
   private readonly BAT_SIGNAL_THRESHOLD = 3;
   private seenUserIds = new Set<string>();
@@ -503,6 +509,7 @@ export default class Server implements Party.Server {
       colorCursorsByVote: this.colorCursorsByVote,
       defaultCursorColor: this.defaultCursorColor,
       ownValenceDisplay: this.ownValenceDisplay,
+      valenceInputMode: this.valenceInputMode,
     }));
   }
 
@@ -686,6 +693,10 @@ export default class Server implements Party.Server {
         if (!this.adminConnectionIds.has(sender.id)) return;
         this.ownValenceDisplay = event.mode;
         this.room.broadcast(JSON.stringify({ type: 'ownValenceDisplayChanged', ownValenceDisplay: this.ownValenceDisplay }));
+      } else if (event.type === 'setValenceInputMode') {
+        if (!this.adminConnectionIds.has(sender.id)) return;
+        this.valenceInputMode = event.mode;
+        this.room.broadcast(JSON.stringify({ type: 'valenceInputModeChanged', valenceInputMode: this.valenceInputMode }));
       } else if (event.type === 'setDefaultCursorColor') {
         if (!this.adminConnectionIds.has(sender.id)) return;
         this.defaultCursorColor = event.color;


### PR DESCRIPTION
## Summary

- Adds **Orientation (Horizontal)** and **Orientation (Vertical)** as alternative valence input modes alongside the existing Touch mode
- Emcee sets the mode room-wide via a new **Valence Input** tab in the Canvas settings modal (existing display options moved to a **Valence Display** tab)
- In orientation modes, the participant's cursor travels along the disagree → pass → agree anchor path based on phone tilt angle (`beta`), giving live on-screen feedback even without touching the screen
- Angle → valence mapping: Horizontal uses `cos(β)` (face-up = +1, edge-on = 0, face-down = −1); Vertical uses `sin(β)` (upright portrait = +1, flat = 0, upside-down = −1)
- iOS prompts for `DeviceOrientationEvent` permission on first use; Android/desktop require no permission
- Non-secure contexts (HTTP LAN in local dev) are detected and show an explanatory banner — the feature works on HTTPS deployed URLs
- `TouchLayer` stays mounted in orientation mode (`disabled` prop) to avoid mid-handshake WebSocket teardown errors

## Test plan

- [ ] Open emcee panel → Canvas settings → confirm two tabs: "Valence Display" and "Valence Input"
- [ ] Switch to **Orientation (Horizontal)** — all participants receive the change
- [ ] On a deployed HTTPS URL (staging), tilt phone from face-up → edge-on → face-down and confirm cursor moves along the disagree→pass→agree path
- [ ] On iOS: confirm permission prompt appears on first tap; cursor starts moving after granting
- [ ] On local HTTP (`192.168.x.x`): confirm "Orientation needs HTTPS" banner appears instead of silently failing
- [ ] Switch back to **Touch** — touch input resumes normally, no WebSocket errors in console
- [ ] Confirm existing Valence Display options (Background / Labels / None) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~150 words of PR description from ~120 words of human prompts across this session)