### PR TITLE
feat: wake lock indicator + haptic priming fixes for orientation modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file. Releases cu
 - Orientation modes require HTTPS; blocked by Chrome on plain HTTP LAN. iOS prompts for `DeviceOrientationEvent` permission on first tap; Android and other platforms require no permission.
 - `pnpm dev-https` script — runs `partykit dev --live --https` for local HTTPS testing of orientation APIs on LAN devices.
 
+- **Wake lock indicator** — a screen-lock toggle button appears below the vibration icon whenever an orientation valence mode is active. Tap to keep the screen awake during orientation-based sessions; the lock icon (`MdScreenLockLandscape`) shows when held, the screen icon (`MdSmartScreen`) shows when off. The lock is released and hidden automatically when switching back to touch mode.
+
 ### Fixed
 - WebSocket connections now use `wss://` when the page is served over HTTPS, preventing mixed-content errors on LAN addresses (`192.168.x.x`). Extracted shared `getPartySocketConfig()` utility (`app/utils/partyHost.ts`) used by all six socket-holding components. ([#82](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/82))
 

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -468,7 +468,10 @@ export default function ReactionCanvasAppV4() {
             disableCursorValence={activity === 'image-canvas'}
             disableBackgroundValence={activity === 'image-canvas'}
             onOwnValenceDisplayChange={setOwnValenceDisplay}
-            onValenceInputModeChange={setValenceInputMode}
+            onValenceInputModeChange={(mode) => {
+              if (hasConnectedRef.current && !isEmcee) triggerBuzzForUpdate();
+              setValenceInputMode(mode);
+            }}
             currentReactionState={canvasBackgroundReactionState}
             heightOffset={chipBarOffset}
             onPresenceCount={setPresenceCount}

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -24,6 +24,7 @@ import ShareQRButton from "./ShareQRButton";
 import QRWithCopy from "./QRWithCopy";
 import { parseInviteChain, appendSelfToChain, chainToEdges, storeChain, getStoredChain } from "../utils/inviteChain";
 import HapticIndicatorButton from "./HapticIndicatorButton";
+import WakeLockIndicatorButton from "./WakeLockIndicatorButton";
 import Treevites from "./Treevites";
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
@@ -162,9 +163,12 @@ export default function ReactionCanvasAppV4() {
   const hapticFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasConnectedRef = useRef(false);
   const { trigger: triggerHaptic } = useWebHaptics();
+  const [wakeLockEnabled, setWakeLockEnabled] = useState(false);
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
 
   // Derived early so useCallback deps below can reference it (must still be before any early return)
   const isEmcee = unlockedInterfaces.includes('emcee');
+  const isOrientationMode = valenceInputMode !== 'touch';
 
   const triggerBuzzForUpdate = useCallback(() => {
     if (hapticFlashTimeoutRef.current) clearTimeout(hapticFlashTimeoutRef.current);
@@ -203,6 +207,53 @@ export default function ReactionCanvasAppV4() {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
+
+  const acquireWakeLock = useCallback(async () => {
+    if (!('wakeLock' in navigator)) return;
+    try {
+      wakeLockRef.current = await navigator.wakeLock.request('screen');
+    } catch {
+      // Wake lock request failed (e.g. low battery, non-secure context)
+    }
+  }, []);
+
+  const releaseWakeLock = useCallback(async () => {
+    if (wakeLockRef.current) {
+      await wakeLockRef.current.release();
+      wakeLockRef.current = null;
+    }
+  }, []);
+
+  const toggleWakeLock = useCallback(() => {
+    setWakeLockEnabled(prev => !prev);
+  }, []);
+
+  useEffect(() => {
+    if (wakeLockEnabled && isOrientationMode) {
+      acquireWakeLock();
+    } else {
+      releaseWakeLock();
+    }
+  }, [wakeLockEnabled, isOrientationMode, acquireWakeLock, releaseWakeLock]);
+
+  // Re-acquire wake lock after tab becomes visible again (API releases it on hide)
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible' && wakeLockEnabled && isOrientationMode) {
+        acquireWakeLock();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+  }, [wakeLockEnabled, isOrientationMode, acquireWakeLock]);
+
+  // Release and reset wake lock when switching away from orientation mode
+  useEffect(() => {
+    if (!isOrientationMode) {
+      releaseWakeLock();
+      setWakeLockEnabled(false);
+    }
+  }, [isOrientationMode, releaseWakeLock]);
 
   const requestOrientationPermission = useCallback(async () => {
     if (typeof DeviceOrientationEvent !== 'undefined' &&
@@ -395,6 +446,13 @@ export default function ReactionCanvasAppV4() {
               canVibrate={WebHaptics.isSupported}
               onToggle={() => { if (WebHaptics.isSupported) setHapticEnabled(prev => !prev); }}
               onShowInfo={() => setHapticPending(true)}
+            />
+          )}
+          {isOrientationMode && (
+            <WakeLockIndicatorButton
+              enabled={wakeLockEnabled}
+              active={wakeLockRef.current !== null}
+              onToggle={toggleWakeLock}
             />
           )}
           {touchPos && (

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -24,6 +24,7 @@ import ShareQRButton from "./ShareQRButton";
 import QRWithCopy from "./QRWithCopy";
 import { parseInviteChain, appendSelfToChain, chainToEdges, storeChain, getStoredChain } from "../utils/inviteChain";
 import HapticIndicatorButton from "./HapticIndicatorButton";
+import { useHapticPriming } from "../hooks/useHapticPriming";
 import WakeLockIndicatorButton from "./WakeLockIndicatorButton";
 import Treevites from "./Treevites";
 
@@ -158,14 +159,9 @@ export default function ReactionCanvasAppV4() {
   const [suppressHapticModal, setSuppressHapticModal] = useState(
     () => localStorage.getItem('v4-suppress-haptic-modal') !== 'false'
   );
-  const [hapticEnabled, setHapticEnabled] = useState(WebHaptics.isSupported);
-  // False on haptic-capable devices until first touch; true elsewhere (no priming needed).
-  const [vibrationPrimed, setVibrationPrimed] = useState(!WebHaptics.isSupported);
+  const { hapticEnabled, effectivelyEnabled: hapticEffectivelyEnabled, onPointerDown: hapticOnPointerDown, onToggle: hapticOnToggle } = useHapticPriming();
   const [hapticFlashing, setHapticFlashing] = useState(false);
   const hapticFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // Captures whether the button was unprimed at pointerdown, so click can skip the toggle
-  // when the first touch is the button itself (avoiding an accidental disable).
-  const hapticWasUnprimedRef = useRef(false);
   const hasConnectedRef = useRef(false);
   const { trigger: triggerHaptic } = useWebHaptics();
   const [wakeLockEnabled, setWakeLockEnabled] = useState(false);
@@ -211,18 +207,6 @@ export default function ReactionCanvasAppV4() {
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, []);
-
-  // Android Chrome gates navigator.vibrate() on prior user interaction. Prime it
-  // on first touch so socket-triggered buzzes work without needing a manual toggle.
-  useEffect(() => {
-    if (!WebHaptics.isSupported) return;
-    const prime = () => {
-      navigator.vibrate(0);
-      setVibrationPrimed(true);
-    };
-    document.addEventListener('touchstart', prime, { once: true });
-    return () => document.removeEventListener('touchstart', prime);
   }, []);
 
   const acquireWakeLock = useCallback(async () => {
@@ -457,20 +441,12 @@ export default function ReactionCanvasAppV4() {
           <div className={`v3-rec-badge${isRecording ? '' : ' v3-rec-badge--off'}`}>● REC</div>
           <ShareQRButton selfId={userId} selfChain={selfChain} />
           {activity !== 'signature' && (
-            <div onPointerDown={() => { hapticWasUnprimedRef.current = !vibrationPrimed; }}>
+            <div onPointerDown={hapticOnPointerDown}>
               <HapticIndicatorButton
-                enabled={hapticEnabled && vibrationPrimed}
+                enabled={hapticEffectivelyEnabled}
                 flashing={hapticFlashing}
                 canVibrate={WebHaptics.isSupported}
-                onToggle={() => {
-                  if (WebHaptics.isSupported) {
-                    if (hapticWasUnprimedRef.current) {
-                      hapticWasUnprimedRef.current = false;
-                    } else {
-                      setHapticEnabled(prev => !prev);
-                    }
-                  }
-                }}
+                onToggle={hapticOnToggle}
                 onShowInfo={() => setHapticPending(true)}
               />
             </div>

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -208,6 +208,15 @@ export default function ReactionCanvasAppV4() {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
+  // Android Chrome gates navigator.vibrate() on prior user interaction. Prime it
+  // on first touch so socket-triggered buzzes work without needing a manual toggle.
+  useEffect(() => {
+    if (!WebHaptics.isSupported) return;
+    const prime = () => navigator.vibrate(0);
+    document.addEventListener('touchstart', prime, { once: true });
+    return () => document.removeEventListener('touchstart', prime);
+  }, []);
+
   const acquireWakeLock = useCallback(async () => {
     if (!('wakeLock' in navigator)) return;
     try {

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -159,6 +159,9 @@ export default function ReactionCanvasAppV4() {
     () => localStorage.getItem('v4-suppress-haptic-modal') !== 'false'
   );
   const [hapticEnabled, setHapticEnabled] = useState(WebHaptics.isSupported);
+  // Stays false on supported devices until first touch primes the Vibration API.
+  // Initialized to true on unsupported devices so the button just shows as disabled normally.
+  const [vibrationPrimed, setVibrationPrimed] = useState(!WebHaptics.isSupported);
   const [hapticFlashing, setHapticFlashing] = useState(false);
   const hapticFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasConnectedRef = useRef(false);
@@ -212,7 +215,10 @@ export default function ReactionCanvasAppV4() {
   // on first touch so socket-triggered buzzes work without needing a manual toggle.
   useEffect(() => {
     if (!WebHaptics.isSupported) return;
-    const prime = () => navigator.vibrate(0);
+    const prime = () => {
+      navigator.vibrate(0);
+      setVibrationPrimed(true);
+    };
     document.addEventListener('touchstart', prime, { once: true });
     return () => document.removeEventListener('touchstart', prime);
   }, []);
@@ -450,7 +456,7 @@ export default function ReactionCanvasAppV4() {
           <ShareQRButton selfId={userId} selfChain={selfChain} />
           {activity !== 'signature' && (
             <HapticIndicatorButton
-              enabled={hapticEnabled}
+              enabled={hapticEnabled && vibrationPrimed}
               flashing={hapticFlashing}
               canVibrate={WebHaptics.isSupported}
               onToggle={() => { if (WebHaptics.isSupported) setHapticEnabled(prev => !prev); }}

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -159,11 +159,13 @@ export default function ReactionCanvasAppV4() {
     () => localStorage.getItem('v4-suppress-haptic-modal') !== 'false'
   );
   const [hapticEnabled, setHapticEnabled] = useState(WebHaptics.isSupported);
-  // Stays false on supported devices until first touch primes the Vibration API.
-  // Initialized to true on unsupported devices so the button just shows as disabled normally.
+  // False on haptic-capable devices until first touch; true elsewhere (no priming needed).
   const [vibrationPrimed, setVibrationPrimed] = useState(!WebHaptics.isSupported);
   const [hapticFlashing, setHapticFlashing] = useState(false);
   const hapticFlashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Captures whether the button was unprimed at pointerdown, so click can skip the toggle
+  // when the first touch is the button itself (avoiding an accidental disable).
+  const hapticWasUnprimedRef = useRef(false);
   const hasConnectedRef = useRef(false);
   const { trigger: triggerHaptic } = useWebHaptics();
   const [wakeLockEnabled, setWakeLockEnabled] = useState(false);
@@ -455,13 +457,23 @@ export default function ReactionCanvasAppV4() {
           <div className={`v3-rec-badge${isRecording ? '' : ' v3-rec-badge--off'}`}>● REC</div>
           <ShareQRButton selfId={userId} selfChain={selfChain} />
           {activity !== 'signature' && (
-            <HapticIndicatorButton
-              enabled={hapticEnabled && vibrationPrimed}
-              flashing={hapticFlashing}
-              canVibrate={WebHaptics.isSupported}
-              onToggle={() => { if (WebHaptics.isSupported) setHapticEnabled(prev => !prev); }}
-              onShowInfo={() => setHapticPending(true)}
-            />
+            <div onPointerDown={() => { hapticWasUnprimedRef.current = !vibrationPrimed; }}>
+              <HapticIndicatorButton
+                enabled={hapticEnabled && vibrationPrimed}
+                flashing={hapticFlashing}
+                canVibrate={WebHaptics.isSupported}
+                onToggle={() => {
+                  if (WebHaptics.isSupported) {
+                    if (hapticWasUnprimedRef.current) {
+                      hapticWasUnprimedRef.current = false;
+                    } else {
+                      setHapticEnabled(prev => !prev);
+                    }
+                  }
+                }}
+                onShowInfo={() => setHapticPending(true)}
+              />
+            </div>
           )}
           {isOrientationMode && (
             <WakeLockIndicatorButton

--- a/app/components/WakeLockIndicatorButton.tsx
+++ b/app/components/WakeLockIndicatorButton.tsx
@@ -1,0 +1,24 @@
+import { MdScreenLockLandscape, MdSmartScreen } from "react-icons/md";
+
+interface Props {
+  enabled: boolean;
+  active: boolean;
+  onToggle: () => void;
+}
+
+export default function WakeLockIndicatorButton({ enabled, active, onToggle }: Props) {
+  const classes = [
+    'wakelock-indicator-btn',
+    !enabled ? 'wakelock-indicator-btn--off' : '',
+  ].filter(Boolean).join(' ');
+
+  return (
+    <button
+      className={classes}
+      onClick={onToggle}
+      aria-label={enabled ? "Disable screen wake lock" : "Enable screen wake lock"}
+    >
+      {enabled && active ? <MdScreenLockLandscape size={20} /> : <MdSmartScreen size={20} />}
+    </button>
+  );
+}

--- a/app/hooks/useHapticPriming.ts
+++ b/app/hooks/useHapticPriming.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { WebHaptics } from "web-haptics";
+
+export function useHapticPriming() {
+  const [hapticEnabled, setHapticEnabled] = useState(WebHaptics.isSupported);
+  const [vibrationPrimed, setVibrationPrimed] = useState(!WebHaptics.isSupported);
+  const hapticWasUnprimedRef = useRef(false);
+
+  // Android Chrome gates navigator.vibrate() on prior user interaction. Prime it
+  // on first touch so socket-triggered buzzes work without needing a manual toggle.
+  useEffect(() => {
+    if (!WebHaptics.isSupported) return;
+    const prime = () => {
+      navigator.vibrate(0);
+      setVibrationPrimed(true);
+    };
+    document.addEventListener('touchstart', prime, { once: true });
+    return () => document.removeEventListener('touchstart', prime);
+  }, []);
+
+  // Capture whether the button was unprimed at pointerdown (before touchstart fires),
+  // so the click handler can skip the toggle when the first touch lands on the icon.
+  const onPointerDown = useCallback(() => {
+    hapticWasUnprimedRef.current = !vibrationPrimed;
+  }, [vibrationPrimed]);
+
+  const onToggle = useCallback(() => {
+    if (!WebHaptics.isSupported) return;
+    if (hapticWasUnprimedRef.current) {
+      hapticWasUnprimedRef.current = false;
+    } else {
+      setHapticEnabled(prev => !prev);
+    }
+  }, []);
+
+  return {
+    hapticEnabled,
+    effectivelyEnabled: hapticEnabled && vibrationPrimed,
+    onPointerDown,
+    onToggle,
+  };
+}

--- a/app/styles.css
+++ b/app/styles.css
@@ -1582,7 +1582,7 @@ body {
 
 .wakelock-indicator-btn {
   position: absolute;
-  top: 136px;
+  top: 128px;
   left: 8px;
   z-index: 200;
   background: transparent;

--- a/app/styles.css
+++ b/app/styles.css
@@ -1588,7 +1588,7 @@ body {
   background: transparent;
   border: none;
   border-radius: 8px;
-  color: rgba(0, 0, 0, 0.6);
+  color: rgba(0, 0, 0, 0.3);
   cursor: pointer;
   padding: 8px;
   display: flex;
@@ -1598,7 +1598,7 @@ body {
 }
 
 .wakelock-indicator-btn--off {
-  color: rgba(0, 0, 0, 0.2);
+  color: rgba(0, 0, 0, 0.15);
 }
 
 .share-qr-modal {

--- a/app/styles.css
+++ b/app/styles.css
@@ -1580,6 +1580,27 @@ body {
   color: rgba(0, 0, 0, 0.75);
 }
 
+.wakelock-indicator-btn {
+  position: absolute;
+  top: 136px;
+  left: 8px;
+  z-index: 200;
+  background: transparent;
+  border: none;
+  border-radius: 8px;
+  color: rgba(0, 0, 0, 0.6);
+  cursor: pointer;
+  padding: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.15s ease;
+}
+
+.wakelock-indicator-btn--off {
+  color: rgba(0, 0, 0, 0.2);
+}
+
 .share-qr-modal {
   position: fixed;
   inset: 0;


### PR DESCRIPTION
## Summary

- Adds a toggleable **screen wake lock button** that appears below the vibration icon whenever an orientation valence mode is active — keeps the screen on during tilt-based sessions, auto-releases when switching back to touch mode
- Buzzes on **valence input mode change**, matching the existing label/activity change behaviour
- Fixes Android haptic feedback not working until the user manually toggled the icon off and on:
  - Primes `navigator.vibrate()` on first touch (Android Chrome gates the API on prior user interaction)
  - Haptic icon starts dim until primed, lighting up on first touch
  - If first touch lands on the icon itself, the toggle is skipped (button was already internally enabled — prevents accidental disable)
- Extracts all priming logic into `app/hooks/useHapticPriming.ts`

## Test plan

- [ ] Select an orientation valence mode — wake lock button appears below vibration icon
- [ ] Tap wake lock button — icon darkens, screen stays on; tap again to release
- [ ] Switch back to touch mode — wake lock button disappears, lock released
- [ ] On Android: reload page, confirm haptic icon starts dim; first touch anywhere lights it up and buzzes work
- [ ] On Android: reload page, tap haptic icon as first touch — icon lights up (not toggled off)
- [ ] Change valence input mode — haptic buzz fires

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~120 words of PR description from ~200 words of human prompts across this session)