### PR TITLE
feat: import Polis CSV exports as synthetic Moments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. Releases cut every Monday morning ET; each section header is `## Week N (YYYY-MM-DD)` where the date is the Monday that week starts on, and Week 0 = 2025-11-17.
 
+## Week 26 (2026-05-18)
+
+### Added
+- **Moments: import Polis CSV exports** — load a `*comments.csv` and `*votes.csv` from a Polis export to generate synthetic Moments in the emcee Moments tab. Each comment becomes a Moment (labeled with the comment body); votes are mapped onto People-tab participants by randomly assigning the most-participatory Polis voters to seen users. ([#103](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/103))
+
 ## Week 25 (2026-05-11)
 
 ### Fixed

--- a/app/components/panels/AdminPanelV4/hooks/useParticipants.ts
+++ b/app/components/panels/AdminPanelV4/hooks/useParticipants.ts
@@ -64,7 +64,14 @@ export function useParticipants(socket: PartySocket, room: string, activeAnchors
     const [commentsText, votesText] = await Promise.all([commentsFile.text(), votesFile.text()]);
     const comments = parsePolisComments(commentsText);
     const votes = parsePolisVotes(votesText);
-    const newMoments = assemblePolisImport(comments, votes, [...seenUsers]);
+    const { moments: newMoments, syntheticUserIds } = assemblePolisImport(comments, votes, [...seenUsers]);
+    if (syntheticUserIds.length > 0) {
+      setSeenUsers(prev => {
+        const next = new Set([...prev, ...syntheticUserIds]);
+        localStorage.setItem(`v4-seen-users-${room}`, JSON.stringify([...next]));
+        return next;
+      });
+    }
     setMoments(prev => {
       const merged = [...newMoments, ...prev];
       localStorage.setItem(`v4-moments-${room}`, JSON.stringify(merged));

--- a/app/components/panels/AdminPanelV4/hooks/useParticipants.ts
+++ b/app/components/panels/AdminPanelV4/hooks/useParticipants.ts
@@ -73,7 +73,9 @@ export function useParticipants(socket: PartySocket, room: string, activeAnchors
       });
     }
     setMoments(prev => {
-      const merged = [...newMoments, ...prev];
+      const importedLabels = new Set(newMoments.map(m => m.label));
+      const kept = prev.filter(m => !importedLabels.has(m.label));
+      const merged = [...newMoments, ...kept];
       localStorage.setItem(`v4-moments-${room}`, JSON.stringify(merged));
       return merged;
     });

--- a/app/components/panels/AdminPanelV4/hooks/useParticipants.ts
+++ b/app/components/panels/AdminPanelV4/hooks/useParticipants.ts
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { generateUUID } from "../../../../utils/userId";
 import { computeReactionRegion } from "../../../../utils/voteRegion";
+import { parsePolisComments, parsePolisVotes, assemblePolisImport } from "../../../../utils/polisImport";
 import type { ReactionAnchors } from "../../../../utils/voteRegion";
 import type { MomentSnapshot, PushTarget } from "../types";
 import type PartySocket from "partysocket";
@@ -56,6 +57,18 @@ export function useParticipants(socket: PartySocket, room: string, activeAnchors
       const next = new Set([...prev, userId]);
       localStorage.setItem(`v4-seen-users-${room}`, JSON.stringify([...next]));
       return next;
+    });
+  };
+
+  const importPolisCSV = async (commentsFile: File, votesFile: File) => {
+    const [commentsText, votesText] = await Promise.all([commentsFile.text(), votesFile.text()]);
+    const comments = parsePolisComments(commentsText);
+    const votes = parsePolisVotes(votesText);
+    const newMoments = assemblePolisImport(comments, votes, [...seenUsers]);
+    setMoments(prev => {
+      const merged = [...newMoments, ...prev];
+      localStorage.setItem(`v4-moments-${room}`, JSON.stringify(merged));
+      return merged;
     });
   };
 
@@ -164,6 +177,7 @@ export function useParticipants(socket: PartySocket, room: string, activeAnchors
     openMenuGroupKey, setOpenMenuGroupKey,
     feedbackStars, setFeedbackStars,
     snapMoment,
+    importPolisCSV,
     applyConnected,
     handleSocketEvent,
   };

--- a/app/components/panels/AdminPanelV4/index.tsx
+++ b/app/components/panels/AdminPanelV4/index.tsx
@@ -355,6 +355,7 @@ export default function AdminPanelV4({ room, selfUserId, selfChain }: AdminPanel
             editingMomentLabel={participants.editingMomentLabel}
             setEditingMomentLabel={participants.setEditingMomentLabel}
             snapMoment={participants.snapMoment}
+            importPolisCSV={participants.importPolisCSV}
             activeLabels={labels.activeLabels}
             activeAnchors={anchors.activeAnchors}
             room={room}

--- a/app/components/panels/AdminPanelV4/tabs/MomentsTab.tsx
+++ b/app/components/panels/AdminPanelV4/tabs/MomentsTab.tsx
@@ -158,7 +158,7 @@ function MomentsTabInner({
               type="file"
               accept=".csv"
               style={{ display: 'none' }}
-              onChange={e => setCommentsFile(e.target.files?.[0] ?? null)}
+              onChange={e => { setCommentsFile(e.target.files?.[0] ?? null); e.target.value = ''; }}
             />
           </label>
           <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
@@ -170,7 +170,7 @@ function MomentsTabInner({
               type="file"
               accept=".csv"
               style={{ display: 'none' }}
-              onChange={e => setVotesFile(e.target.files?.[0] ?? null)}
+              onChange={e => { setVotesFile(e.target.files?.[0] ?? null); e.target.value = ''; }}
             />
           </label>
         </div>

--- a/app/components/panels/AdminPanelV4/tabs/MomentsTab.tsx
+++ b/app/components/panels/AdminPanelV4/tabs/MomentsTab.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useState } from "react";
 import { computeReactionRegion } from "../../../../utils/voteRegion";
 import type { ReactionAnchors, ReactionRegion } from "../../../../utils/voteRegion";
 import type { ReactionLabelSet } from "../../../../voteLabels";
@@ -19,6 +19,7 @@ interface MomentsTabProps {
   editingMomentLabel: string;
   setEditingMomentLabel: (v: string) => void;
   snapMoment: () => void;
+  importPolisCSV: (commentsFile: File, votesFile: File) => Promise<void>;
   activeLabels: ReactionLabelSet;
   activeAnchors: ReactionAnchors;
   room: string;
@@ -31,8 +32,24 @@ function MomentsTabInner({
   expandedMoments, setExpandedMoments,
   editingMomentId, setEditingMomentId,
   editingMomentLabel, setEditingMomentLabel,
-  snapMoment, activeLabels, activeAnchors, room,
+  snapMoment, importPolisCSV, activeLabels, activeAnchors, room,
 }: MomentsTabProps) {
+  const [commentsFile, setCommentsFile] = useState<File | null>(null);
+  const [votesFile, setVotesFile] = useState<File | null>(null);
+  const [importing, setImporting] = useState(false);
+
+  const handleImport = async () => {
+    if (!commentsFile || !votesFile || importing) return;
+    setImporting(true);
+    try {
+      await importPolisCSV(commentsFile, votesFile);
+      setCommentsFile(null);
+      setVotesFile(null);
+    } finally {
+      setImporting(false);
+    }
+  };
+
   const toggleExpanded = (id: string) => {
     setExpandedMoments(prev => {
       const s = new Set(prev);
@@ -125,6 +142,45 @@ function MomentsTabInner({
           style={{ display: 'block', width: '100%', padding: '12px', background: '#1a7a3c', color: '#fff', border: 'none', fontSize: 14, fontWeight: 700, cursor: 'pointer' }}
         >
           Snap Moment
+        </button>
+      </div>
+
+      {/* Polis CSV import */}
+      <div style={{ marginBottom: 20, border: '1px solid #333', borderRadius: 6, padding: '10px 12px' }}>
+        <div style={{ fontWeight: 600, fontSize: 11, color: '#666', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 10 }}>Import from Polis CSV</div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 10 }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+            <span className="v3-admin-btn" style={{ display: 'inline-block', fontSize: 12, flexShrink: 0 }}>↑ comments.csv</span>
+            <span style={{ fontSize: 12, color: commentsFile ? '#cec' : '#555', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {commentsFile ? commentsFile.name : 'no file selected'}
+            </span>
+            <input
+              type="file"
+              accept=".csv"
+              style={{ display: 'none' }}
+              onChange={e => setCommentsFile(e.target.files?.[0] ?? null)}
+            />
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+            <span className="v3-admin-btn" style={{ display: 'inline-block', fontSize: 12, flexShrink: 0 }}>↑ votes.csv</span>
+            <span style={{ fontSize: 12, color: votesFile ? '#cec' : '#555', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {votesFile ? votesFile.name : 'no file selected'}
+            </span>
+            <input
+              type="file"
+              accept=".csv"
+              style={{ display: 'none' }}
+              onChange={e => setVotesFile(e.target.files?.[0] ?? null)}
+            />
+          </label>
+        </div>
+        <button
+          className="v3-admin-btn"
+          disabled={!commentsFile || !votesFile || importing}
+          onClick={handleImport}
+          style={{ opacity: (!commentsFile || !votesFile || importing) ? 0.4 : 1 }}
+        >
+          {importing ? 'Importing…' : 'Import moments'}
         </button>
       </div>
 

--- a/app/components/panels/AdminPanelV4/tabs/MomentsTab.tsx
+++ b/app/components/panels/AdminPanelV4/tabs/MomentsTab.tsx
@@ -37,6 +37,7 @@ function MomentsTabInner({
   const [commentsFile, setCommentsFile] = useState<File | null>(null);
   const [votesFile, setVotesFile] = useState<File | null>(null);
   const [importing, setImporting] = useState(false);
+  const [multiFileMode, setMultiFileMode] = useState(true);
 
   const handleImport = async () => {
     if (!commentsFile || !votesFile || importing) return;
@@ -149,32 +150,69 @@ function MomentsTabInner({
       <div style={{ marginBottom: 20, border: '1px solid #333', borderRadius: 6, padding: '10px 12px' }}>
         <div style={{ fontWeight: 600, fontSize: 11, color: '#666', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 10 }}>Import from Polis CSV</div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 10 }}>
-          <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
-            <span className="v3-admin-btn" style={{ display: 'inline-block', fontSize: 12, flexShrink: 0 }}>↑ Select files</span>
-            <span style={{ fontSize: 12, color: (commentsFile || votesFile) ? '#cec' : '#555', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {commentsFile && votesFile
-                ? `${commentsFile.name}, ${votesFile.name}`
-                : commentsFile
-                  ? commentsFile.name
-                  : votesFile
-                    ? votesFile.name
-                    : 'select *comments.csv + *votes.csv'}
-            </span>
-            <input
-              type="file"
-              accept=".csv"
-              multiple
-              style={{ display: 'none' }}
-              onChange={e => {
-                const files = Array.from(e.target.files ?? []);
-                setCommentsFile(files.find(f => f.name.endsWith('comments.csv')) ?? null);
-                setVotesFile(files.find(f => f.name.endsWith('votes.csv')) ?? null);
-                e.target.value = '';
-              }}
-            />
-          </label>
+          {multiFileMode ? (
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+              <span className="v3-admin-btn" style={{ display: 'inline-block', fontSize: 12, flexShrink: 0 }}>↑ Select files</span>
+              <span style={{ fontSize: 12, color: (commentsFile || votesFile) ? '#cec' : '#555', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {commentsFile && votesFile
+                  ? `${commentsFile.name}, ${votesFile.name}`
+                  : commentsFile
+                    ? commentsFile.name
+                    : votesFile
+                      ? votesFile.name
+                      : 'select *comments.csv + *votes.csv'}
+              </span>
+              <input
+                type="file"
+                accept=".csv"
+                multiple
+                style={{ display: 'none' }}
+                onChange={e => {
+                  const files = Array.from(e.target.files ?? []);
+                  setCommentsFile(files.find(f => f.name.endsWith('comments.csv')) ?? null);
+                  setVotesFile(files.find(f => f.name.endsWith('votes.csv')) ?? null);
+                  e.target.value = '';
+                }}
+              />
+            </label>
+          ) : (
+            <>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                <span className="v3-admin-btn" style={{ display: 'inline-block', fontSize: 12, flexShrink: 0 }}>↑ comments.csv</span>
+                <span style={{ fontSize: 12, color: commentsFile ? '#cec' : '#555', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {commentsFile ? commentsFile.name : 'no file selected'}
+                </span>
+                <input
+                  type="file"
+                  accept=".csv"
+                  style={{ display: 'none' }}
+                  onChange={e => { setCommentsFile(e.target.files?.[0] ?? null); e.target.value = ''; }}
+                />
+              </label>
+              <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
+                <span className="v3-admin-btn" style={{ display: 'inline-block', fontSize: 12, flexShrink: 0 }}>↑ votes.csv</span>
+                <span style={{ fontSize: 12, color: votesFile ? '#cec' : '#555', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {votesFile ? votesFile.name : 'no file selected'}
+                </span>
+                <input
+                  type="file"
+                  accept=".csv"
+                  style={{ display: 'none' }}
+                  onChange={e => { setVotesFile(e.target.files?.[0] ?? null); e.target.value = ''; }}
+                />
+              </label>
+            </>
+          )}
           {commentsFile && !votesFile && <span style={{ fontSize: 11, color: '#a74' }}>Missing *votes.csv</span>}
           {votesFile && !commentsFile && <span style={{ fontSize: 11, color: '#a74' }}>Missing *comments.csv</span>}
+          {multiFileMode && (
+            <button
+              onClick={() => setMultiFileMode(false)}
+              style={{ background: 'none', border: 'none', padding: 0, color: '#555', fontSize: 11, cursor: 'pointer', textAlign: 'left', textDecoration: 'underline' }}
+            >
+              load each file individually?
+            </button>
+          )}
         </div>
         <div style={{ display: 'flex', gap: 8 }}>
           <button

--- a/app/components/panels/AdminPanelV4/tabs/MomentsTab.tsx
+++ b/app/components/panels/AdminPanelV4/tabs/MomentsTab.tsx
@@ -150,29 +150,31 @@ function MomentsTabInner({
         <div style={{ fontWeight: 600, fontSize: 11, color: '#666', textTransform: 'uppercase', letterSpacing: '0.08em', marginBottom: 10 }}>Import from Polis CSV</div>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 10 }}>
           <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
-            <span className="v3-admin-btn" style={{ display: 'inline-block', fontSize: 12, flexShrink: 0 }}>↑ comments.csv</span>
-            <span style={{ fontSize: 12, color: commentsFile ? '#cec' : '#555', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {commentsFile ? commentsFile.name : 'no file selected'}
+            <span className="v3-admin-btn" style={{ display: 'inline-block', fontSize: 12, flexShrink: 0 }}>↑ Select files</span>
+            <span style={{ fontSize: 12, color: (commentsFile || votesFile) ? '#cec' : '#555', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {commentsFile && votesFile
+                ? `${commentsFile.name}, ${votesFile.name}`
+                : commentsFile
+                  ? commentsFile.name
+                  : votesFile
+                    ? votesFile.name
+                    : 'select *comments.csv + *votes.csv'}
             </span>
             <input
               type="file"
               accept=".csv"
+              multiple
               style={{ display: 'none' }}
-              onChange={e => { setCommentsFile(e.target.files?.[0] ?? null); e.target.value = ''; }}
+              onChange={e => {
+                const files = Array.from(e.target.files ?? []);
+                setCommentsFile(files.find(f => f.name.endsWith('comments.csv')) ?? null);
+                setVotesFile(files.find(f => f.name.endsWith('votes.csv')) ?? null);
+                e.target.value = '';
+              }}
             />
           </label>
-          <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer' }}>
-            <span className="v3-admin-btn" style={{ display: 'inline-block', fontSize: 12, flexShrink: 0 }}>↑ votes.csv</span>
-            <span style={{ fontSize: 12, color: votesFile ? '#cec' : '#555', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {votesFile ? votesFile.name : 'no file selected'}
-            </span>
-            <input
-              type="file"
-              accept=".csv"
-              style={{ display: 'none' }}
-              onChange={e => { setVotesFile(e.target.files?.[0] ?? null); e.target.value = ''; }}
-            />
-          </label>
+          {commentsFile && !votesFile && <span style={{ fontSize: 11, color: '#a74' }}>Missing *votes.csv</span>}
+          {votesFile && !commentsFile && <span style={{ fontSize: 11, color: '#a74' }}>Missing *comments.csv</span>}
         </div>
         <div style={{ display: 'flex', gap: 8 }}>
           <button

--- a/app/components/panels/AdminPanelV4/tabs/MomentsTab.tsx
+++ b/app/components/panels/AdminPanelV4/tabs/MomentsTab.tsx
@@ -242,7 +242,16 @@ function MomentsTabInner({
                   ) : (
                     <span style={{ flex: 1, fontSize: 13, color: '#ddd' }}>{moment.label}</span>
                   )}
-                  <span style={{ fontSize: 11, color: '#555', flexShrink: 0 }}>{new Date(moment.timestamp).toLocaleTimeString()}</span>
+                  <span style={{ fontSize: 11, color: '#555', flexShrink: 0 }}>
+                    {(() => {
+                      const d = new Date(moment.timestamp);
+                      const today = new Date();
+                      const isToday = d.getFullYear() === today.getFullYear() && d.getMonth() === today.getMonth() && d.getDate() === today.getDate();
+                      return isToday
+                        ? d.toLocaleTimeString()
+                        : `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')} ${d.toLocaleTimeString()}`;
+                    })()}
+                  </span>
                   <button
                     onClick={e => { e.stopPropagation(); setEditingMomentId(moment.id); setEditingMomentLabel(moment.label); }}
                     style={{ background: 'none', border: 'none', color: '#555', cursor: 'pointer', fontSize: 11, padding: '0 4px', flexShrink: 0 }}

--- a/app/components/panels/AdminPanelV4/tabs/MomentsTab.tsx
+++ b/app/components/panels/AdminPanelV4/tabs/MomentsTab.tsx
@@ -174,14 +174,29 @@ function MomentsTabInner({
             />
           </label>
         </div>
-        <button
-          className="v3-admin-btn"
-          disabled={!commentsFile || !votesFile || importing}
-          onClick={handleImport}
-          style={{ opacity: (!commentsFile || !votesFile || importing) ? 0.4 : 1 }}
-        >
-          {importing ? 'Importing…' : 'Import moments'}
-        </button>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            className="v3-admin-btn"
+            disabled={!commentsFile || !votesFile || importing}
+            onClick={handleImport}
+            style={{ opacity: (!commentsFile || !votesFile || importing) ? 0.4 : 1 }}
+          >
+            {importing ? 'Importing…' : 'Import moments'}
+          </button>
+          <button
+            className="v3-admin-btn"
+            disabled={moments.length === 0}
+            onClick={() => {
+              if (window.confirm('Clear all moments?')) {
+                setMoments([]);
+                localStorage.setItem(`v4-moments-${room}`, JSON.stringify([]));
+              }
+            }}
+            style={{ opacity: moments.length === 0 ? 0.4 : 1 }}
+          >
+            Clear all
+          </button>
+        </div>
       </div>
 
       {moments.length === 0 ? (

--- a/app/utils/polisImport.ts
+++ b/app/utils/polisImport.ts
@@ -39,11 +39,16 @@ function shuffle<T>(arr: T[]): T[] {
   return a;
 }
 
+export interface PolisImportResult {
+  moments: MomentSnapshot[];
+  syntheticUserIds: string[];
+}
+
 export function assemblePolisImport(
   comments: ReturnType<typeof parsePolisComments>,
   votes: ReturnType<typeof parsePolisVotes>,
   seenUsers: string[],
-): MomentSnapshot[] {
+): PolisImportResult {
   // Count votes per voter-id to find most participatory voters
   const voteCounts = new Map<number, number>();
   for (const v of votes) {
@@ -53,12 +58,18 @@ export function assemblePolisImport(
     .sort((a, b) => b[1] - a[1])
     .map(([voterId]) => voterId);
 
-  // Randomly map top-N voter-ids to seen users
+  // Map top-N voter-ids to real seen users; generate synthetic IDs for the rest
   const shuffledUsers = shuffle(seenUsers);
   const n = Math.min(rankedVoterIds.length, shuffledUsers.length);
   const voterToUser = new Map<number, string>();
   for (let i = 0; i < n; i++) {
     voterToUser.set(rankedVoterIds[i], shuffledUsers[i]);
+  }
+  const syntheticUserIds: string[] = [];
+  for (let i = n; i < rankedVoterIds.length; i++) {
+    const syntheticId = generateUUID();
+    voterToUser.set(rankedVoterIds[i], syntheticId);
+    syntheticUserIds.push(syntheticId);
   }
 
   // Build commentId → voterId → vote lookup
@@ -70,7 +81,7 @@ export function assemblePolisImport(
 
   const sorted = [...comments].sort((a, b) => a.timestamp - b.timestamp);
 
-  return sorted.map(comment => {
+  const moments = sorted.map(comment => {
     const regions: Record<string, 'positive' | 'negative' | 'neutral' | null> = {};
     const votesForComment = commentVotes.get(comment.commentId);
     for (const [voterId, userId] of voterToUser) {
@@ -87,4 +98,6 @@ export function assemblePolisImport(
       regions,
     };
   });
+
+  return { moments, syntheticUserIds };
 }

--- a/app/utils/polisImport.ts
+++ b/app/utils/polisImport.ts
@@ -79,7 +79,7 @@ export function assemblePolisImport(
     commentVotes.get(v.commentId)!.set(v.voterId, v.vote);
   }
 
-  const sorted = [...comments].sort((a, b) => a.timestamp - b.timestamp);
+  const sorted = [...comments].sort((a, b) => b.timestamp - a.timestamp);
 
   const moments = sorted.map(comment => {
     const regions: Record<string, 'positive' | 'negative' | 'neutral' | null> = {};

--- a/app/utils/polisImport.ts
+++ b/app/utils/polisImport.ts
@@ -1,0 +1,90 @@
+import { csvParse } from 'd3';
+import { generateUUID } from './userId';
+import type { MomentSnapshot } from '../components/panels/AdminPanelV4/types';
+
+interface PolisVoteRow {
+  'comment-id': string;
+  'voter-id': string;
+  vote: string;
+}
+
+interface PolisCommentRow {
+  'comment-id': string;
+  timestamp: string;
+  'comment-body': string;
+}
+
+export function parsePolisVotes(text: string) {
+  return (csvParse(text) as PolisVoteRow[]).map(row => ({
+    commentId: Number(row['comment-id']),
+    voterId: Number(row['voter-id']),
+    vote: Number(row.vote) as 1 | -1 | 0,
+  }));
+}
+
+export function parsePolisComments(text: string) {
+  return (csvParse(text) as PolisCommentRow[]).map(row => ({
+    commentId: Number(row['comment-id']),
+    timestamp: Number(row.timestamp),
+    body: row['comment-body'],
+  }));
+}
+
+function shuffle<T>(arr: T[]): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+export function assemblePolisImport(
+  comments: ReturnType<typeof parsePolisComments>,
+  votes: ReturnType<typeof parsePolisVotes>,
+  seenUsers: string[],
+): MomentSnapshot[] {
+  // Count votes per voter-id to find most participatory voters
+  const voteCounts = new Map<number, number>();
+  for (const v of votes) {
+    voteCounts.set(v.voterId, (voteCounts.get(v.voterId) ?? 0) + 1);
+  }
+  const rankedVoterIds = [...voteCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([voterId]) => voterId);
+
+  // Randomly map top-N voter-ids to seen users
+  const shuffledUsers = shuffle(seenUsers);
+  const n = Math.min(rankedVoterIds.length, shuffledUsers.length);
+  const voterToUser = new Map<number, string>();
+  for (let i = 0; i < n; i++) {
+    voterToUser.set(rankedVoterIds[i], shuffledUsers[i]);
+  }
+
+  // Build commentId → voterId → vote lookup
+  const commentVotes = new Map<number, Map<number, number>>();
+  for (const v of votes) {
+    if (!commentVotes.has(v.commentId)) commentVotes.set(v.commentId, new Map());
+    commentVotes.get(v.commentId)!.set(v.voterId, v.vote);
+  }
+
+  const sorted = [...comments].sort((a, b) => a.timestamp - b.timestamp);
+
+  return sorted.map(comment => {
+    const regions: Record<string, 'positive' | 'negative' | 'neutral' | null> = {};
+    const votesForComment = commentVotes.get(comment.commentId);
+    for (const [voterId, userId] of voterToUser) {
+      const vote = votesForComment?.get(voterId);
+      if (vote === 1) regions[userId] = 'positive';
+      else if (vote === -1) regions[userId] = 'negative';
+      else if (vote === 0) regions[userId] = 'neutral';
+      else regions[userId] = null;
+    }
+    return {
+      id: generateUUID(),
+      label: comment.body,
+      timestamp: comment.timestamp * 1000,
+      regions,
+    };
+  });
+}


### PR DESCRIPTION
## Summary

- Adds a Polis CSV import section to the emcee Moments tab — select a `*comments.csv` and `*votes.csv` export together (or individually via a toggle link) to generate one `MomentSnapshot` per comment
- Each comment's body becomes the moment label; votes map to participant regions (positive/negative/neutral/null)
- The most-participatory Polis voters are randomly mapped to existing seen users; all remaining voters get synthetic user IDs added to the People tab
- Imported moments deduplicate by label (re-importing replaces existing matches)
- Moments load in reverse chronological order; timestamps before today show `YYYY-MM-DD` prefix
- "Clear all" button added beside the import button

## Related issues

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~100 words of PR description from ~230 words of human prompts across this session)