### PR TITLE
feat: force-flush steno VTT segments after 5 seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 25 (2026-05-11)
 
+### Fixed
+- **Steno: max 5-second segment duration** — VTT cues are now force-flushed after 5 seconds of continuous speech even if no natural pause is detected, preventing ~60-second monolithic chunks in rapid panel discussions where speakers don't pause between turns.
+
 ### Added
 - **Steno: VTT transcript format** — the Steno panel now stores transcriptions as WebVTT with absolute ISO 8601 wall-clock timestamps (e.g. `2026-05-09T14:30:05Z --> 2026-05-09T14:30:08Z`) so cues are independently timestamped without relative-offset math. A VTT / Plaintext toggle switches between the editable raw VTT view and a read-only concatenated text view.
 - **Steno interface** — a new V4 interface for live shared speech-to-text transcription. Unlock via `?interface=steno`, or push it to participants via the Emcee → Participants tab. Features: streaming Web Speech API (`continuous` mode with interim-text preview), a single-user recording mutex (one person transcribes at a time), server-persisted transcript shared live to all connected participants, Wake Lock while recording, and editable textarea (read-only for observers while another user holds the lock). ([#85](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/85))

--- a/app/components/panels/StenoPanel.tsx
+++ b/app/components/panels/StenoPanel.tsx
@@ -27,8 +27,10 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
   const recognitionRef = useRef<any>(null);
   // segmentStartRef: ISO timestamp captured when first interim result arrives for a speech segment.
   // sessionFinalRef: deduplicates repeated transcripts across onend/restart cycles.
+  // segmentTimerRef: forces a flush if speech runs longer than MAX_SEGMENT_MS without a natural pause.
   const segmentStartRef = useRef<string | null>(null);
   const sessionFinalRef = useRef('');
+  const segmentTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const acquireWakeLock = useCallback(async () => {
     if (!('wakeLock' in navigator)) return;
@@ -80,6 +82,10 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
     setIsRecording(false);
     isRecordingRef.current = false;
     setInterimText('');
+    if (segmentTimerRef.current !== null) {
+      clearTimeout(segmentTimerRef.current);
+      segmentTimerRef.current = null;
+    }
     releaseWakeLock();
     try { recognitionRef.current?.stop(); } catch { /* ignore */ }
     socket.send(JSON.stringify({ type: 'stenoStopRecording', userId }));
@@ -94,6 +100,8 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
     acquireWakeLock();
     try { recognitionRef.current?.start(); } catch { /* ignore if already started */ }
   }, [socket, userId, acquireWakeLock]);
+
+  const MAX_SEGMENT_MS = 5_000;
 
   useEffect(() => {
     if (!SpeechRecognitionCtor) return;
@@ -113,9 +121,14 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
         }
       }
 
-      // Capture cue start time on first interim result of a new speech segment.
+      // Capture cue start time on first interim result of a new speech segment,
+      // and start a forced-flush timer in case speech runs without a natural pause.
       if (hasInterim && !segmentStartRef.current) {
         segmentStartRef.current = new Date().toISOString();
+        segmentTimerRef.current = setTimeout(() => {
+          segmentTimerRef.current = null;
+          try { recognitionRef.current?.stop(); } catch { /* ignore */ }
+        }, MAX_SEGMENT_MS);
       }
       setInterimText(interim);
 
@@ -124,6 +137,12 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
       // is the full phrase accumulated so far — concatenating ALL results would
       // duplicate words. On desktop a single result becomes final with the whole phrase.
       const latest = e.results[e.resultIndex];
+      if (latest.isFinal) {
+        if (segmentTimerRef.current !== null) {
+          clearTimeout(segmentTimerRef.current);
+          segmentTimerRef.current = null;
+        }
+      }
       if (!latest.isFinal) return;
 
       const endTime = new Date().toISOString();
@@ -147,6 +166,10 @@ export default function StenoPanel({ room, userId }: StenoPanelProps) {
     };
 
     r.onend = () => {
+      if (segmentTimerRef.current !== null) {
+        clearTimeout(segmentTimerRef.current);
+        segmentTimerRef.current = null;
+      }
       // Mobile browsers stop recognition after each phrase; restart if still recording.
       if (isRecordingRef.current) {
         segmentStartRef.current = null;


### PR DESCRIPTION
## Summary

- Steno VTT cues were accumulating for up to ~60 seconds in rapid panel discussions where speakers change without natural pauses
- Adds a 5-second forced-flush: if no natural speech pause fires within 5 seconds, `recognition.stop()` is called to emit a final result and restart
- Cleans up the timer on natural final results, `onend`, and manual stop to prevent stale timeouts

## Test plan

- [ ] Open app at `localhost:1999`, switch to steno mode, start recording
- [ ] Speak continuously for >5 seconds without pausing — a new VTT cue should appear within 5s
- [ ] Verify natural pauses still produce cues without waiting for the timer
- [ ] Verify stopping recording mid-segment doesn't produce extra cues afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~60 words of PR description from ~50 words of human prompts across this session)