### PR TITLE
feat: Steno interface — live shared speech-to-text transcription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 25 (2026-05-11)
 
 ### Added
-- **Steno interface** — a new V4 interface for live shared speech-to-text transcription. Unlock via `?interface=steno`, or push it to participants via the Emcee → Participants tab. Features: streaming Web Speech API (`continuous` mode with interim-text preview), a single-user recording mutex (one person transcribes at a time), server-persisted transcript shared live to all connected participants, Wake Lock while recording, and editable textarea (read-only for observers while another user holds the lock).
+- **Steno interface** — a new V4 interface for live shared speech-to-text transcription. Unlock via `?interface=steno`, or push it to participants via the Emcee → Participants tab. Features: streaming Web Speech API (`continuous` mode with interim-text preview), a single-user recording mutex (one person transcribes at a time), server-persisted transcript shared live to all connected participants, Wake Lock while recording, and editable textarea (read-only for observers while another user holds the lock). ([#85](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/85))
 - Canvas settings modal: **Valence Input tab** — emcee can now switch participants between four input modes ([#82](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/82)):
   - **Touch** (default) — finger position on canvas
   - **Orientation (Horizontal)** — phone face-up = agree, face-down = disagree; works for any flip direction or combination (`cos β · cos γ`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 25 (2026-05-11)
 
 ### Added
+- **Steno interface** — a new V4 interface for live shared speech-to-text transcription. Unlock via `?interface=steno`, or push it to participants via the Emcee → Participants tab. Features: streaming Web Speech API (`continuous` mode with interim-text preview), a single-user recording mutex (one person transcribes at a time), server-persisted transcript shared live to all connected participants, Wake Lock while recording, and editable textarea (read-only for observers while another user holds the lock).
 - Canvas settings modal: **Valence Input tab** — emcee can now switch participants between four input modes ([#82](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/82)):
   - **Touch** (default) — finger position on canvas
   - **Orientation (Horizontal)** — phone face-up = agree, face-down = disagree; works for any flip direction or combination (`cos β · cos γ`)

--- a/app/components/AdminPanelV4/OfferInterfaceModal.tsx
+++ b/app/components/AdminPanelV4/OfferInterfaceModal.tsx
@@ -56,6 +56,7 @@ export default function OfferInterfaceModal({
           <option value="treevites">treevites</option>
           <option value="greeter">greeter</option>
           <option value="emcee">emcee</option>
+          <option value="steno">steno</option>
         </select>
         <div style={{ display: 'flex', gap: 8 }}>
           <button

--- a/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
+++ b/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
@@ -46,7 +46,7 @@ const ROWS: { id: string; label: string; desc: string; patchable: boolean; activ
   { id: 'mood-tones',   label: 'Mood Tones',      desc: 'Generative audio keyed to audience reactions',  patchable: true,  activityMode: true  },
   { id: 'treevites',    label: 'Leaderboard',     desc: 'Invite stats — who invited whom',                patchable: true,  activityMode: true  },
   { id: 'greeter',      label: 'Greeter',         desc: 'Guild event attendee welcome list',              patchable: true,  activityMode: true  },
-  { id: 'steno',        label: 'Steno',           desc: 'Live shared speech-to-text transcript',          patchable: true,  activityMode: false },
+  { id: 'steno',        label: 'Steno',           desc: 'Live shared speech-to-text transcript',          patchable: true,  activityMode: true  },
 ];
 
 export default function InterfacesTab({

--- a/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
+++ b/app/components/AdminPanelV4/tabs/InterfacesTab.tsx
@@ -46,6 +46,7 @@ const ROWS: { id: string; label: string; desc: string; patchable: boolean; activ
   { id: 'mood-tones',   label: 'Mood Tones',      desc: 'Generative audio keyed to audience reactions',  patchable: true,  activityMode: true  },
   { id: 'treevites',    label: 'Leaderboard',     desc: 'Invite stats — who invited whom',                patchable: true,  activityMode: true  },
   { id: 'greeter',      label: 'Greeter',         desc: 'Guild event attendee welcome list',              patchable: true,  activityMode: true  },
+  { id: 'steno',        label: 'Steno',           desc: 'Live shared speech-to-text transcript',          patchable: true,  activityMode: false },
 ];
 
 export default function InterfacesTab({

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -415,8 +415,11 @@ export default function ReactionCanvasAppV4() {
       {activeInterface === 'canvas' && activity === 'greeter' && (
         <GreeterPanel greeterConfig={serverGreeterConfig} />
       )}
+      {activeInterface === 'canvas' && activity === 'steno' && (
+        <StenoPanel room={room} userId={userId} />
+      )}
       {/* Canvas is always mounted to keep the WebSocket alive for all interfaces */}
-      <div className="v2-vote-canvas-container" style={{ flex: 1, display: (activeInterface === 'canvas' && activity !== 'social' && activity !== 'mood-tones' && activity !== 'treevites' && activity !== 'greeter') ? undefined : 'none' }}>
+      <div className="v2-vote-canvas-container" style={{ flex: 1, display: (activeInterface === 'canvas' && activity !== 'social' && activity !== 'mood-tones' && activity !== 'treevites' && activity !== 'greeter' && activity !== 'steno') ? undefined : 'none' }}>
           {activity === 'image-canvas' && serverImageUrl && (
             <img
               src={serverImageUrl}

--- a/app/components/ReactionCanvasAppV4.tsx
+++ b/app/components/ReactionCanvasAppV4.tsx
@@ -27,6 +27,7 @@ import HapticIndicatorButton from "./HapticIndicatorButton";
 import { useHapticPriming } from "../hooks/useHapticPriming";
 import WakeLockIndicatorButton from "./WakeLockIndicatorButton";
 import Treevites from "./Treevites";
+import StenoPanel from "./StenoPanel";
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
 
@@ -65,6 +66,7 @@ function getUnlockedInterfaces(): string[] {
   if (p.get('interface') === 'mood-tones') interfaces.push('mood-tones');
   if (p.get('interface') === 'treevites') interfaces.push('treevites');
   if (p.get('interface') === 'greeter') interfaces.push('greeter');
+  if (p.get('interface') === 'steno') interfaces.push('steno');
   try {
     const stored = JSON.parse(localStorage.getItem(PUSHED_INTERFACES_KEY) ?? '[]');
     if (Array.isArray(stored)) {
@@ -370,7 +372,7 @@ export default function ReactionCanvasAppV4() {
 
   const showChipBar = unlockedInterfaces.length >= 2;
   const chipBarOffset = showChipBar ? CHIP_BAR_HEIGHT : 0;
-  const KNOWN_CHIPS: Record<string, string> = { canvas: 'Canvas', emcee: 'Emcee', social: 'Social', 'mood-tones': 'Mood Tones', treevites: 'Leaderboard', greeter: 'Greeter' };
+  const KNOWN_CHIPS: Record<string, string> = { canvas: 'Canvas', emcee: 'Emcee', social: 'Social', 'mood-tones': 'Mood Tones', treevites: 'Leaderboard', greeter: 'Greeter', steno: 'Steno' };
   const INTERFACE_CHIPS = unlockedInterfaces.map(key => ({
     key,
     label: KNOWN_CHIPS[key] ?? (key.charAt(0).toUpperCase() + key.slice(1)),
@@ -395,6 +397,8 @@ export default function ReactionCanvasAppV4() {
         <Treevites selfId={userId} inviteEdges={inviteEdges} />
       ) : activeInterface === 'greeter' ? (
         <GreeterPanel greeterConfig={serverGreeterConfig} />
+      ) : activeInterface === 'steno' ? (
+        <StenoPanel room={room} userId={userId} />
       ) : null}
       {/* When activity is 'social', show SocialPanel as a flex sibling (fills the
           remaining height below the chip bar, same as the chip-based case).

--- a/app/components/StenoPanel.tsx
+++ b/app/components/StenoPanel.tsx
@@ -22,12 +22,17 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
   const wakeLockRef = useRef<WakeLockSentinel | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const recognitionRef = useRef<any>(null);
+  // baseTextRef: server text captured when recording started; carried forward across
+  // onend/restart cycles so each new recognition run appends to the right base.
+  // sessionFinalRef: transcript of the latest final result in the current run.
+  const baseTextRef = useRef('');
+  const sessionFinalRef = useRef('');
 
   const acquireWakeLock = useCallback(async () => {
     if (!('wakeLock' in navigator)) return;
     try {
       wakeLockRef.current = await navigator.wakeLock.request('screen');
-    } catch { /* wake lock unavailable (low battery, non-secure context, etc.) */ }
+    } catch { /* unavailable: low battery, non-secure context, etc. */ }
   }, []);
 
   const releaseWakeLock = useCallback(async () => {
@@ -78,11 +83,13 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
 
   const startRecording = useCallback(() => {
     socket.send(JSON.stringify({ type: 'stenoStartRecording', userId }));
+    baseTextRef.current = stenoText;
+    sessionFinalRef.current = '';
     setIsRecording(true);
     isRecordingRef.current = true;
     acquireWakeLock();
     try { recognitionRef.current?.start(); } catch { /* ignore if already started */ }
-  }, [socket, userId, acquireWakeLock]);
+  }, [socket, userId, acquireWakeLock, stenoText]);
 
   useEffect(() => {
     if (!SpeechRecognitionCtor) return;
@@ -94,18 +101,25 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     r.onresult = (e: any) => {
       let interim = '';
-      let finalChunk = '';
-      for (let i = e.resultIndex; i < e.results.length; i++) {
-        if (e.results[i].isFinal) {
-          finalChunk += e.results[i][0].transcript;
-        } else {
-          interim += e.results[i][0].transcript;
-        }
+      for (let i = 0; i < e.results.length; i++) {
+        if (!e.results[i].isFinal) interim += e.results[i][0].transcript;
       }
       setInterimText(interim);
-      if (finalChunk.trim()) {
-        socket.send(JSON.stringify({ type: 'stenoAppendText', userId, text: finalChunk.trim() }));
-      }
+
+      // Only process the result that just changed (e.resultIndex).
+      // On Android Chrome each event fires with a new resultIndex whose transcript
+      // is the full phrase accumulated so far — concatenating ALL results would
+      // duplicate words. On desktop a single result becomes final with the whole phrase.
+      const latest = e.results[e.resultIndex];
+      if (!latest.isFinal) return;
+
+      const transcript = latest[0].transcript.trim();
+      if (!transcript || transcript === sessionFinalRef.current) return;
+
+      sessionFinalRef.current = transcript;
+      const base = baseTextRef.current.trimEnd();
+      const fullText = base ? `${base} ${transcript}` : transcript;
+      socket.send(JSON.stringify({ type: 'stenoSetText', userId, text: fullText }));
     };
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -117,8 +131,15 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
     };
 
     r.onend = () => {
-      // Chrome auto-stops after silence in continuous mode — restart if still recording
+      // Mobile browsers stop recognition after each phrase; restart if still recording.
+      // Promote sessionFinalRef into baseTextRef so the next run appends correctly.
       if (isRecordingRef.current) {
+        const session = sessionFinalRef.current.trim();
+        if (session) {
+          const base = baseTextRef.current.trimEnd();
+          baseTextRef.current = base ? `${base} ${session}` : session;
+          sessionFinalRef.current = '';
+        }
         try { r.start(); } catch { /* ignore */ }
       }
     };
@@ -156,7 +177,7 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
           disabled={isLockedByOther || !SpeechRecognitionCtor}
           title={
             !SpeechRecognitionCtor ? 'Speech recognition not supported in this browser'
-            : isLockedByOther ? `Another participant is recording`
+            : isLockedByOther ? 'Another participant is recording'
             : isRecording ? 'Stop transcribing'
             : 'Start transcribing'
           }

--- a/app/components/StenoPanel.tsx
+++ b/app/components/StenoPanel.tsx
@@ -1,0 +1,170 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import usePartySocket from "partysocket/react";
+import { getPartySocketConfig } from "../utils/partyHost";
+import { MdKeyboard, MdStopCircle } from "react-icons/md";
+import { MdScreenLockLandscape } from "react-icons/md";
+
+interface StenoPanelProps {
+  room: string;
+  userId: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const SpeechRecognitionCtor: (new () => any) | null =
+  (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition ?? null; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+export default function StenoPanel({ room, userId }: StenoPanelProps) {
+  const [stenoText, setStenoText] = useState('');
+  const [interimText, setInterimText] = useState('');
+  const [lockHolder, setLockHolder] = useState<string | null>(null);
+  const [isRecording, setIsRecording] = useState(false);
+  const isRecordingRef = useRef(false);
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const recognitionRef = useRef<any>(null);
+
+  const acquireWakeLock = useCallback(async () => {
+    if (!('wakeLock' in navigator)) return;
+    try {
+      wakeLockRef.current = await navigator.wakeLock.request('screen');
+    } catch { /* wake lock unavailable (low battery, non-secure context, etc.) */ }
+  }, []);
+
+  const releaseWakeLock = useCallback(async () => {
+    if (wakeLockRef.current) {
+      await wakeLockRef.current.release();
+      wakeLockRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible' && isRecordingRef.current) acquireWakeLock();
+    };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [acquireWakeLock]);
+
+  const socket = usePartySocket({
+    ...getPartySocketConfig(),
+    room,
+    query: { userId },
+    onMessage(evt) {
+      const data = JSON.parse(evt.data);
+      if (data.type === 'connected') {
+        setStenoText(data.stenoText ?? '');
+        setLockHolder(data.stenoLockUserId ?? null);
+        return;
+      }
+      if (data.type === 'stenoTextChanged') { setStenoText(data.text); return; }
+      if (data.type === 'stenoLockAcquired') { setLockHolder(data.userId); return; }
+      if (data.type === 'stenoLockReleased') {
+        setLockHolder(null);
+        if (data.userId === userId) stopRecording();
+        return;
+      }
+    },
+  });
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const stopRecording = useCallback(() => {
+    setIsRecording(false);
+    isRecordingRef.current = false;
+    setInterimText('');
+    releaseWakeLock();
+    try { recognitionRef.current?.stop(); } catch { /* ignore */ }
+    socket.send(JSON.stringify({ type: 'stenoStopRecording', userId }));
+  }, [socket, userId, releaseWakeLock]);
+
+  const startRecording = useCallback(() => {
+    socket.send(JSON.stringify({ type: 'stenoStartRecording', userId }));
+    setIsRecording(true);
+    isRecordingRef.current = true;
+    acquireWakeLock();
+    try { recognitionRef.current?.start(); } catch { /* ignore if already started */ }
+  }, [socket, userId, acquireWakeLock]);
+
+  useEffect(() => {
+    if (!SpeechRecognitionCtor) return;
+    const r = new SpeechRecognitionCtor();
+    r.continuous = true;
+    r.interimResults = true;
+    r.lang = 'en-US';
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    r.onresult = (e: any) => {
+      let interim = '';
+      let finalChunk = '';
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        if (e.results[i].isFinal) {
+          finalChunk += e.results[i][0].transcript;
+        } else {
+          interim += e.results[i][0].transcript;
+        }
+      }
+      setInterimText(interim);
+      if (finalChunk.trim()) {
+        socket.send(JSON.stringify({ type: 'stenoAppendText', userId, text: finalChunk.trim() }));
+      }
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    r.onerror = (e: any) => {
+      if (e.error === 'not-allowed' || e.error === 'service-not-allowed') {
+        setIsRecording(false);
+        isRecordingRef.current = false;
+      }
+    };
+
+    r.onend = () => {
+      // Chrome auto-stops after silence in continuous mode — restart if still recording
+      if (isRecordingRef.current) {
+        try { r.start(); } catch { /* ignore */ }
+      }
+    };
+
+    recognitionRef.current = r;
+    return () => { try { r.abort(); } catch { /* ignore */ } };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const isLockedByOther = lockHolder !== null && lockHolder !== userId;
+
+  return (
+    <div className="steno-panel">
+      <div className="steno-body">
+        <textarea
+          className="steno-textarea"
+          value={stenoText}
+          placeholder="Transcription will appear here..."
+          readOnly={isLockedByOther}
+          onChange={e => {
+            if (isLockedByOther) return;
+            socket.send(JSON.stringify({ type: 'stenoSetText', userId, text: e.target.value }));
+          }}
+        />
+        {interimText && <div className="steno-interim">{interimText}</div>}
+      </div>
+      <div className="steno-footer">
+        {isRecording && (
+          <span className="steno-wakelock-hint" title="Screen lock active">
+            <MdScreenLockLandscape size={16} />
+          </span>
+        )}
+        <button
+          className={`steno-record-btn${isRecording ? ' steno-record-btn--active' : ''}${isLockedByOther ? ' steno-record-btn--locked' : ''}`}
+          onClick={isRecording ? stopRecording : startRecording}
+          disabled={isLockedByOther || !SpeechRecognitionCtor}
+          title={
+            !SpeechRecognitionCtor ? 'Speech recognition not supported in this browser'
+            : isLockedByOther ? `Another participant is recording`
+            : isRecording ? 'Stop transcribing'
+            : 'Start transcribing'
+          }
+        >
+          {isRecording ? <MdStopCircle size={20} /> : <MdKeyboard size={20} />}
+          {isRecording ? 'Stop' : isLockedByOther ? 'In use' : 'Transcribe'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/StenoPanel.tsx
+++ b/app/components/StenoPanel.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import usePartySocket from "partysocket/react";
 import { getPartySocketConfig } from "../utils/partyHost";
 import { MdKeyboard, MdStopCircle } from "react-icons/md";
-import { MdScreenLockLandscape } from "react-icons/md";
+import WakeLockIndicatorButton from "./WakeLockIndicatorButton";
 
 interface StenoPanelProps {
   room: string;
@@ -18,6 +18,7 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
   const [interimText, setInterimText] = useState('');
   const [lockHolder, setLockHolder] = useState<string | null>(null);
   const [isRecording, setIsRecording] = useState(false);
+  const [wakeLockActive, setWakeLockActive] = useState(false);
   const isRecordingRef = useRef(false);
   const wakeLockRef = useRef<WakeLockSentinel | null>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,6 +33,7 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
     if (!('wakeLock' in navigator)) return;
     try {
       wakeLockRef.current = await navigator.wakeLock.request('screen');
+      setWakeLockActive(true);
     } catch { /* unavailable: low battery, non-secure context, etc. */ }
   }, []);
 
@@ -39,6 +41,7 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
     if (wakeLockRef.current) {
       await wakeLockRef.current.release();
       wakeLockRef.current = null;
+      setWakeLockActive(false);
     }
   }, []);
 
@@ -166,11 +169,11 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
         {interimText && <div className="steno-interim">{interimText}</div>}
       </div>
       <div className="steno-footer">
-        {isRecording && (
-          <span className="steno-wakelock-hint" title="Screen lock active">
-            <MdScreenLockLandscape size={16} />
-          </span>
-        )}
+        <WakeLockIndicatorButton
+          enabled={isRecording}
+          active={wakeLockActive}
+          onToggle={() => {}}
+        />
         <button
           className={`steno-record-btn${isRecording ? ' steno-record-btn--active' : ''}${isLockedByOther ? ' steno-record-btn--locked' : ''}`}
           onClick={isRecording ? stopRecording : startRecording}

--- a/app/styles.css
+++ b/app/styles.css
@@ -1963,6 +1963,18 @@ body {
   overflow: hidden;
 }
 
+/* Wake lock button — inverted for dark panel background, anchored left in footer */
+.steno-panel .wakelock-indicator-btn {
+  position: absolute;
+  left: 8px;
+  top: unset;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.steno-panel .wakelock-indicator-btn--off {
+  color: rgba(255, 255, 255, 0.15);
+}
+
 .steno-body {
   flex: 1;
   display: flex;
@@ -2013,10 +2025,10 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
   padding: 10px 12px 14px;
   border-top: 1px solid #222;
   flex-shrink: 0;
+  position: relative;
 }
 
 .steno-record-btn {
@@ -2045,8 +2057,3 @@ body {
   cursor: not-allowed;
 }
 
-.steno-wakelock-hint {
-  color: rgba(255, 255, 255, 0.3);
-  display: flex;
-  align-items: center;
-}

--- a/app/styles.css
+++ b/app/styles.css
@@ -1951,3 +1951,102 @@ body {
   padding: 1px 6px;
   flex-shrink: 0;
 }
+
+/* ── Steno interface ── */
+.steno-panel {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #0f0f0e;
+  color: #ccc;
+  font-family: monospace;
+  overflow: hidden;
+}
+
+.steno-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 12px;
+  gap: 6px;
+  min-height: 0;
+}
+
+.steno-textarea {
+  flex: 1;
+  width: 100%;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 8px;
+  color: #ddd;
+  font-size: 15px;
+  font-family: monospace;
+  line-height: 1.6;
+  padding: 10px;
+  resize: none;
+  overflow-y: scroll;
+  /* Override body's user-select: none and touch-action: none */
+  -webkit-user-select: text;
+  user-select: text;
+  touch-action: auto;
+  box-sizing: border-box;
+}
+
+.steno-textarea:read-only {
+  border-color: #2a2a2a;
+  color: #aaa;
+}
+
+.steno-interim {
+  min-height: 32px;
+  padding: 6px 10px;
+  background: #1e1e1e;
+  border: 1px dashed #444;
+  border-radius: 6px;
+  color: #888;
+  font-size: 13px;
+  font-style: italic;
+  pointer-events: none;
+}
+
+.steno-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  padding: 10px 12px 14px;
+  border-top: 1px solid #222;
+  flex-shrink: 0;
+}
+
+.steno-record-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 24px;
+  background: #1e1e1e;
+  border: 1px solid #555;
+  border-radius: 999px;
+  color: #ccc;
+  font-size: 15px;
+  cursor: pointer;
+  touch-action: manipulation;
+  transition: background 0.15s, border-color 0.15s;
+}
+
+.steno-record-btn--active {
+  background: #3a1a1a;
+  border-color: #cc4444;
+  color: #ff8888;
+}
+
+.steno-record-btn--locked {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.steno-wakelock-hint {
+  color: rgba(255, 255, 255, 0.3);
+  display: flex;
+  align-items: center;
+}

--- a/app/types.ts
+++ b/app/types.ts
@@ -28,7 +28,7 @@ export interface Statement {
   text: string;
 }
 
-export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social' | 'mood-tones' | 'treevites' | 'greeter' | 'signature';
+export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social' | 'mood-tones' | 'treevites' | 'greeter' | 'signature' | 'steno';
 
 export type ValenceInputMode = 'touch' | 'orientation-horizontal' | 'orientation-vertical' | 'orientation-rotation';
 

--- a/party/server.ts
+++ b/party/server.ts
@@ -247,9 +247,15 @@ interface ClearSignatureEvent {
 
 interface PersistedState {
   roomSocialConfig: { default: string; twitter: string; bluesky: string; mastodon: string } | null;
+  stenoText: string;
 }
 
-type ClientEvent =CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | SetGreeterConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent | RegisterCustomAvatarEvent | SetColorCursorsByVoteEvent | SetDefaultCursorColorEvent | SetOwnValenceDisplayEvent | SetValenceInputModeEvent | StrokeSegmentEvent | ClearSignatureEvent;
+interface StenoStartRecordingEvent { type: 'stenoStartRecording'; userId: string }
+interface StenoStopRecordingEvent  { type: 'stenoStopRecording';  userId: string }
+interface StenoAppendTextEvent     { type: 'stenoAppendText';     userId: string; text: string }
+interface StenoSetTextEvent        { type: 'stenoSetText';        userId: string; text: string }
+
+type ClientEvent =CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | SetGreeterConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent | RegisterCustomAvatarEvent | SetColorCursorsByVoteEvent | SetDefaultCursorColorEvent | SetOwnValenceDisplayEvent | SetValenceInputModeEvent | StrokeSegmentEvent | ClearSignatureEvent | StenoStartRecordingEvent | StenoStopRecordingEvent | StenoAppendTextEvent | StenoSetTextEvent;
 
 // ===== REACTION REGION HELPER (mirrors app/utils/voteRegion.ts) =====
 const DEFAULT_ANCHORS = {
@@ -321,6 +327,8 @@ export default class Server implements Party.Server {
   private roomHost: string | null = null;
   private readonly BAT_SIGNAL_THRESHOLD = 3;
   private seenUserIds = new Set<string>();
+  private stenoText: string = '';
+  private stenoLockUserId: string | null = null;
 
   // ===== GHOST CURSOR DEMO CODE (can be easily removed) =====
   private ghostCursorsEnabled: boolean = false;
@@ -362,11 +370,13 @@ export default class Server implements Party.Server {
   private getPersistedState(): PersistedState {
     return {
       roomSocialConfig: this.roomSocialConfig,
+      stenoText: this.stenoText,
     };
   }
 
   private applyPersistedState(saved: Partial<PersistedState>): void {
     if (saved.roomSocialConfig !== undefined) this.roomSocialConfig = saved.roomSocialConfig;
+    if (saved.stenoText !== undefined) this.stenoText = saved.stenoText;
   }
 
   private async persistState(): Promise<void> {
@@ -510,6 +520,8 @@ export default class Server implements Party.Server {
       defaultCursorColor: this.defaultCursorColor,
       ownValenceDisplay: this.ownValenceDisplay,
       valenceInputMode: this.valenceInputMode,
+      stenoText: this.stenoText,
+      stenoLockUserId: this.stenoLockUserId,
     }));
   }
 
@@ -525,6 +537,10 @@ export default class Server implements Party.Server {
 
     if (!isAdmin && userId) {
       this.room.broadcast(JSON.stringify({ type: 'userLeft', userId, wasViewer }));
+      if (this.stenoLockUserId === userId) {
+        this.stenoLockUserId = null;
+        this.room.broadcast(JSON.stringify({ type: 'stenoLockReleased', userId }));
+      }
     }
 
     const count = this.participantCount();
@@ -723,6 +739,27 @@ export default class Server implements Party.Server {
         this.room.broadcast(message);
       } else if (event.type === 'clearSignature') {
         this.room.broadcast(JSON.stringify({ type: 'signatureCleared', userId: event.userId }));
+      } else if (event.type === 'stenoStartRecording') {
+        if (this.stenoLockUserId !== null && this.stenoLockUserId !== event.userId) {
+          sender.send(JSON.stringify({ type: 'stenoLockDenied', lockHolderUserId: this.stenoLockUserId }));
+          return;
+        }
+        this.stenoLockUserId = event.userId;
+        this.room.broadcast(JSON.stringify({ type: 'stenoLockAcquired', userId: event.userId }));
+      } else if (event.type === 'stenoStopRecording') {
+        if (this.stenoLockUserId !== event.userId) return;
+        this.stenoLockUserId = null;
+        this.room.broadcast(JSON.stringify({ type: 'stenoLockReleased', userId: event.userId }));
+      } else if (event.type === 'stenoAppendText') {
+        if (this.stenoLockUserId !== event.userId) return;
+        this.stenoText += (this.stenoText.length > 0 ? ' ' : '') + event.text;
+        this.room.broadcast(JSON.stringify({ type: 'stenoTextChanged', text: this.stenoText }));
+        void this.persistState();
+      } else if (event.type === 'stenoSetText') {
+        if (this.stenoLockUserId !== null && this.stenoLockUserId !== event.userId) return;
+        this.stenoText = event.text;
+        this.room.broadcast(JSON.stringify({ type: 'stenoTextChanged', text: this.stenoText }));
+        void this.persistState();
       }
     } catch (e) {
       console.error('Failed to parse event:', e);


### PR DESCRIPTION
## Summary

- Adds a new **Steno** interface to the V4 canvas: a shared live transcript powered by the Web Speech API
- Only one participant can hold the recording lock at a time; the lock releases automatically on disconnect
- Transcript is stored server-side (persisted across restarts) and broadcast live to all connected participants
- Wake Lock keeps the recorder's screen on while transcribing
- Unlock via `?interface=steno#v4`; emcee can also push it to specific participants via the People tab

## Implementation notes

- `StenoPanel.tsx` — new component with streaming Web Speech API (`continuous: true`, `interimResults: true`), interim-text preview below the textarea, wake lock management, and mutex-aware record button
- `party/server.ts` — four new message types (`stenoStartRecording`, `stenoStopRecording`, `stenoAppendText`, `stenoSetText`), `stenoText`/`stenoLockUserId` state, `stenoText` persisted to room storage, steno state sent in `connected` message
- Steno appears in the Emcee → Interfaces tab (patchable, not an activity mode) and in the Offer Interface push modal

## Test plan

- [ ] Open `?interface=steno#v4` — Steno chip appears, panel loads
- [ ] Click Transcribe — recording starts, wake lock acquired, speech streams into textarea
- [ ] Open second tab — committed text syncs live; interim text does NOT appear there
- [ ] Second tab's button shows "In use" and is disabled while first tab is recording
- [ ] Stop recording — second tab's button re-enables
- [ ] Close first tab while recording — lock releases, second tab's button re-enables
- [ ] Edit textarea as lock holder — changes sync to other tabs
- [ ] Restart dev server — transcript rehydrates from storage
- [ ] In Emcee → Participants tab, push `steno` to a participant

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~130 words of PR description from ~50 words of human prompts across this session)