### PR TITLE
feat: WebRTC call reconnection grace period for Android screen-off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 26 (2026-05-18)
 
 ### Added
+- **PhonePanel: reconnection grace period** — when a caller's WebSocket drops briefly (e.g. Android screen-off kills the connection), the server waits 15 s before hanging up the other party. The waiting side sees "Reconnecting…" instead of an abrupt disconnect. Call duration timer pauses and resumes across the gap.
 - **PhonePanel: wake lock during calls** — screen stays on as soon as a user joins the queue and releases on hang up. A small "screen on" indicator appears while active.
 - **PhonePanel: Media Session API** — lock-screen call card with title and hang-up action on iOS 15+; hardware buttons (headphone remote, AirPods, Bluetooth) can hang up the call. Android notification not yet working ([#112](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/112)).
 - **Refactor: `useWakeLock` hook** — extracted into `app/utils/useWakeLock.ts`; `StenoPanel` and `ReactionCanvasAppV4` now use it instead of inline acquire/release logic.

--- a/app/components/panels/PhonePanel/index.tsx
+++ b/app/components/panels/PhonePanel/index.tsx
@@ -232,14 +232,21 @@ export default function PhonePanel({ room, userId }: PhonePanelProps) {
     }).catch(() => setSelectedSinkLabel('(enumerateDevices failed)'));
   }, [wrtc.remoteStream]);
 
-  // Call duration timer
+  // Call duration timer — pauses during 'reconnecting' so the count survives the gap
   useEffect(() => {
     if (wrtc.callState === 'connected') {
-      callStartRef.current = Date.now();
-      setCallDuration(0);
+      if (!callStartRef.current) {
+        callStartRef.current = Date.now();
+        setCallDuration(0);
+      }
       durationIntervalRef.current = setInterval(() => {
         setCallDuration(Math.floor((Date.now() - (callStartRef.current ?? Date.now())) / 1000));
       }, 1000);
+    } else if (wrtc.callState === 'reconnecting') {
+      if (durationIntervalRef.current) {
+        clearInterval(durationIntervalRef.current);
+        durationIntervalRef.current = null;
+      }
     } else {
       if (durationIntervalRef.current) {
         clearInterval(durationIntervalRef.current);
@@ -407,6 +414,7 @@ export default function PhonePanel({ room, userId }: PhonePanelProps) {
       )}
       {wrtc.callState === 'queued' && <QueuedView onCancel={wrtc.cancelQueue} />}
       {wrtc.callState === 'connecting' && <ConnectingView />}
+      {wrtc.callState === 'reconnecting' && <ReconnectingView onHangUp={wrtc.hangUp} />}
       {wrtc.callState === 'connected' && (
         <ConnectedView
           peerId={wrtc.peerId}
@@ -672,6 +680,29 @@ function ConnectingView() {
     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 16 }}>
       <div style={{ fontSize: 36, color: '#1a7a1a' }}><FaPhone /></div>
       <p style={{ color: '#aaa', fontSize: 15, margin: 0 }}>Connecting…</p>
+    </div>
+  );
+}
+
+function ReconnectingView({ onHangUp }: { onHangUp: () => void }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 24 }}>
+      <div style={{ fontSize: 36, color: '#7a6a1a' }}><FaPhone /></div>
+      <p style={{ color: '#aaa', fontSize: 15, textAlign: 'center', margin: 0 }}>
+        Reconnecting…
+      </p>
+      <p style={{ color: '#666', fontSize: 12, textAlign: 'center', margin: 0 }}>
+        Your match lost connection briefly
+      </p>
+      <button
+        onClick={onHangUp}
+        style={{
+          background: 'none', color: '#888', border: '1px solid #444',
+          borderRadius: 20, padding: '8px 20px', fontSize: 13, cursor: 'pointer',
+        }}
+      >
+        Hang up
+      </button>
     </div>
   );
 }

--- a/app/components/panels/PhonePanel/index.tsx
+++ b/app/components/panels/PhonePanel/index.tsx
@@ -363,6 +363,9 @@ export default function PhonePanel({ room, userId }: PhonePanelProps) {
   const copyDebugInfo = () => {
     const lines: string[] = [
       `timestamp: ${new Date().toISOString()}`,
+      `callState: ${wrtc.callState}`,
+      `rtc: ${wrtc.rtcConnectionState}`,
+      `ice: ${wrtc.iceConnectionState}`,
       `platform: ${platform.label}`,
       `userAgent: ${navigator.userAgent}`,
       `setSinkId: ${hasSinkId ? 'yes' : 'no'}`,
@@ -442,6 +445,18 @@ export default function PhonePanel({ room, userId }: PhonePanelProps) {
         </div>
         {showDebug && (
           <div style={{ background: '#1a1a1a', border: '1px solid #333', borderRadius: 6, padding: 10, fontSize: 11, fontFamily: 'monospace', maxHeight: '60vh', overflowY: 'auto' }}>
+
+            {/* Section 0 — Call state */}
+            <div style={{ color: '#777', marginBottom: 6, textTransform: 'uppercase', fontSize: 10, letterSpacing: 1 }}>call state</div>
+            <div style={{ color: '#666', marginBottom: 4 }}>
+              callState: <span style={{ color: '#4af' }}>{wrtc.callState}</span>
+            </div>
+            <div style={{ color: '#666', marginBottom: 4 }}>
+              rtc: <span style={{ color: wrtc.rtcConnectionState === 'connected' ? '#4c4' : wrtc.rtcConnectionState === '—' ? '#555' : '#fa4' }}>{wrtc.rtcConnectionState}</span>
+            </div>
+            <div style={{ color: '#666', marginBottom: 12 }}>
+              ice: <span style={{ color: wrtc.iceConnectionState === 'connected' || wrtc.iceConnectionState === 'completed' ? '#4c4' : wrtc.iceConnectionState === '—' ? '#555' : '#fa4' }}>{wrtc.iceConnectionState}</span>
+            </div>
 
             {/* Section A — Environment */}
             <div style={{ color: '#777', marginBottom: 6, textTransform: 'uppercase', fontSize: 10, letterSpacing: 1 }}>environment</div>

--- a/app/components/panels/PhonePanel/index.tsx
+++ b/app/components/panels/PhonePanel/index.tsx
@@ -194,7 +194,7 @@ export default function PhonePanel({ room, userId }: PhonePanelProps) {
   const socket = usePartySocket({
     ...getPartySocketConfig(),
     room,
-    query: { userId },
+    query: { userId, isPhonePanel: 'true' },
     onMessage(evt) {
       try {
         void dispatchRef.current(JSON.parse(evt.data) as Record<string, unknown>);

--- a/app/components/panels/PhonePanel/useWebRTCCall.ts
+++ b/app/components/panels/PhonePanel/useWebRTCCall.ts
@@ -14,6 +14,8 @@ export function useWebRTCCall(
   const [peerId, setPeerId] = useState<string | null>(null);
   const [remoteStream, setRemoteStream] = useState<MediaStream | null>(null);
   const [isMuted, setIsMuted] = useState(false);
+  const [rtcConnectionState, setRtcConnectionState] = useState<string>('—');
+  const [iceConnectionState, setIceConnectionState] = useState<string>('—');
 
   const pcRef = useRef<RTCPeerConnection | null>(null);
   const peerIdRef = useRef<string | null>(null);
@@ -29,6 +31,8 @@ export function useWebRTCCall(
     setPeerId(null);
     peerIdRef.current = null;
     setCallState('idle');
+    setRtcConnectionState('—');
+    setIceConnectionState('—');
   }, []);
 
   const createPc = useCallback((peer: string) => {
@@ -62,11 +66,16 @@ export function useWebRTCCall(
     };
 
     pc.onconnectionstatechange = () => {
+      setRtcConnectionState(pc.connectionState);
       if (pc.connectionState === 'connected') {
         setCallState('connected');
       } else if (pc.connectionState === 'failed' || pc.connectionState === 'closed') {
         closePc();
       }
+    };
+
+    pc.oniceconnectionstatechange = () => {
+      setIceConnectionState(pc.iceConnectionState);
     };
 
     return pc;
@@ -130,14 +139,14 @@ export function useWebRTCCall(
       setCallState('reconnecting');
     } else if (data.type === 'callResumed') {
       const peer = data.peerId as string;
-      if (pcRef.current && pcRef.current.connectionState === 'connected') {
-        // WebRTC survived the drop — just restore UI state
+      if (pcRef.current) {
+        // PC still exists — WebRTC survived (may be 'disconnected' transiently, not yet 'failed').
+        // Restore UI state; onconnectionstatechange will call closePc() if it truly fails.
         peerIdRef.current = peer;
         setPeerId(peer);
         setCallState('connected');
       } else {
-        // WebRTC also died during the gap — clean up and let the server know
-        closePc();
+        // closePc() already ran (connection went 'failed') — inform server and stay idle
         sendRef.current({ type: 'hangUp', targetUserId: peer });
       }
     } else if (data.type === 'hangUp') {
@@ -145,5 +154,5 @@ export function useWebRTCCall(
     }
   }, [createPc, sendRef, closePc]);
 
-  return { callState, peerId, remoteStream, isMuted, joinQueue, cancelQueue, hangUp, toggleMute, handleServerMessage };
+  return { callState, peerId, remoteStream, isMuted, rtcConnectionState, iceConnectionState, joinQueue, cancelQueue, hangUp, toggleMute, handleServerMessage };
 }

--- a/app/components/panels/PhonePanel/useWebRTCCall.ts
+++ b/app/components/panels/PhonePanel/useWebRTCCall.ts
@@ -1,6 +1,6 @@
 import { useRef, useState, useCallback } from 'react';
 
-export type CallState = 'idle' | 'queued' | 'connecting' | 'connected';
+export type CallState = 'idle' | 'queued' | 'connecting' | 'connected' | 'reconnecting';
 
 const RTC_CONFIG: RTCConfiguration = {
   iceServers: [{ urls: 'stun:stun.l.google.com:19302' }],
@@ -125,6 +125,20 @@ export function useWebRTCCall(
     } else if (data.type === 'webrtcIce') {
       if (pcRef.current && data.candidate) {
         await pcRef.current.addIceCandidate(new RTCIceCandidate(data.candidate as RTCIceCandidateInit));
+      }
+    } else if (data.type === 'peerReconnecting') {
+      setCallState('reconnecting');
+    } else if (data.type === 'callResumed') {
+      const peer = data.peerId as string;
+      if (pcRef.current && pcRef.current.connectionState === 'connected') {
+        // WebRTC survived the drop — just restore UI state
+        peerIdRef.current = peer;
+        setPeerId(peer);
+        setCallState('connected');
+      } else {
+        // WebRTC also died during the gap — clean up and let the server know
+        closePc();
+        sendRef.current({ type: 'hangUp', targetUserId: peer });
       }
     } else if (data.type === 'hangUp') {
       closePc();

--- a/party/server.ts
+++ b/party/server.ts
@@ -489,10 +489,13 @@ export default class Server implements Party.Server {
     const userId = url.searchParams.get('userId') ?? conn.id;
     this.connectionUserMap.set(conn.id, userId);
 
-    // If this user reconnected within the grace period after a drop, cancel the hangup
-    // timer and restore both sides of the call.
+    // If this user's PhonePanel reconnected within the grace period after a drop, cancel
+    // the hangup timer and restore both sides of the call. We check isPhonePanel because
+    // the Canvas socket (same userId, different connection) reconnects independently and
+    // must not trigger the resume — it fires first and would cancel the timer prematurely.
+    const isPhonePanel = url.searchParams.get('isPhonePanel') === 'true';
     const reconnectTimer = this.callReconnectTimers.get(userId);
-    if (reconnectTimer !== undefined) {
+    if (isPhonePanel && reconnectTimer !== undefined) {
       clearTimeout(reconnectTimer);
       this.callReconnectTimers.delete(userId);
       const peerId = this.callPairs.get(userId);
@@ -604,9 +607,19 @@ export default class Server implements Party.Server {
       // Notify the peer they're waiting, then give the disconnected user time to come back.
       const peerId = this.callPairs.get(userId);
       if (peerId) {
-        console.log(`[call] ${userId} dropped — notifying peer ${peerId}, grace period ${this.CALL_RECONNECT_GRACE_MS}ms`);
-        for (const conn of this.getTargetConnections(peerId)) {
-          conn.send(JSON.stringify({ type: 'peerReconnecting', fromUserId: userId }));
+        // Cancel any existing timer for this userId — both Canvas and PhonePanel share
+        // the same userId, and both drop when the screen turns off. Without this, the
+        // first timer keeps running even after the map entry is overwritten, causing a
+        // double expiry that sends hangUp twice.
+        const existing = this.callReconnectTimers.get(userId);
+        if (existing !== undefined) {
+          clearTimeout(existing);
+          console.log(`[call] ${userId} another connection dropped — resetting grace period`);
+        } else {
+          console.log(`[call] ${userId} dropped — notifying peer ${peerId}, grace period ${this.CALL_RECONNECT_GRACE_MS}ms`);
+          for (const conn of this.getTargetConnections(peerId)) {
+            conn.send(JSON.stringify({ type: 'peerReconnecting', fromUserId: userId }));
+          }
         }
         const timer = setTimeout(() => {
           this.callReconnectTimers.delete(userId);

--- a/party/server.ts
+++ b/party/server.ts
@@ -497,10 +497,13 @@ export default class Server implements Party.Server {
       this.callReconnectTimers.delete(userId);
       const peerId = this.callPairs.get(userId);
       if (peerId) {
+        console.log(`[call] ${userId} reconnected within grace period — resuming call with ${peerId}`);
         conn.send(JSON.stringify({ type: 'callResumed', peerId }));
         for (const peerConn of this.getTargetConnections(peerId)) {
           peerConn.send(JSON.stringify({ type: 'callResumed', peerId: userId }));
         }
+      } else {
+        console.log(`[call] ${userId} reconnected within grace period but call pair already gone`);
       }
     }
 
@@ -601,6 +604,7 @@ export default class Server implements Party.Server {
       // Notify the peer they're waiting, then give the disconnected user time to come back.
       const peerId = this.callPairs.get(userId);
       if (peerId) {
+        console.log(`[call] ${userId} dropped — notifying peer ${peerId}, grace period ${this.CALL_RECONNECT_GRACE_MS}ms`);
         for (const conn of this.getTargetConnections(peerId)) {
           conn.send(JSON.stringify({ type: 'peerReconnecting', fromUserId: userId }));
         }
@@ -608,6 +612,7 @@ export default class Server implements Party.Server {
           this.callReconnectTimers.delete(userId);
           this.callPairs.delete(userId);
           this.callPairs.delete(peerId);
+          console.log(`[call] grace period expired for ${userId} — hanging up peer ${peerId}`);
           for (const conn of this.getTargetConnections(peerId)) {
             conn.send(JSON.stringify({ type: 'hangUp', fromUserId: userId }));
           }

--- a/party/server.ts
+++ b/party/server.ts
@@ -348,6 +348,12 @@ export default class Server implements Party.Server {
   private callQueue: string[] = [];
   private callPairs: Map<string, string> = new Map();
   private callAlgorithm: string = 'first-available';
+  // Grace period timers: when a paired user's WebSocket drops, we wait before notifying
+  // their peer. Android Chrome kills the WebSocket when the screen turns off but the
+  // WebRTC connection often survives. If the user reconnects within the window, we
+  // cancel the timer and send callResumed instead.
+  private callReconnectTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly CALL_RECONNECT_GRACE_MS = 15_000;
 
   // ===== GHOST CURSOR DEMO CODE (can be easily removed) =====
   private ghostCursorsEnabled: boolean = false;
@@ -482,6 +488,22 @@ export default class Server implements Party.Server {
 
     const userId = url.searchParams.get('userId') ?? conn.id;
     this.connectionUserMap.set(conn.id, userId);
+
+    // If this user reconnected within the grace period after a drop, cancel the hangup
+    // timer and restore both sides of the call.
+    const reconnectTimer = this.callReconnectTimers.get(userId);
+    if (reconnectTimer !== undefined) {
+      clearTimeout(reconnectTimer);
+      this.callReconnectTimers.delete(userId);
+      const peerId = this.callPairs.get(userId);
+      if (peerId) {
+        conn.send(JSON.stringify({ type: 'callResumed', peerId }));
+        for (const peerConn of this.getTargetConnections(peerId)) {
+          peerConn.send(JSON.stringify({ type: 'callResumed', peerId: userId }));
+        }
+      }
+    }
+
     if (isViewer) {
       this.viewerConnectionIds.add(conn.id);
     }
@@ -571,16 +593,26 @@ export default class Server implements Party.Server {
         this.stenoLockUserId = null;
         this.room.broadcast(JSON.stringify({ type: 'stenoLockReleased', userId }));
       }
-      // Call queue cleanup
+      // Call queue cleanup (immediate — nothing to preserve)
       const qIdx = this.callQueue.indexOf(userId);
       if (qIdx !== -1) this.callQueue.splice(qIdx, 1);
+      // Call pair cleanup — deferred to allow brief reconnects (e.g. Android kills the
+      // WebSocket when the screen turns off, but the WebRTC connection often survives).
+      // Notify the peer they're waiting, then give the disconnected user time to come back.
       const peerId = this.callPairs.get(userId);
       if (peerId) {
-        this.callPairs.delete(userId);
-        this.callPairs.delete(peerId);
         for (const conn of this.getTargetConnections(peerId)) {
-          conn.send(JSON.stringify({ type: 'hangUp', fromUserId: userId }));
+          conn.send(JSON.stringify({ type: 'peerReconnecting', fromUserId: userId }));
         }
+        const timer = setTimeout(() => {
+          this.callReconnectTimers.delete(userId);
+          this.callPairs.delete(userId);
+          this.callPairs.delete(peerId);
+          for (const conn of this.getTargetConnections(peerId)) {
+            conn.send(JSON.stringify({ type: 'hangUp', fromUserId: userId }));
+          }
+        }, this.CALL_RECONNECT_GRACE_MS);
+        this.callReconnectTimers.set(userId, timer);
       }
     }
 


### PR DESCRIPTION
## Summary

- Server holds a 15 s grace period when a user's WebSocket drops mid-call, instead of immediately sending `hangUp` to the peer
- Peer receives `peerReconnecting` → shows "Reconnecting…" UI instead of going idle
- When the disconnected user's PhonePanel socket reconnects within the grace period, both sides receive `callResumed` and restore call state without renegotiating WebRTC
- `isPhonePanel=true` query param on the PhonePanel socket gates reconnect detection, preventing the Canvas socket (same userId) from triggering a false early resume
- Fixes double grace-period expiry: cancels any existing timer before setting a new one when the same userId's socket drops again
- `callResumed` handler checks `pcRef.current !== null` rather than `connectionState` to avoid false-negative when ICE is transiently `'disconnected'`
- Adds WebRTC debug panel (call state, RTC connection state, ICE state) visible in-app on mobile without console access
- Adds server-side `[call]` logging for queue, pair, disconnect, reconnect, and grace-period expiry events

## Known issue

Calls still disconnect a few seconds after Android reconnects — a delayed haptic buzz (from Canvas processing its reconnect `connected` message via `triggerBuzzForUpdate()`) fires right as the call drops. Tracked in #113 (spurious buzz) and #114 (disconnect correlation). Fixing #113 is expected to resolve #114.

## Test plan

- [ ] Turn off Android screen mid-call → iOS shows "Reconnecting…"
- [ ] Turn Android screen back on → both sides resume call (no re-queue)
- [ ] Cancel/hang up while in "Reconnecting…" → goes idle cleanly
- [ ] Grace period expires (>15 s offline) → both sides go idle
- [ ] Check debug panel on mobile shows correct call/RTC/ICE states

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~200 words of PR description from ~20 words of human prompt)