### PR TITLE
feat: Fibonacci-milestone batsignal with preview env support

### DIFF
--- a/.github/workflows/event-preview.yml
+++ b/.github/workflows/event-preview.yml
@@ -69,6 +69,20 @@ jobs:
         run: |
           pnpm exec partykit deploy --config partykit.event.json --preview "$SLUG"
 
+      - name: Set Telegram env vars for event preview
+        env:
+          PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
+          PARTYKIT_LOGIN: patcon
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          SLUG: ${{ steps.config.outputs.slug }}
+        run: |
+          if [ -n "$TELEGRAM_BOT_TOKEN" ]; then
+            printf 'TELEGRAM_BOT_TOKEN="%s"\nTELEGRAM_CHAT_ID="%s"\n' "$TELEGRAM_BOT_TOKEN" "$TELEGRAM_CHAT_ID" > .env
+            pnpm exec partykit env push --config partykit.event.json --preview "$SLUG"
+            rm -f .env
+          fi
+
       - name: Post deployment comment
         uses: actions/github-script@v9
         env:

--- a/.github/workflows/event-preview.yml
+++ b/.github/workflows/event-preview.yml
@@ -73,15 +73,11 @@ jobs:
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
           SLUG: ${{ steps.config.outputs.slug }}
         run: |
-          if [ -n "$TELEGRAM_BOT_TOKEN" ]; then
-            printf 'TELEGRAM_BOT_TOKEN="%s"\nTELEGRAM_CHAT_ID="%s"\n' "$TELEGRAM_BOT_TOKEN" "$TELEGRAM_CHAT_ID" > .env
-            pnpm exec partykit env push --config partykit.event.json --preview "$SLUG"
-            rm -f .env
-          fi
+          pnpm exec partykit env pull .env
+          pnpm exec partykit env push --config partykit.event.json --preview "$SLUG"
+          rm -f .env
 
       - name: Post deployment comment
         uses: actions/github-script@v9

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -72,14 +72,10 @@ jobs:
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon
-          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
-          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
-          if [ -n "$TELEGRAM_BOT_TOKEN" ]; then
-            printf 'TELEGRAM_BOT_TOKEN="%s"\nTELEGRAM_CHAT_ID="%s"\n' "$TELEGRAM_BOT_TOKEN" "$TELEGRAM_CHAT_ID" > .env
-            pnpm exec partykit env push --preview pr-${{ github.event.pull_request.number }}
-            rm -f .env
-          fi
+          pnpm exec partykit env pull .env
+          pnpm exec partykit env push --preview pr-${{ github.event.pull_request.number }}
+          rm -f .env
       - name: Mark deployment success and post preview URL
         uses: actions/github-script@v9
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -68,6 +68,18 @@ jobs:
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon
+      - name: Set Telegram env vars for preview
+        env:
+          PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
+          PARTYKIT_LOGIN: patcon
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          if [ -n "$TELEGRAM_BOT_TOKEN" ]; then
+            printf 'TELEGRAM_BOT_TOKEN="%s"\nTELEGRAM_CHAT_ID="%s"\n' "$TELEGRAM_BOT_TOKEN" "$TELEGRAM_CHAT_ID" > .env
+            pnpm exec partykit env push --preview pr-${{ github.event.pull_request.number }}
+            rm -f .env
+          fi
       - name: Mark deployment success and post preview URL
         uses: actions/github-script@v9
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 25 (2026-05-11)
 
 ### Changed
-- **Batsignal: Fibonacci-milestone notifications** — instead of a single notification when 3 unique users have ever visited, the batsignal now tracks max concurrent participants and fires at each Fibonacci milestone (3, 5, 8, 13, 21, …). The Telegram message now includes the actual count (e.g. "👀 5 devices in the reaction canvas"). State resets on server restart. ([#98](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/98))
+- **Batsignal: Fibonacci-milestone notifications** — instead of a single notification when 3 unique users have ever visited, the batsignal now tracks max concurrent participants and fires at each Fibonacci milestone (3, 5, 8, 13, 21, …). The Telegram message now includes the actual count (e.g. "👀 5 devices in the reaction canvas"). State resets on server restart. Batsignal Telegram credentials are now also pushed to PR preview and event-preview deployments during CI, so the signal fires in those environments too. ([#98](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/98))
 
 ### Fixed
 - **Labels tab: custom fields pre-filled on load** — switching to a preset radio now pre-fills the Custom fields even when the selection is restored from the server on arrival, not just on explicit click.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 25 (2026-05-11)
 
+### Changed
+- **Batsignal: Fibonacci-milestone notifications** — instead of a single notification when 3 unique users have ever visited, the batsignal now tracks max concurrent participants and fires at each Fibonacci milestone (3, 5, 8, 13, 21, …). The Telegram message now includes the actual count (e.g. "👀 5 devices in the reaction canvas"). State resets on server restart. ([#98](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/98))
+
 ### Fixed
 - **Labels tab: custom fields pre-filled on load** — switching to a preset radio now pre-fills the Custom fields even when the selection is restored from the server on arrival, not just on explicit click.
 

--- a/party/server.ts
+++ b/party/server.ts
@@ -330,8 +330,9 @@ export default class Server implements Party.Server {
   private ownValenceDisplay: 'background' | 'labels' | 'none' = 'labels';
   private valenceInputMode: 'touch' | 'orientation-horizontal' | 'orientation-vertical' | 'orientation-rotation' = 'touch';
   private roomHost: string | null = null;
-  private readonly BAT_SIGNAL_THRESHOLD = 3;
-  private seenUserIds = new Set<string>();
+  private readonly BAT_SIGNAL_FIBONACCI = [3, 5, 8, 13, 21, 34, 55, 89, 144, 233];
+  private maxParticipantCount = 0;
+  private lastFibNotifiedIndex = -1;
   private stenoVtt: string = 'WEBVTT\n';
   private stenoLockUserId: string | null = null;
   private storyTracerPoints: StoryTracerPoint[] | null = null;
@@ -421,7 +422,7 @@ export default class Server implements Party.Server {
     });
   }
 
-  private async sendTelegramBatSignal(): Promise<void> {
+  private async sendTelegramBatSignal(count: number): Promise<void> {
     const token = this.room.env.TELEGRAM_BOT_TOKEN as string | undefined;
     const chatId = this.room.env.TELEGRAM_CHAT_ID as string | undefined;
     if (!token || !chatId) {
@@ -432,7 +433,7 @@ export default class Server implements Party.Server {
     const host = this.roomHost; // always set by first connection; bat signal only fires with N+ connections
     if (!host) return;
     const roomUrl = `https://${host}/?room=${encodeURIComponent(this.room.id)}`;
-    const text = `👀 Something's happening in the reaction canvas (${this.BAT_SIGNAL_THRESHOLD}+ devices in room) — ${roomUrl}`;
+    const text = `👀 ${count} devices in the reaction canvas — ${roomUrl}`;
 
     console.log(`[bat-signal] room=${this.room.id} firing → ${roomUrl}`);
     await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
@@ -477,12 +478,15 @@ export default class Server implements Party.Server {
     const count = this.participantCount();
     const vCount = this.viewerCount();
 
-    const isNewUser = !isAdmin && !isViewer && !this.seenUserIds.has(userId);
-    if (isNewUser) {
-      const prevSeenCount = this.seenUserIds.size;
-      this.seenUserIds.add(userId);
-      if (prevSeenCount < this.BAT_SIGNAL_THRESHOLD && this.seenUserIds.size >= this.BAT_SIGNAL_THRESHOLD) {
-        void this.sendTelegramBatSignal();
+    if (!isAdmin && !isViewer && count > this.maxParticipantCount) {
+      this.maxParticipantCount = count;
+      for (let i = this.lastFibNotifiedIndex + 1; i < this.BAT_SIGNAL_FIBONACCI.length; i++) {
+        if (this.BAT_SIGNAL_FIBONACCI[i] <= this.maxParticipantCount) {
+          this.lastFibNotifiedIndex = i;
+          void this.sendTelegramBatSignal(this.maxParticipantCount);
+        } else {
+          break;
+        }
       }
     }
     // Send directly to new connection (broadcast may not include it)


### PR DESCRIPTION
## Summary

- Replaces the single "3+ devices" Telegram notification with milestone notifications at each Fibonacci number (3, 5, 8, 13, 21, …)
- Tracks max **concurrent** participant count (not cumulative unique users), so the count reflects who's actually in the room at once
- Notification message now includes the exact count (e.g. `👀 5 devices in the reaction canvas — <url>`)
- State resets on server restart (as specified in #98)
- Adds a CI step to both `preview.yml` and `event-preview.yml` that pushes `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` to the PartyKit preview environment after each deploy — so the batsignal fires in PR previews and event previews too (no-ops if the GitHub secrets aren't set)

## Test plan

- [ ] Confirm `pnpm tsc --noEmit` passes (no type errors)
- [ ] Open 3 tabs to a local or preview room and verify a batsignal fires with "3 devices" in the message
- [ ] Open a 5th tab and verify another fires with "5 devices"
- [ ] Close tabs back below threshold and reopen — confirm it fires again on the next new max
- [ ] Verify no notification fires if `TELEGRAM_BOT_TOKEN` / `TELEGRAM_CHAT_ID` are absent (silent no-op in logs)
- [ ] After PR preview deploys, confirm the CI "Set Telegram env vars" step runs without error

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~100 words of PR description from ~50 words of human prompts across this session)