### PR TITLE
Story Tracer: embedding cache with resume, reducer progress, and UX fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 26 (2026-05-18)
 
+### Added
+- **Story Tracer: cache embeddings across runs** — raw embedding vectors are now cached in-memory and in IndexedDB, keyed by model + chunks. Re-running with different reducer params or after a page reload skips the embedding step entirely and jumps straight to the reducer. ([#96](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/96))
+
 ### Changed
 - **Event preview workflow: health check before posting URL** — after deploy, the workflow polls the preview URL with Fibonacci backoff (1, 1, 2, 3, 5, 8, 13, 21, 34, 55s — up to ~2m20s total) and only posts the "deployed" comment once it returns 200. Fails the job if it never comes up.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 26 (2026-05-18)
 
 ### Added
-- **Story Tracer: cache embeddings across runs** — raw embedding vectors are now cached in-memory and in IndexedDB, keyed by model + chunks. Re-running with different reducer params or after a page reload skips the embedding step entirely and jumps straight to the reducer. ([#96](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/96))
+- **Story Tracer: cache embeddings with resume support** — raw embedding vectors are cached per-chunk in-memory and in IndexedDB. Re-running with different reducer params skips embedding entirely. Cancelling mid-run and re-running resumes from where it left off — only un-cached chunks are re-embedded. ([#96](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/96))
 
 ### Changed
 - **Event preview workflow: health check before posting URL** — after deploy, the workflow polls the preview URL with Fibonacci backoff (1, 1, 2, 3, 5, 8, 13, 21, 34, 55s — up to ~2m20s total) and only posts the "deployed" comment once it returns 200. Fails the job if it never comes up.

--- a/app/components/panels/StoryTracerPanel.tsx
+++ b/app/components/panels/StoryTracerPanel.tsx
@@ -67,15 +67,12 @@ export default function StoryTracerPanel({ room, userId }: StoryTracerPanelProps
     if (phase.status !== 'done') return;
     const chunks = pendingChunksRef.current;
     const cues = pendingCuesRef.current;
-    const points: StoryTracerPoint[] = phase.points.map(([x, y, z], i) => {
-      const words = chunks.slice(0, i + 1).join(' ').trim().split(/\s+/)
-      const wordIndex = Math.max(0, words.length - windowSize)
-      return {
-        x, y, z,
-        text: chunks[i],
-        startTime: getTimestampForWordIndex(wordIndex, cues),
-      }
-    });
+    const step = Math.max(1, Math.round(windowSize * (1 - overlapPct / 100)))
+    const points: StoryTracerPoint[] = phase.points.map(([x, y, z], i) => ({
+      x, y, z,
+      text: chunks[i],
+      startTime: getTimestampForWordIndex(i * step, cues),
+    }));
     const meta: StoryTracerMeta = {
       modelId: selectedModel,
       algorithmId: selectedAlgo,

--- a/app/components/panels/StoryTracerPanel.tsx
+++ b/app/components/panels/StoryTracerPanel.tsx
@@ -82,7 +82,14 @@ export default function StoryTracerPanel({ room, userId }: StoryTracerPanelProps
       segmentCount: chunks.length,
       computedAt: new Date().toISOString(),
     };
-    socket.send(JSON.stringify({ type: 'storyTracerSetPoints', userId, points, meta }));
+    // Send via HTTP POST — the full points payload can exceed the WebSocket frame limit
+    const { host, protocol } = getPartySocketConfig()
+    const httpProtocol = protocol === 'wss' ? 'https' : 'http'
+    void fetch(`${httpProtocol}://${host}/parties/main/${room}/storyTracerSetPoints`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId, points, meta }),
+    })
     setIsRerunMode(false);
     resetPhase();
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/app/components/panels/StoryTracerPanel.tsx
+++ b/app/components/panels/StoryTracerPanel.tsx
@@ -22,6 +22,7 @@ export default function StoryTracerPanel({ room, userId }: StoryTracerPanelProps
   const [storedPoints, setStoredPoints] = useState<StoryTracerPoint[] | null>(null);
   const [isRerunMode, setIsRerunMode] = useState(false);
   const [segmentsOpen, setSegmentsOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
 
   const [selectedModel, setSelectedModel] = useState<EmbeddingModelId>(() => {
     const stored = localStorage.getItem(LS_MODEL);
@@ -55,6 +56,7 @@ export default function StoryTracerPanel({ room, userId }: StoryTracerPanelProps
       if (data.type === 'storyTracerPointsChanged') {
         setStoredMeta(data.meta ?? null);
         setStoredPoints(data.points ?? null);
+        setIsSaving(false);
         return;
       }
     },
@@ -85,6 +87,7 @@ export default function StoryTracerPanel({ room, userId }: StoryTracerPanelProps
     // Send via HTTP POST — the full points payload can exceed the WebSocket frame limit
     const { host, protocol } = getPartySocketConfig()
     const httpProtocol = protocol === 'wss' ? 'https' : 'http'
+    setIsSaving(true);
     void fetch(`${httpProtocol}://${host}/parties/main/${room}/storyTracerSetPoints`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -303,6 +306,18 @@ export default function StoryTracerPanel({ room, userId }: StoryTracerPanelProps
               </div>
             </>
           )}
+        </div>
+      )}
+
+      {isSaving && (
+        <div className="story-tracer-progress">
+          <div className="story-tracer-progress-row">
+            <div className="story-tracer-spinner" />
+            <span>Saving to server…</span>
+          </div>
+          <div className="story-tracer-bar story-tracer-bar--indeterminate">
+            <div className="story-tracer-bar-fill" />
+          </div>
         </div>
       )}
 

--- a/app/components/panels/StoryTracerPanel.tsx
+++ b/app/components/panels/StoryTracerPanel.tsx
@@ -290,7 +290,7 @@ export default function StoryTracerPanel({ room, userId }: StoryTracerPanelProps
                 <div className="story-tracer-spinner" />
                 <span>
                   {phase.total > 0
-                    ? `Running reducer… ${phase.epoch} / ${phase.total}`
+                    ? `Running reducer… iteration ${phase.epoch} / ${phase.total}`
                     : 'Running reducer…'}
                 </span>
                 <button className="story-tracer-cancel-btn" onClick={handleCancel}>Cancel</button>

--- a/app/components/panels/StoryTracerPanel.tsx
+++ b/app/components/panels/StoryTracerPanel.tsx
@@ -290,7 +290,9 @@ export default function StoryTracerPanel({ room, userId }: StoryTracerPanelProps
                 <div className="story-tracer-spinner" />
                 <span>
                   {phase.total > 0
-                    ? `Running reducer… iteration ${phase.epoch} / ${phase.total}`
+                    ? phase.epoch === 0
+                      ? `Running reducer… (generating KNN graph)`
+                      : `Running reducer… iteration ${phase.epoch} / ${phase.total}`
                     : 'Running reducer…'}
                 </span>
                 <button className="story-tracer-cancel-btn" onClick={handleCancel}>Cancel</button>

--- a/app/components/panels/StoryTracerPanel.tsx
+++ b/app/components/panels/StoryTracerPanel.tsx
@@ -281,11 +281,18 @@ export default function StoryTracerPanel({ room, userId }: StoryTracerPanelProps
             <>
               <div className="story-tracer-progress-row">
                 <div className="story-tracer-spinner" />
-                <span>Running reducer…</span>
+                <span>
+                  {phase.total > 0
+                    ? `Running reducer… ${phase.epoch} / ${phase.total}`
+                    : 'Running reducer…'}
+                </span>
                 <button className="story-tracer-cancel-btn" onClick={handleCancel}>Cancel</button>
               </div>
-              <div className="story-tracer-bar story-tracer-bar--indeterminate">
-                <div className="story-tracer-bar-fill" />
+              <div className={`story-tracer-bar${phase.total === 0 ? ' story-tracer-bar--indeterminate' : ''}`}>
+                <div
+                  className="story-tracer-bar-fill"
+                  style={{ width: phase.total > 0 ? `${(phase.epoch / phase.total) * 100}%` : undefined }}
+                />
               </div>
             </>
           )}

--- a/app/components/panels/StoryTracerPanel.tsx
+++ b/app/components/panels/StoryTracerPanel.tsx
@@ -109,7 +109,7 @@ export default function StoryTracerPanel({ room, userId }: StoryTracerPanelProps
     pendingChunksRef.current = freshChunks;
     pendingCuesRef.current = freshCues;
     runEmbedding(freshChunks, selectedModel, selectedAlgo, reducerParams[selectedAlgo]);
-  }, [hasContent, stenoVtt, windowSize, overlapPct, selectedModel, runEmbedding]);
+  }, [hasContent, stenoVtt, windowSize, overlapPct, selectedModel, selectedAlgo, reducerParams, runEmbedding]);
 
   const handleClear = useCallback(() => {
     socket.send(JSON.stringify({ type: 'storyTracerClearPoints', userId }));

--- a/app/utils/useEmbeddingWorker.ts
+++ b/app/utils/useEmbeddingWorker.ts
@@ -60,7 +60,7 @@ export type EmbedPhase =
   | { status: 'idle' }
   | { status: 'model-loading'; progress: number }
   | { status: 'embedding'; loaded: number; total: number }
-  | { status: 'reducer-running' }
+  | { status: 'reducer-running'; epoch: number; total: number }
   | { status: 'done'; points: [number, number, number][] }
   | { status: 'error'; message: string }
 
@@ -78,8 +78,8 @@ export function useEmbeddingWorker() {
             setPhase({ status: 'model-loading', progress: msg.progress }); break
           case 'progress:embedding':
             setPhase({ status: 'embedding', loaded: msg.loaded, total: msg.total }); break
-          case 'progress:reducer-running':
-            setPhase({ status: 'reducer-running' }); break
+          case 'progress:reducer':
+            setPhase({ status: 'reducer-running', epoch: msg.epoch, total: msg.total }); break
           case 'done':
             setPhase({ status: 'done', points: msg.points }); break
           case 'error':

--- a/app/utils/useEmbeddingWorker.ts
+++ b/app/utils/useEmbeddingWorker.ts
@@ -15,7 +15,7 @@ export type EmbeddingModelId = typeof EMBEDDING_MODELS[number]['id']
 export const REDUCERS = [
   { id: 'umap-js'    as ReducerAlgorithmId, label: 'UMAP (umap-js)',  default: true  },
   { id: 'umap-druid' as ReducerAlgorithmId, label: 'UMAP (DruidJS)',  default: false },
-  { id: 'localmap'   as ReducerAlgorithmId, label: 'LocalMAP',        default: false },
+  { id: 'localmap'   as ReducerAlgorithmId, label: 'LocalMAP (maybe broken)', default: false },
   { id: 'pacmap'     as ReducerAlgorithmId, label: 'PaCMAP',          default: false },
 ] as const
 

--- a/app/utils/useEmbeddingWorker.ts
+++ b/app/utils/useEmbeddingWorker.ts
@@ -26,13 +26,13 @@ export const REDUCER_PARAM_DEFS: Record<ReducerAlgorithmId, Record<string, Param
     n_neighbors: { label: 'Neighbors',       min: 2,   max: 200,  step: 1,    default: 15  },
     min_dist:    { label: 'Min dist',        min: 0,   max: 1,    step: 0.01, default: 0.1 },
     spread:      { label: 'Spread',          min: 0.1, max: 10,   step: 0.1,  default: 1.0 },
-    epochs:      { label: 'Epochs (0=auto)', min: 0,   max: 1000, step: 10,   default: 0   },
+    epochs:      { label: 'Iterations (0=auto)', min: 0,   max: 1000, step: 10,   default: 0   },
   },
   'umap-druid': {
     n_neighbors: { label: 'Neighbors',       min: 2,   max: 200,  step: 1,    default: 15  },
     min_dist:    { label: 'Min dist',        min: 0,   max: 1,    step: 0.01, default: 0.1 },
     spread:      { label: 'Spread',          min: 0.1, max: 10,   step: 0.1,  default: 1.0 },
-    epochs:      { label: 'Epochs (0=auto)', min: 0,   max: 1000, step: 10,   default: 0   },
+    epochs:      { label: 'Iterations (0=auto)', min: 0,   max: 1000, step: 10,   default: 0   },
   },
   'pacmap': {
     n_neighbors: { label: 'Neighbors', min: 2,   max: 200, step: 1,   default: 10  },

--- a/app/workers/embeddingWorker.ts
+++ b/app/workers/embeddingWorker.ts
@@ -4,29 +4,37 @@ import type { ReducerAlgorithmId, ReducerParams, WorkerCommand, WorkerEvent } fr
 type AnyPipeline = any
 
 const pipelineCache = new Map<string, AnyPipeline>()
-const vectorCache = new Map<string, Float32Array[]>()
+// Per-chunk vector cache: key = `${modelId}\x00${text}`
+const vectorCache = new Map<string, Float32Array>()
 
-const IDB_DB = 'embedding-cache'
 const IDB_STORE = 'vectors'
+let dbPromise: Promise<IDBDatabase> | null = null
 
-function openIdb(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open(IDB_DB, 1)
-    req.onupgradeneeded = () => req.result.createObjectStore(IDB_STORE)
-    req.onsuccess = () => resolve(req.result)
-    req.onerror = () => reject(req.error)
-  })
+function getDb(): Promise<IDBDatabase> {
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      // Version 2: per-chunk entries (ArrayBuffer each); v1 used per-batch (ArrayBuffer[]) — incompatible, so recreate the store
+      const req = indexedDB.open('embedding-cache', 2)
+      req.onupgradeneeded = (ev) => {
+        const db = (ev.target as IDBOpenDBRequest).result
+        if (db.objectStoreNames.contains(IDB_STORE)) db.deleteObjectStore(IDB_STORE)
+        db.createObjectStore(IDB_STORE)
+      }
+      req.onsuccess = () => resolve(req.result)
+      req.onerror = () => { dbPromise = null; reject(req.error) }
+    })
+  }
+  return dbPromise
 }
 
-async function idbGet(key: string): Promise<Float32Array[] | null> {
+async function idbGetChunk(key: string): Promise<Float32Array | null> {
   try {
-    const db = await openIdb()
+    const db = await getDb()
     return new Promise((resolve, reject) => {
-      const tx = db.transaction(IDB_STORE, 'readonly')
-      const req = tx.objectStore(IDB_STORE).get(key)
+      const req = db.transaction(IDB_STORE, 'readonly').objectStore(IDB_STORE).get(key)
       req.onsuccess = () => {
-        const val = req.result as ArrayBuffer[] | undefined
-        resolve(val ? val.map(buf => new Float32Array(buf)) : null)
+        const buf = req.result as ArrayBuffer | undefined
+        resolve(buf ? new Float32Array(buf) : null)
       }
       req.onerror = () => reject(req.error)
     })
@@ -35,13 +43,12 @@ async function idbGet(key: string): Promise<Float32Array[] | null> {
   }
 }
 
-async function idbSet(key: string, vectors: Float32Array[]): Promise<void> {
+async function idbSetChunk(key: string, vector: Float32Array): Promise<void> {
   try {
-    const db = await openIdb()
+    const db = await getDb()
     return new Promise((resolve, reject) => {
-      const tx = db.transaction(IDB_STORE, 'readwrite')
-      const bufs = vectors.map(v => v.buffer.slice(v.byteOffset, v.byteOffset + v.byteLength))
-      const req = tx.objectStore(IDB_STORE).put(bufs, key)
+      const buf = vector.buffer.slice(vector.byteOffset, vector.byteOffset + vector.byteLength)
+      const req = db.transaction(IDB_STORE, 'readwrite').objectStore(IDB_STORE).put(buf, key)
       req.onsuccess = () => resolve()
       req.onerror = () => reject(req.error)
     })
@@ -105,16 +112,27 @@ self.onmessage = async (e: MessageEvent<WorkerCommand>) => {
   const cmd = e.data
   if (cmd.type === 'embed') {
     try {
-      const cacheKey = `${cmd.modelId}\x00${cmd.texts.join('\x00')}`
+      const chunkKeys = cmd.texts.map(text => `${cmd.modelId}\x00${text}`)
 
-      let vectors = vectorCache.get(cacheKey) ?? null
+      // Pass 1: in-memory cache
+      const vectors: (Float32Array | null)[] = chunkKeys.map(k => vectorCache.get(k) ?? null)
 
-      if (!vectors) {
-        vectors = await idbGet(cacheKey)
-        if (vectors) vectorCache.set(cacheKey, vectors)
+      // Pass 2: IDB for any still-missing chunks (parallel reads)
+      const afterMemory = vectors.map((v, i) => v === null ? i : -1).filter(i => i >= 0)
+      if (afterMemory.length > 0) {
+        const idbResults = await Promise.all(afterMemory.map(i => idbGetChunk(chunkKeys[i])))
+        for (let j = 0; j < afterMemory.length; j++) {
+          const i = afterMemory[j]
+          if (idbResults[j]) {
+            vectors[i] = idbResults[j]
+            vectorCache.set(chunkKeys[i], idbResults[j]!)
+          }
+        }
       }
 
-      if (!vectors) {
+      // Pass 3: embed any still-missing chunks
+      const toEmbed = vectors.map((v, i) => v === null ? i : -1).filter(i => i >= 0)
+      if (toEmbed.length > 0) {
         if (!pipelineCache.has(cmd.modelId)) {
           const { pipeline } = await import('@huggingface/transformers')
           const instance = await pipeline('feature-extraction', cmd.modelId, {
@@ -127,21 +145,22 @@ self.onmessage = async (e: MessageEvent<WorkerCommand>) => {
         }
 
         const pipe = pipelineCache.get(cmd.modelId)!
-        vectors = []
-        for (let i = 0; i < cmd.texts.length; i++) {
-          self.postMessage({ type: 'progress:embedding', loaded: i, total: cmd.texts.length } satisfies WorkerEvent)
+        for (let j = 0; j < toEmbed.length; j++) {
+          const i = toEmbed[j]
+          // progress counts only the chunks that actually need embedding
+          self.postMessage({ type: 'progress:embedding', loaded: j, total: toEmbed.length } satisfies WorkerEvent)
           const output = await pipe(cmd.texts[i], { pooling: 'mean', normalize: true })
-          vectors.push(output.data as Float32Array)
+          const vector = output.data as Float32Array
+          vectors[i] = vector
+          vectorCache.set(chunkKeys[i], vector)
+          void idbSetChunk(chunkKeys[i], vector)
         }
-
-        vectorCache.set(cacheKey, vectors)
-        void idbSet(cacheKey, vectors)
       }
 
       self.postMessage({ type: 'progress:reducer-running' } satisfies WorkerEvent)
-      const n = vectors.length
-      const data = vectors.map(v => Array.from(v))
-      const result = await runReducer(cmd.algorithmId, data, n, cmd.reducerParams)
+      const finalVectors = vectors as Float32Array[]
+      const data = finalVectors.map(v => Array.from(v))
+      const result = await runReducer(cmd.algorithmId, data, finalVectors.length, cmd.reducerParams)
       self.postMessage({ type: 'done', points: result as [number, number, number][] } satisfies WorkerEvent)
     } catch (err) {
       console.error('[embeddingWorker] caught error', err)

--- a/app/workers/embeddingWorker.ts
+++ b/app/workers/embeddingWorker.ts
@@ -72,17 +72,26 @@ const PROGRESS_INTERVAL = 10  // emit progress every N epochs
 async function druidGenerate(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   reducer: any,
-  total: number,
+  explicitTotal: number,
   onProgress: (epoch: number, total: number) => void,
 ): Promise<number[][]> {
-  const gen = reducer.generator(total === 0 ? undefined : total)
+  // For algorithms that don't take an explicit iteration count (localmap/pacmap),
+  // compute the total from their internal num_iters phase array so the bar is determinate
+  let total = explicitTotal
+  if (total === 0) {
+    try {
+      const numIters = reducer.parameter('num_iters') as number[]
+      total = numIters.reduce((a: number, b: number) => a + b, 0)
+    } catch { /* leave as 0 — bar stays indeterminate */ }
+  }
+  const gen = reducer.generator(total || undefined)
   let i = 0
   while (true) {
     const { done } = gen.next()
     if (done) break
     i++
     if (i % PROGRESS_INTERVAL === 0) {
-      onProgress(i, total || i)
+      onProgress(i, total)
       await new Promise(resolve => setTimeout(resolve, 0))
     }
   }

--- a/app/workers/embeddingWorker.ts
+++ b/app/workers/embeddingWorker.ts
@@ -84,6 +84,9 @@ async function druidGenerate(
       total = numIters.reduce((a: number, b: number) => a + b, 0)
     } catch { /* leave as 0 — bar stays indeterminate */ }
   }
+  // Show determinate bar immediately while the first gen.next() runs init
+  onProgress(0, total)
+  await new Promise(resolve => setTimeout(resolve, 0))
   const gen = reducer.generator(total || undefined)
   let i = 0
   while (true) {

--- a/app/workers/embeddingWorker.ts
+++ b/app/workers/embeddingWorker.ts
@@ -4,6 +4,51 @@ import type { ReducerAlgorithmId, ReducerParams, WorkerCommand, WorkerEvent } fr
 type AnyPipeline = any
 
 const pipelineCache = new Map<string, AnyPipeline>()
+const vectorCache = new Map<string, Float32Array[]>()
+
+const IDB_DB = 'embedding-cache'
+const IDB_STORE = 'vectors'
+
+function openIdb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(IDB_DB, 1)
+    req.onupgradeneeded = () => req.result.createObjectStore(IDB_STORE)
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+async function idbGet(key: string): Promise<Float32Array[] | null> {
+  try {
+    const db = await openIdb()
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(IDB_STORE, 'readonly')
+      const req = tx.objectStore(IDB_STORE).get(key)
+      req.onsuccess = () => {
+        const val = req.result as ArrayBuffer[] | undefined
+        resolve(val ? val.map(buf => new Float32Array(buf)) : null)
+      }
+      req.onerror = () => reject(req.error)
+    })
+  } catch {
+    return null
+  }
+}
+
+async function idbSet(key: string, vectors: Float32Array[]): Promise<void> {
+  try {
+    const db = await openIdb()
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(IDB_STORE, 'readwrite')
+      const bufs = vectors.map(v => v.buffer.slice(v.byteOffset, v.byteOffset + v.byteLength))
+      const req = tx.objectStore(IDB_STORE).put(bufs, key)
+      req.onsuccess = () => resolve()
+      req.onerror = () => reject(req.error)
+    })
+  } catch {
+    // non-fatal — cache write failure doesn't break the run
+  }
+}
 
 self.onerror = (msg, src, line, col, err) => {
   console.error('[embeddingWorker] global onerror', { msg, src, line, col, err })
@@ -60,23 +105,37 @@ self.onmessage = async (e: MessageEvent<WorkerCommand>) => {
   const cmd = e.data
   if (cmd.type === 'embed') {
     try {
-      if (!pipelineCache.has(cmd.modelId)) {
-        const { pipeline } = await import('@huggingface/transformers')
-        const instance = await pipeline('feature-extraction', cmd.modelId, {
-          progress_callback: (info: unknown) => {
-            const pct = (info as { progress?: number })?.progress ?? 0
-            self.postMessage({ type: 'progress:model-loading', progress: Math.round(pct) } satisfies WorkerEvent)
-          },
-        })
-        pipelineCache.set(cmd.modelId, instance)
+      const cacheKey = `${cmd.modelId}\x00${cmd.texts.join('\x00')}`
+
+      let vectors = vectorCache.get(cacheKey) ?? null
+
+      if (!vectors) {
+        vectors = await idbGet(cacheKey)
+        if (vectors) vectorCache.set(cacheKey, vectors)
       }
 
-      const pipe = pipelineCache.get(cmd.modelId)!
-      const vectors: Float32Array[] = []
-      for (let i = 0; i < cmd.texts.length; i++) {
-        self.postMessage({ type: 'progress:embedding', loaded: i, total: cmd.texts.length } satisfies WorkerEvent)
-        const output = await pipe(cmd.texts[i], { pooling: 'mean', normalize: true })
-        vectors.push(output.data as Float32Array)
+      if (!vectors) {
+        if (!pipelineCache.has(cmd.modelId)) {
+          const { pipeline } = await import('@huggingface/transformers')
+          const instance = await pipeline('feature-extraction', cmd.modelId, {
+            progress_callback: (info: unknown) => {
+              const pct = (info as { progress?: number })?.progress ?? 0
+              self.postMessage({ type: 'progress:model-loading', progress: Math.round(pct) } satisfies WorkerEvent)
+            },
+          })
+          pipelineCache.set(cmd.modelId, instance)
+        }
+
+        const pipe = pipelineCache.get(cmd.modelId)!
+        vectors = []
+        for (let i = 0; i < cmd.texts.length; i++) {
+          self.postMessage({ type: 'progress:embedding', loaded: i, total: cmd.texts.length } satisfies WorkerEvent)
+          const output = await pipe(cmd.texts[i], { pooling: 'mean', normalize: true })
+          vectors.push(output.data as Float32Array)
+        }
+
+        vectorCache.set(cacheKey, vectors)
+        void idbSet(cacheKey, vectors)
       }
 
       self.postMessage({ type: 'progress:reducer-running' } satisfies WorkerEvent)

--- a/app/workers/embeddingWorker.ts
+++ b/app/workers/embeddingWorker.ts
@@ -145,10 +145,14 @@ self.onmessage = async (e: MessageEvent<WorkerCommand>) => {
         }
 
         const pipe = pipelineCache.get(cmd.modelId)!
+        const cachedCount = cmd.texts.length - toEmbed.length
+        // Jump bar to cached position before starting
+        if (cachedCount > 0) {
+          self.postMessage({ type: 'progress:embedding', loaded: cachedCount - 1, total: cmd.texts.length } satisfies WorkerEvent)
+        }
         for (let j = 0; j < toEmbed.length; j++) {
           const i = toEmbed[j]
-          // progress counts only the chunks that actually need embedding
-          self.postMessage({ type: 'progress:embedding', loaded: j, total: toEmbed.length } satisfies WorkerEvent)
+          self.postMessage({ type: 'progress:embedding', loaded: i, total: cmd.texts.length } satisfies WorkerEvent)
           const output = await pipe(cmd.texts[i], { pooling: 'mean', normalize: true })
           const vector = output.data as Float32Array
           vectors[i] = vector

--- a/app/workers/embeddingWorker.ts
+++ b/app/workers/embeddingWorker.ts
@@ -67,10 +67,41 @@ self.onunhandledrejection = (e: PromiseRejectionEvent) => {
   self.postMessage({ type: 'error', message: `Worker unhandled rejection: ${String(e.reason)}` } satisfies WorkerEvent)
 }
 
-async function runReducer(algorithmId: ReducerAlgorithmId, data: number[][], n: number, p: ReducerParams): Promise<number[][]> {
+const PROGRESS_INTERVAL = 10  // emit progress every N epochs
+
+async function druidGenerate(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reducer: any,
+  total: number,
+  onProgress: (epoch: number, total: number) => void,
+): Promise<number[][]> {
+  const gen = reducer.generator(total === 0 ? undefined : total)
+  let i = 0
+  while (true) {
+    const { done } = gen.next()
+    if (done) break
+    i++
+    if (i % PROGRESS_INTERVAL === 0) {
+      onProgress(i, total || i)
+      await new Promise(resolve => setTimeout(resolve, 0))
+    }
+  }
+  onProgress(total || i, total || i)
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return reducer.projection as any
+}
+
+async function runReducer(
+  algorithmId: ReducerAlgorithmId,
+  data: number[][],
+  n: number,
+  p: ReducerParams,
+  onProgress: (epoch: number, total: number) => void,
+): Promise<number[][]> {
   // Mirror umap-js epoch auto-calculation: fewer epochs for larger datasets
   const autoEpochs = n <= 2500 ? 500 : n <= 5000 ? 400 : n <= 7500 ? 300 : 200
   const epochs = p.epochs > 0 ? p.epochs : autoEpochs
+
   if (algorithmId === 'umap-js') {
     const { UMAP } = await import('umap-js')
     const umap = new UMAP({
@@ -80,13 +111,24 @@ async function runReducer(algorithmId: ReducerAlgorithmId, data: number[][], n: 
       spread: p.spread,
       nEpochs: p.epochs,  // 0 triggers umap-js's own auto-calculation
     })
-    return umap.fit(data) as number[][]
+    umap.initializeFit(data)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const total: number = (umap as any).getNEpochs()
+    for (let i = 0; i < total; i++) {
+      umap.step()
+      if (i % PROGRESS_INTERVAL === 0 || i === total - 1) {
+        onProgress(i + 1, total)
+        await new Promise(resolve => setTimeout(resolve, 0))
+      }
+    }
+    return umap.getEmbedding() as number[][]
   }
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const druid = await import('@saehrimnir/druidjs') as any
   if (algorithmId === 'umap-druid') {
     const reducer = new druid.UMAP(data, { d: 3, n_neighbors: Math.min(p.n_neighbors, n - 1), min_dist: p.min_dist, _spread: p.spread })
-    return reducer.transform(epochs)
+    return druidGenerate(reducer, epochs, onProgress)
   }
   if (algorithmId === 'localmap') {
     const reducer = new druid.LocalMAP(data, {
@@ -96,7 +138,8 @@ async function runReducer(algorithmId: ReducerAlgorithmId, data: number[][], n: 
       FP_ratio: p.FP_ratio,
       low_dist_thres: p.low_dist_thres,
     })
-    return reducer.transform()
+    // total comes from the algorithm's own num_iters phases; pass 0 to use default
+    return druidGenerate(reducer, 0, onProgress)
   }
   // pacmap
   const reducer = new druid.PaCMAP(data, {
@@ -105,7 +148,7 @@ async function runReducer(algorithmId: ReducerAlgorithmId, data: number[][], n: 
     MN_ratio: p.MN_ratio,
     FP_ratio: p.FP_ratio,
   })
-  return reducer.transform()
+  return druidGenerate(reducer, 0, onProgress)
 }
 
 self.onmessage = async (e: MessageEvent<WorkerCommand>) => {
@@ -161,10 +204,16 @@ self.onmessage = async (e: MessageEvent<WorkerCommand>) => {
         }
       }
 
-      self.postMessage({ type: 'progress:reducer-running' } satisfies WorkerEvent)
+      self.postMessage({ type: 'progress:reducer', epoch: 0, total: 0 } satisfies WorkerEvent)
       const finalVectors = vectors as Float32Array[]
       const data = finalVectors.map(v => Array.from(v))
-      const result = await runReducer(cmd.algorithmId, data, finalVectors.length, cmd.reducerParams)
+      const result = await runReducer(
+        cmd.algorithmId,
+        data,
+        finalVectors.length,
+        cmd.reducerParams,
+        (epoch, total) => self.postMessage({ type: 'progress:reducer', epoch, total } satisfies WorkerEvent),
+      )
       self.postMessage({ type: 'done', points: result as [number, number, number][] } satisfies WorkerEvent)
     } catch (err) {
       console.error('[embeddingWorker] caught error', err)

--- a/app/workers/embeddingWorker.ts
+++ b/app/workers/embeddingWorker.ts
@@ -153,7 +153,7 @@ self.onmessage = async (e: MessageEvent<WorkerCommand>) => {
           const vector = output.data as Float32Array
           vectors[i] = vector
           vectorCache.set(chunkKeys[i], vector)
-          void idbSetChunk(chunkKeys[i], vector)
+          await idbSetChunk(chunkKeys[i], vector)
         }
       }
 

--- a/app/workers/embeddingWorker.ts
+++ b/app/workers/embeddingWorker.ts
@@ -114,6 +114,9 @@ async function runReducer(
     umap.initializeFit(data)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const total: number = (umap as any).getNEpochs()
+    // Signal that KNN init is done and epochs are about to start
+    onProgress(0, total)
+    await new Promise(resolve => setTimeout(resolve, 0))
     for (let i = 0; i < total; i++) {
       umap.step()
       if (i % PROGRESS_INTERVAL === 0 || i === total - 1) {

--- a/app/workers/embeddingWorker.types.ts
+++ b/app/workers/embeddingWorker.types.ts
@@ -8,6 +8,6 @@ export type WorkerCommand =
 export type WorkerEvent =
   | { type: 'progress:model-loading'; progress: number }
   | { type: 'progress:embedding'; loaded: number; total: number }
-  | { type: 'progress:reducer-running' }
+  | { type: 'progress:reducer'; epoch: number; total: number }
   | { type: 'done'; points: [number, number, number][] }
   | { type: 'error'; message: string }

--- a/party/server.ts
+++ b/party/server.ts
@@ -1266,6 +1266,20 @@ export default class Server implements Party.Server {
     const url = new URL(request.url);
     console.log(`[VOTE] Incoming request: ${request.method} ${url.pathname}`);
 
+    if (request.method === "POST" && url.pathname.endsWith("/storyTracerSetPoints")) {
+      try {
+        const body = await request.json<{ userId: string; points: StoryTracerPoint[]; meta: StoryTracerMeta }>()
+        this.storyTracerPoints = body.points
+        this.storyTracerMeta = body.meta
+        void this.persistState()
+        this.room.broadcast(JSON.stringify({ type: 'storyTracerPointsChanged', points: body.points, meta: body.meta }))
+        return new Response(JSON.stringify({ success: true }), { headers: { 'Content-Type': 'application/json' } })
+      } catch (err) {
+        console.error('[storyTracer] error processing setPoints:', err)
+        return new Response('Invalid request', { status: 400 })
+      }
+    }
+
     if (request.method === "POST" && url.pathname.endsWith("/vote")) {
       console.log(`[VOTE] Processing vote submission...`);
       try {


### PR DESCRIPTION
Closes https://github.com/patcon/polislike-partykit-reaction-canvas/issues/96

## Summary

- **Per-chunk embedding cache** (in-memory + IndexedDB) — vectors are cached keyed by `(modelId, chunk-text)` and written to IDB immediately after each chunk, so cancelling mid-run and re-running resumes from where it left off rather than starting over
- **Reducer progress bar** — all four algorithms now report per-iteration progress; umap-js uses `initializeFit`/`step` loop, DruidJS uses `*generator()` with manual `.next()` calls and async yields
- **KNN graph hint** — bar goes determinate at iteration 0 with "(generating KNN graph)" label while the slow init runs
- **HTTP POST for large payloads** — `storyTracerSetPoints` switched from WebSocket to HTTP POST to bypass the ~64KB workerd frame limit that was silently dropping results for large transcripts
- **O(n²) → O(1) annotation** — word index calculation for timestamp lookup was joining all prior chunk strings on each iteration; replaced with `i * step` formula
- **Stale closure fix** — `selectedAlgo` and `reducerParams` were missing from `handleRun` deps, causing algorithm changes to have no effect until page refresh
- **"Saving to server" indicator** — spinner shown between reducer completion and server broadcast confirmation
- LocalMAP marked "(maybe broken)" in dropdown

## Test plan

- [x] Run Story Tracer, cancel mid-embedding, re-run — should resume from cached chunks (check DevTools → Application → IndexedDB → `embedding-cache`)
- [x] Re-run with different reducer params only — should skip embedding entirely and jump straight to reducer
- [x] Switch reducer algorithm and re-run — should use the new algorithm (iteration count changes)
- [x] Verify reducer progress bar shows "iteration N / M" for umap-js and DruidJS algorithms
- [x] Verify "(generating KNN graph)" appears during the 0th iteration for all algorithms
- [x] Run with a large transcript (1000+ chunks) — should succeed and render the 3D plot without WebSocket errors in the server log

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~200 words of PR description from ~500 words of human prompts across this session)