### PR TITLE
feat(stories): baseline Storybook stories for all panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file. Releases cu
 - **Panel registry** — introduced `app/panelRegistry.ts` as a single source of truth for all panel metadata (id, label, description, patchable, activityMode); `KNOWN_CHIPS` in `ReactionCanvasAppV4`, `ROWS` in `InterfacesTab`, and the hardcoded `<option>` list in `OfferInterfaceModal` now all derive from this registry. Adding a new panel no longer requires edits in three separate files.
 - **Social sharing panel id renamed** — activity/interface key changed from `'social'` → `'social-media'` → `'social-sharing'` to match its label. Affects URL `addInterface` param, localStorage interface lists, and emcee push messages. Old values stored in localStorage will silently fall back to the canvas interface on next load.
 
+### Added
+- **ReactionCanvas Storybook stories** — two stories (`Interactive`, `Recorder`) under `Canvas/ReactionCanvas` let you try the voting canvas outside the full app; `Recorder` captures cursor events via `onCursorEvent` and displays copyable JSON fixture data for use in future stories.
+
 ### Fixed
 - **CI: preview-cleanup workflow node-version bumped to 22** — `pnpm` now requires Node ≥22.13; the delete-preview job was pinned to Node 18, causing it to fail silently after every PR merge. ([57cdd01](https://github.com/patcon/polislike-partykit-reaction-canvas/commit/57cdd01))
 - **OfferInterfaceModal: show panel labels in dropdown** — the interface selector now shows human-readable labels (e.g. "Social Sharing") instead of internal IDs (e.g. "social-media").

--- a/app/components/panels/GreeterPanel/index.tsx
+++ b/app/components/panels/GreeterPanel/index.tsx
@@ -145,7 +145,7 @@ export default function GreeterPanel() {
   const [pastEndCursor, setPastEndCursor] = useState<string | null>(null);
   const [groupSlug, setGroupSlug] = useState<string | null>(null);
   const [attendees, setAttendees] = useState<Attendee[]>([]);
-  const [listStatus, setListStatus] = useState<'idle' | 'loading' | 'no-event' | 'error'>('idle');
+  const [listStatus, setListStatus] = useState<'idle' | 'loading' | 'no-event' | 'error' | 'invalid-url'>('idle');
   const [attendeeStatus, setAttendeeStatus] = useState<'idle' | 'loading' | 'error'>('idle');
 
   const eventUrl = greeterConfig?.eventUrl ?? null;
@@ -158,7 +158,7 @@ export default function GreeterPanel() {
     }
     const parsed = parseGuildUrl(eventUrl);
     if (!parsed) {
-      setEvents([]); setCurrentIndex(0); setGroupSlug(null); setListStatus('idle');
+      setEvents([]); setCurrentIndex(0); setGroupSlug(null); setListStatus('invalid-url');
       return;
     }
 
@@ -379,7 +379,9 @@ export default function GreeterPanel() {
       ) : (
         <div style={{ flex: 1, overflowY: 'auto', padding: '8px 0' }}>
           {!greeterConfig || !eventUrl ? (
-            <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>No URL configured yet.</p>
+            <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>No URL configured yet. Contact the app admin.</p>
+          ) : listStatus === 'invalid-url' ? (
+            <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>Unrecognized URL — must be a guild.host event or group link. Contact the app admin.</p>
           ) : listStatus === 'loading' ? (
             <p style={{ color: '#555', fontSize: 13, padding: '16px 20px' }}>Loading…</p>
           ) : listStatus === 'no-event' ? (

--- a/app/components/panels/MapViewerPanel/index.tsx
+++ b/app/components/panels/MapViewerPanel/index.tsx
@@ -158,10 +158,16 @@ const btnStyle = (active: boolean, disabled?: boolean): React.CSSProperties => (
   lineHeight: 1,
 });
 
-export default function MapViewerPanel() {
+// TODO: remove initialProjection once Storybook has a proper socket mock that can emit fake messages.
+// See: https://github.com/patcon/polislike-partykit-reaction-canvas/issues/123
+export default function MapViewerPanel({ initialProjection }: { initialProjection?: MapProjection } = {}) {
   const { room, userId } = usePanelContext();
   const { config } = useMapViewerConfig();
-  const [projState, setProjState] = useState<ProjState>({ history: [], idx: -1 });
+  const [projState, setProjState] = useState<ProjState>(
+    initialProjection
+      ? { history: [{ projection: initialProjection, flipX: false, flipY: false }], idx: 0 }
+      : { history: [], idx: -1 }
+  );
   const [moments, setMoments] = useState<MomentSnapshot[]>([]);
   const [connectedUserIds, setConnectedUserIds] = useState<string[]>([]);
   const [liveCursors, setLiveCursors] = useState<Map<string, { x: number; y: number }>>(new Map());
@@ -310,8 +316,10 @@ export default function MapViewerPanel() {
 
   if (!mapProjection) {
     return (
-      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', color: '#555', fontSize: 14 }}>
-        No projection computed yet. Use Map Maker to generate one.
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%', padding: '0 24px' }}>
+        <p style={{ color: '#555', fontSize: 14, textAlign: 'center', margin: 0 }}>
+          No projection computed yet. Use Map Maker to generate one.
+        </p>
       </div>
     );
   }

--- a/stories/GreeterPanel.stories.tsx
+++ b/stories/GreeterPanel.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import React from 'react';
+import GreeterPanel from '../app/components/panels/GreeterPanel';
+import { GreeterConfigProvider } from '../app/context/PanelConfigs';
+
+const meta = {
+  title: 'Panels/GreeterPanel',
+  component: GreeterPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story, ctx) => (
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <GreeterConfigProvider value={{ greeterConfig: (ctx.args as { greeterConfig: { eventUrl: string } | null }).greeterConfig }}>
+          <Story />
+        </GreeterConfigProvider>
+      </div>
+    ),
+  ],
+  args: {
+    greeterConfig: null,
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Unconfigured: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/No URL configured yet. Contact the app admin./)).toBeInTheDocument();
+  },
+};
+
+export const WithBadUrl: Story = {
+  args: { greeterConfig: { eventUrl: 'https://example.com' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Unrecognized URL.*Contact the app admin/)).toBeInTheDocument();
+  },
+};
+
+export const WithGroupUrl: Story = {
+  args: { greeterConfig: { eventUrl: 'https://guild.host/civic-tech-toronto' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('In-Person Attendees')).toBeInTheDocument();
+  },
+};
+
+export const WithEventUrl: Story = {
+  args: { greeterConfig: { eventUrl: 'https://guild.host/events/civic-meetup-542-using-2vakqi' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('In-Person Attendees')).toBeInTheDocument();
+  },
+};

--- a/stories/MapMakerPanel.stories.tsx
+++ b/stories/MapMakerPanel.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import React from 'react';
+import MapMakerPanel from '../app/components/panels/MapMakerPanel';
+import { PanelContextProvider } from '../app/context/PanelContext';
+
+const meta = {
+  title: 'Panels/MapMakerPanel',
+  component: MapMakerPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story, ctx) => (
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <PanelContextProvider value={ctx.args as never}>
+          <Story />
+        </PanelContextProvider>
+      </div>
+    ),
+  ],
+  args: {
+    room: 'storybook',
+    userId: 'user-1',
+    inviteEdges: {},
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const EmptyState: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Map Maker')).toBeInTheDocument();
+    await expect(canvas.getByText(/No moments found/)).toBeInTheDocument();
+  },
+};

--- a/stories/MapViewerPanel.stories.tsx
+++ b/stories/MapViewerPanel.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import React from 'react';
+import MapViewerPanel from '../app/components/panels/MapViewerPanel';
+import { PanelContextProvider } from '../app/context/PanelContext';
+import { MapViewerConfigProvider } from '../app/context/PanelConfigs';
+import type { MapViewerConfig, MapProjection } from '../app/types';
+
+// Seeded LCG so the blob is deterministic across renders
+function makeSeededRand(seed: number) {
+  let s = seed;
+  return () => { s = (s * 1664525 + 1013904223) & 0xffffffff; return (s >>> 0) / 0xffffffff; };
+}
+
+function gaussianBlob(n: number, seed: number): MapProjection {
+  const rand = makeSeededRand(seed);
+  const boxMuller = () => {
+    const u = Math.max(rand(), 1e-10);
+    const v = rand();
+    const mag = Math.sqrt(-2 * Math.log(u));
+    return [mag * Math.cos(2 * Math.PI * v), mag * Math.sin(2 * Math.PI * v)] as [number, number];
+  };
+  const coords: [string, [number, number]][] = Array.from({ length: n }, (_, i) => [
+    `user-${i + 1}`,
+    boxMuller(),
+  ]);
+  return { algorithm: 'umap', computedAt: new Date('2025-01-01T12:00:00Z').toISOString(), coords };
+}
+
+const GAUSSIAN_PROJECTION = gaussianBlob(30, 42);
+
+const DEFAULT_CONFIG: MapViewerConfig = { colorMode: 'none', momentId: null };
+
+const meta = {
+  title: 'Panels/MapViewerPanel',
+  component: MapViewerPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story, ctx) => (
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <PanelContextProvider value={ctx.args as never}>
+          <MapViewerConfigProvider value={{ config: (ctx.args as { config: MapViewerConfig }).config }}>
+            <Story />
+          </MapViewerConfigProvider>
+        </PanelContextProvider>
+      </div>
+    ),
+  ],
+  args: {
+    room: 'storybook',
+    userId: 'user-1',
+    inviteEdges: {},
+    config: DEFAULT_CONFIG,
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NoProjection: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/No projection computed yet/)).toBeInTheDocument();
+  },
+};
+
+export const WithGaussianBlob: Story = {
+  args: { initialProjection: GAUSSIAN_PROJECTION },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/UMAP/)).toBeInTheDocument();
+  },
+};

--- a/stories/MoodTonesPanel.stories.tsx
+++ b/stories/MoodTonesPanel.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import React from 'react';
+import MoodTonesPanel from '../app/components/panels/MoodTonesPanel';
+import { PanelContextProvider } from '../app/context/PanelContext';
+
+const meta = {
+  title: 'Panels/MoodTonesPanel',
+  component: MoodTonesPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story, ctx) => (
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <PanelContextProvider value={ctx.args as never}>
+          <Story />
+        </PanelContextProvider>
+      </div>
+    ),
+  ],
+  args: {
+    room: 'storybook',
+    userId: 'user-1',
+    inviteEdges: {},
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('mood tones')).toBeInTheDocument();
+    await expect(canvas.getByText('sad → happy')).toBeInTheDocument();
+  },
+};

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -158,6 +158,7 @@ export const Recorder: Story = {
         userCountRef.current += 1;
 
         setCompletedPaths(prev => [...prev, newPath]);
+        setReplayCursors([]);
         currentEventsRef.current = [];
         setCurrentEventsDisplay([]);
         startTimeRef.current = null;
@@ -165,9 +166,9 @@ export const Recorder: Story = {
       }
     };
 
-    // Animate replay cursors at ~20fps
+    // Animate replay cursors at ~20fps — only while a recording is active
     useEffect(() => {
-      if (completedPaths.length === 0) return;
+      if (completedPaths.length === 0 || !isRecording) return;
       const interval = setInterval(() => {
         const now = Date.now();
         setReplayCursors(completedPaths.map((path, i) => {
@@ -182,7 +183,7 @@ export const Recorder: Story = {
         }));
       }, 50);
       return () => clearInterval(interval);
-    }, [completedPaths]);
+    }, [completedPaths, isRecording]);
 
     const handleClear = () => {
       setCompletedPaths([]);

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -137,8 +137,12 @@ export const Recorder: Story = {
       if ((e.target as HTMLElement).tagName === 'BUTTON') return;
 
       if (!isRecording) {
-        // Start recording
-        startTimeRef.current = Date.now();
+        // Start recording — also kick off replay for any paths completed since last start
+        const now = Date.now();
+        while (replayStartTimesRef.current.length < userCountRef.current) {
+          replayStartTimesRef.current.push(now);
+        }
+        startTimeRef.current = now;
         currentEventsRef.current = [];
         setCurrentEventsDisplay([]);
         setIsRecording(true);
@@ -151,7 +155,6 @@ export const Recorder: Story = {
         const finalEvents = [...currentEventsRef.current, removeEvent];
         const newPath: UserPath = { userId: `user-${userCountRef.current + 1}`, events: finalEvents };
 
-        replayStartTimesRef.current.push(Date.now());
         userCountRef.current += 1;
 
         setCompletedPaths(prev => [...prev, newPath]);

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -47,7 +47,7 @@ function CanvasComposition({ room, userId, labels, onCursorEvent }: CanvasCompos
   const effectiveLabels = labels ?? REACTION_LABEL_PRESETS['default'];
 
   return (
-    <div className="v2-app-container" style={{ position: 'relative', height: '100vh', overflow: 'hidden' }}>
+    <div className="v2-app-container" style={{ position: 'relative', height: '100%', overflow: 'hidden' }}>
       <LabelOverlay labels={effectiveLabels} />
       <Canvas
         room={room}
@@ -221,65 +221,74 @@ export const Recorder: Story = {
       : `Click to record ${nextUser}`;
     const totalEvents = completedPaths.reduce((s, p) => s + p.events.length, 0) + currentEventsDisplay.length;
 
+    const BAR_HEIGHT = 40;
+
     return (
       <div
-        style={{ position: 'relative', width: '100%', height: '100vh' }}
+        style={{ position: 'relative', width: '100%', height: '100vh', display: 'flex', flexDirection: 'column' }}
         onClick={handleCanvasClick}
         onMouseLeave={handleMouseLeave}
         onMouseEnter={handleMouseEnter}
       >
-        <CanvasComposition {...args} onCursorEvent={isRecording ? handleCursorEvent : undefined} />
+        {/* Canvas area — fills everything above the bar */}
+        <div style={{ flex: 1, position: 'relative', minHeight: 0 }}>
+          <CanvasComposition {...args} onCursorEvent={isRecording ? handleCursorEvent : undefined} />
 
-        {/* Replay cursor dots for completed paths */}
-        {completedPaths.map((path, i) => {
-          const cursor = replayCursors[i];
-          if (!cursor) return null;
-          return (
-            <div key={path.userId} style={{
+          {/* Replay cursor dots — positioned relative to canvas area */}
+          {completedPaths.map((path, i) => {
+            const cursor = replayCursors[i];
+            if (!cursor) return null;
+            return (
+              <div key={path.userId} style={{
+                position: 'absolute',
+                left: `${cursor.x}%`,
+                top: `${cursor.y}%`,
+                width: 14,
+                height: 14,
+                borderRadius: '50%',
+                background: replayCursorColor(i),
+                border: '2px solid rgba(0,0,0,0.5)',
+                transform: 'translate(-50%, -50%)',
+                pointerEvents: 'none',
+                zIndex: 15,
+              }} />
+            );
+          })}
+        </div>
+
+        {/* Spacer: always BAR_HEIGHT in flow so canvas stops here.
+            The inner bar div expands upward as an overlay on hover. */}
+        <div style={{ flexShrink: 0, position: 'relative', height: BAR_HEIGHT }}>
+          <div
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => setHovered(false)}
+            style={{
               position: 'absolute',
-              left: `${cursor.x}%`,
-              top: `${cursor.y}%`,
-              width: 14,
-              height: 14,
-              borderRadius: '50%',
-              background: replayCursorColor(i),
-              border: '2px solid rgba(0,0,0,0.5)',
-              transform: 'translate(-50%, -50%)',
-              pointerEvents: 'none',
-              zIndex: 15,
-            }} />
-          );
-        })}
-
-        <div
-          onMouseEnter={() => setHovered(true)}
-          onMouseLeave={() => setHovered(false)}
-          style={{
-            position: 'absolute',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            background: 'rgba(0,0,0,0.88)',
-            color: '#ccc',
-            fontFamily: 'monospace',
-            fontSize: '11px',
-            padding: '8px 12px',
-            height: hovered ? '220px' : 'auto',
-            overflowY: 'auto',
-            zIndex: 100,
-            borderTop: '1px solid #444',
-          }}
-        >
-          <div style={{ display: 'flex', gap: '8px', marginBottom: hovered ? '6px' : 0, alignItems: 'center' }}>
-            <span style={{ flex: 1, color: isRecording ? '#f4a460' : '#888' }}>
-              {statusMsg}{totalEvents > 0 ? ` · ${totalEvents} events` : ''}
-            </span>
-            <button style={btnStyle} onClick={(e) => { e.stopPropagation(); handleClear(); }}>Clear</button>
-            <button style={{ ...btnStyle, color: copied ? '#7fc97f' : '#ccc' }} onClick={(e) => { e.stopPropagation(); handleCopy(); }}>
-              {copied ? 'Copied!' : 'Copy JSON'}
-            </button>
+              bottom: 0,
+              left: 0,
+              right: 0,
+              background: 'rgba(0,0,0,0.88)',
+              color: '#ccc',
+              fontFamily: 'monospace',
+              fontSize: '11px',
+              padding: '8px 12px',
+              height: hovered ? '220px' : BAR_HEIGHT,
+              overflowY: 'auto',
+              zIndex: 100,
+              borderTop: '1px solid #444',
+            }}
+          >
+            <div style={{ display: 'flex', gap: '8px', marginBottom: hovered ? '6px' : 0, alignItems: 'center' }}>
+              <span style={{ flex: 1, color: isRecording ? '#f4a460' : '#888' }}>
+                {statusMsg}{totalEvents > 0 ? ` · ${totalEvents} events` : ''}
+              </span>
+              <button style={btnStyle} onClick={(e) => { e.stopPropagation(); handleClear(); }}>Clear</button>
+              <button style={{ ...btnStyle, color: copied ? '#7fc97f' : '#ccc' }} onClick={(e) => { e.stopPropagation(); handleCopy(); }}>
+                {copied ? 'Copied!' : 'Copy JSON'}
+              </button>
+            </div>
+            {hovered && <pre style={{ margin: 0, overflowX: 'auto', color: '#aaa' }}>{JSON.stringify(completedPaths, null, 2)}</pre>}
           </div>
-          {hovered && <pre style={{ margin: 0, overflowX: 'auto', color: '#aaa' }}>{JSON.stringify(completedPaths, null, 2)}</pre>}
         </div>
       </div>
     );

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React, { useState, useCallback, useRef } from 'react';
+import Canvas from '../app/components/shared/Canvas';
+import TouchLayer from '../app/components/shared/TouchLayer';
+import { REACTION_LABEL_PRESETS } from '../app/voteLabels';
+
+type ReactionState = 'positive' | 'negative' | 'neutral' | null;
+type CursorEventType = 'move' | 'touch' | 'remove';
+
+interface RecordedEvent {
+  type: CursorEventType;
+  x: number;
+  y: number;
+  t: number; // ms offset from first event
+}
+
+interface CanvasCompositionProps {
+  room: string;
+  userId: string;
+  labels?: { positive: string; negative: string; neutral: string };
+  onCursorEvent?: (type: CursorEventType, pos: { x: number; y: number }) => void;
+}
+
+function LabelOverlay({ labels }: { labels: { positive: string; negative: string; neutral: string } }) {
+  const base: React.CSSProperties = {
+    position: 'absolute',
+    fontFamily: 'sans-serif',
+    fontSize: '1.1rem',
+    fontWeight: 'bold',
+    pointerEvents: 'none',
+    zIndex: 20,
+    color: '#fff',
+    textShadow: '0 1px 4px rgba(0,0,0,0.7)',
+    userSelect: 'none',
+  };
+  return (
+    <>
+      <div style={{ ...base, top: '5%', right: '5%' }}>{labels.positive}</div>
+      <div style={{ ...base, bottom: '5%', left: '5%' }}>{labels.negative}</div>
+      <div style={{ ...base, bottom: '5%', right: '5%' }}>{labels.neutral}</div>
+    </>
+  );
+}
+
+function CanvasComposition({ room, userId, labels, onCursorEvent }: CanvasCompositionProps) {
+  const [reactionState, setReactionState] = useState<ReactionState>(null);
+  const effectiveLabels = labels ?? REACTION_LABEL_PRESETS['default'];
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: '100vh', overflow: 'hidden', background: '#1a1a2e' }}>
+      <LabelOverlay labels={effectiveLabels} />
+      <Canvas
+        room={room}
+        userId={userId}
+        currentReactionState={reactionState}
+        heightOffset={0}
+        colorCursorsByVote
+      />
+      <TouchLayer
+        room={room}
+        userId={userId}
+        onActiveStatementChange={() => {}}
+        onReactionStateChange={setReactionState}
+        onBackgroundColorChange={() => {}}
+        heightOffset={0}
+        onCursorEvent={onCursorEvent}
+      />
+    </div>
+  );
+}
+
+const meta = {
+  title: 'Canvas/ReactionCanvas',
+  component: CanvasComposition,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  args: {
+    room: 'storybook-canvas',
+    userId: 'story-user-1',
+    labels: REACTION_LABEL_PRESETS['default'],
+  },
+} satisfies Meta<typeof CanvasComposition>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Interactive: Story = {};
+
+const btnStyle: React.CSSProperties = {
+  padding: '3px 10px',
+  fontSize: '11px',
+  fontFamily: 'monospace',
+  cursor: 'pointer',
+  background: '#333',
+  color: '#ccc',
+  border: '1px solid #555',
+  borderRadius: '3px',
+};
+
+export const Recorder: Story = {
+  render: (args) => {
+    const [events, setEvents] = useState<RecordedEvent[]>([]);
+    const [copied, setCopied] = useState(false);
+    const startTimeRef = useRef<number | null>(null);
+
+    const handleCursorEvent = useCallback((type: CursorEventType, pos: { x: number; y: number }) => {
+      const now = Date.now();
+      if (startTimeRef.current === null) startTimeRef.current = now;
+      const t = now - startTimeRef.current;
+      setEvents(prev => [...prev, {
+        type,
+        x: Math.round(pos.x * 10) / 10,
+        y: Math.round(pos.y * 10) / 10,
+        t,
+      }]);
+    }, []);
+
+    const handleClear = () => {
+      setEvents([]);
+      startTimeRef.current = null;
+    };
+
+    const handleCopy = () => {
+      const fixture = JSON.stringify({ userId: args.userId, events }, null, 2);
+      navigator.clipboard.writeText(fixture);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    };
+
+    const fixture = JSON.stringify({ userId: args.userId, events }, null, 2);
+
+    return (
+      <div style={{ position: 'relative', width: '100%', height: '100vh' }}>
+        <CanvasComposition {...args} onCursorEvent={handleCursorEvent} />
+        <div style={{
+          position: 'absolute',
+          bottom: 0,
+          left: 0,
+          right: 0,
+          background: 'rgba(0,0,0,0.88)',
+          color: '#ccc',
+          fontFamily: 'monospace',
+          fontSize: '11px',
+          padding: '8px 12px',
+          maxHeight: '220px',
+          overflowY: 'auto',
+          zIndex: 100,
+          borderTop: '1px solid #444',
+        }}>
+          <div style={{ display: 'flex', gap: '8px', marginBottom: '6px', alignItems: 'center' }}>
+            <span style={{ flex: 1, color: '#888' }}>{events.length} events recorded — move or touch the canvas above</span>
+            <button style={btnStyle} onClick={handleClear}>Clear</button>
+            <button style={{ ...btnStyle, color: copied ? '#7fc97f' : '#ccc' }} onClick={handleCopy}>
+              {copied ? 'Copied!' : 'Copy JSON'}
+            </button>
+          </div>
+          <pre style={{ margin: 0, overflowX: 'auto', color: '#aaa' }}>{fixture}</pre>
+        </div>
+      </div>
+    );
+  },
+};

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -138,11 +138,9 @@ export const Recorder: Story = {
       if ((e.target as HTMLElement).tagName === 'BUTTON') return;
 
       if (!isRecording) {
-        // Start recording — also kick off replay for any paths completed since last start
+        // Start recording — reset ALL replay start times to now so every path starts at t=0
         const now = Date.now();
-        while (replayStartTimesRef.current.length < userCountRef.current) {
-          replayStartTimesRef.current.push(now);
-        }
+        replayStartTimesRef.current = Array.from({ length: userCountRef.current }, () => now);
         startTimeRef.current = now;
         currentEventsRef.current = [];
         setCurrentEventsDisplay([]);

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -47,7 +47,7 @@ function CanvasComposition({ room, userId, labels, onCursorEvent }: CanvasCompos
   const effectiveLabels = labels ?? REACTION_LABEL_PRESETS['default'];
 
   return (
-    <div style={{ position: 'relative', width: '100%', height: '100vh', overflow: 'hidden', background: '#1a1a2e' }}>
+    <div className="v2-app-container" style={{ position: 'relative', height: '100vh', overflow: 'hidden' }}>
       <LabelOverlay labels={effectiveLabels} />
       <Canvas
         room={room}

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import Canvas from '../app/components/shared/Canvas';
 import TouchLayer from '../app/components/shared/TouchLayer';
 import { REACTION_LABEL_PRESETS } from '../app/voteLabels';
@@ -97,68 +97,167 @@ const btnStyle: React.CSSProperties = {
   borderRadius: '3px',
 };
 
+interface UserPath {
+  userId: string;
+  events: RecordedEvent[];
+}
+
+// Distinct hues that avoid the reaction-zone colors (green/red/yellow)
+const replayCursorColor = (i: number) => `hsl(${(210 + i * 137) % 360}, 70%, 65%)`;
+
 export const Recorder: Story = {
   render: (args) => {
-    const [events, setEvents] = useState<RecordedEvent[]>([]);
-    const [copied, setCopied] = useState(false);
+    const [isRecording, setIsRecording] = useState(false);
+    const [completedPaths, setCompletedPaths] = useState<UserPath[]>([]);
+    const [replayCursors, setReplayCursors] = useState<Array<{ x: number; y: number } | null>>([]);
     const [hovered, setHovered] = useState(false);
+    const [copied, setCopied] = useState(false);
+
+    // Use a ref for the in-progress buffer so the end-click handler reads current data
+    const currentEventsRef = useRef<RecordedEvent[]>([]);
+    // Display copy of currentEventsRef for rendering
+    const [currentEventsDisplay, setCurrentEventsDisplay] = useState<RecordedEvent[]>([]);
     const startTimeRef = useRef<number | null>(null);
+    const replayStartTimesRef = useRef<number[]>([]);
+    const userCountRef = useRef(0);
 
     const handleCursorEvent = useCallback((type: CursorEventType, pos: { x: number; y: number }) => {
-      const now = Date.now();
-      if (startTimeRef.current === null) startTimeRef.current = now;
-      const t = now - startTimeRef.current;
-      setEvents(prev => [...prev, {
+      if (startTimeRef.current === null) return;
+      const event: RecordedEvent = {
         type,
         x: Math.round(pos.x * 10) / 10,
         y: Math.round(pos.y * 10) / 10,
-        t,
-      }]);
+        t: Date.now() - startTimeRef.current,
+      };
+      currentEventsRef.current = [...currentEventsRef.current, event];
+      setCurrentEventsDisplay(currentEventsRef.current);
     }, []);
 
+    const handleCanvasClick = (e: React.MouseEvent) => {
+      if ((e.target as HTMLElement).tagName === 'BUTTON') return;
+
+      if (!isRecording) {
+        // Start recording
+        startTimeRef.current = Date.now();
+        currentEventsRef.current = [];
+        setCurrentEventsDisplay([]);
+        setIsRecording(true);
+      } else {
+        // End recording — append a remove event to close the stream
+        const removeEvent: RecordedEvent = {
+          type: 'remove', x: 0, y: 0,
+          t: Date.now() - (startTimeRef.current ?? Date.now()),
+        };
+        const finalEvents = [...currentEventsRef.current, removeEvent];
+        const newPath: UserPath = { userId: `user-${userCountRef.current + 1}`, events: finalEvents };
+
+        replayStartTimesRef.current.push(Date.now());
+        userCountRef.current += 1;
+
+        setCompletedPaths(prev => [...prev, newPath]);
+        currentEventsRef.current = [];
+        setCurrentEventsDisplay([]);
+        startTimeRef.current = null;
+        setIsRecording(false);
+      }
+    };
+
+    // Animate replay cursors at ~20fps
+    useEffect(() => {
+      if (completedPaths.length === 0) return;
+      const interval = setInterval(() => {
+        const now = Date.now();
+        setReplayCursors(completedPaths.map((path, i) => {
+          const duration = path.events[path.events.length - 1].t;
+          const elapsed = (now - replayStartTimesRef.current[i]) % (duration + 2000);
+          let last: RecordedEvent | null = null;
+          for (const e of path.events) {
+            if (e.t <= elapsed) last = e;
+            else break;
+          }
+          return (!last || last.type === 'remove') ? null : { x: last.x, y: last.y };
+        }));
+      }, 50);
+      return () => clearInterval(interval);
+    }, [completedPaths]);
+
     const handleClear = () => {
-      setEvents([]);
+      setCompletedPaths([]);
+      setReplayCursors([]);
+      setCurrentEventsDisplay([]);
+      currentEventsRef.current = [];
+      replayStartTimesRef.current = [];
+      userCountRef.current = 0;
       startTimeRef.current = null;
+      setIsRecording(false);
     };
 
     const handleCopy = () => {
-      const fixture = JSON.stringify({ userId: args.userId, events }, null, 2);
-      navigator.clipboard.writeText(fixture);
+      navigator.clipboard.writeText(JSON.stringify(completedPaths, null, 2));
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     };
 
-    const fixture = JSON.stringify({ userId: args.userId, events }, null, 2);
+    const nextUser = `user-${userCountRef.current + 1}`;
+    const statusMsg = isRecording
+      ? `Recording ${nextUser}… click to stop`
+      : `Click to record ${nextUser}`;
+    const totalEvents = completedPaths.reduce((s, p) => s + p.events.length, 0) + currentEventsDisplay.length;
 
     return (
-      <div style={{ position: 'relative', width: '100%', height: '100vh' }}>
-        <CanvasComposition {...args} onCursorEvent={handleCursorEvent} />
+      <div style={{ position: 'relative', width: '100%', height: '100vh' }} onClick={handleCanvasClick}>
+        <CanvasComposition {...args} onCursorEvent={isRecording ? handleCursorEvent : undefined} />
+
+        {/* Replay cursor dots for completed paths */}
+        {completedPaths.map((path, i) => {
+          const cursor = replayCursors[i];
+          if (!cursor) return null;
+          return (
+            <div key={path.userId} style={{
+              position: 'absolute',
+              left: `${cursor.x}%`,
+              top: `${cursor.y}%`,
+              width: 14,
+              height: 14,
+              borderRadius: '50%',
+              background: replayCursorColor(i),
+              border: '2px solid rgba(0,0,0,0.5)',
+              transform: 'translate(-50%, -50%)',
+              pointerEvents: 'none',
+              zIndex: 15,
+            }} />
+          );
+        })}
+
         <div
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
           style={{
-          position: 'absolute',
-          bottom: 0,
-          left: 0,
-          right: 0,
-          background: 'rgba(0,0,0,0.88)',
-          color: '#ccc',
-          fontFamily: 'monospace',
-          fontSize: '11px',
-          padding: '8px 12px',
-          height: hovered ? '220px' : 'auto',
-          overflowY: 'auto',
-          zIndex: 100,
-          borderTop: '1px solid #444',
-        }}>
-          <div style={{ display: 'flex', gap: '8px', marginBottom: '6px', alignItems: 'center' }}>
-            <span style={{ flex: 1, color: '#888' }}>{events.length} events recorded</span>
-            <button style={btnStyle} onClick={handleClear}>Clear</button>
-            <button style={{ ...btnStyle, color: copied ? '#7fc97f' : '#ccc' }} onClick={handleCopy}>
+            position: 'absolute',
+            bottom: 0,
+            left: 0,
+            right: 0,
+            background: 'rgba(0,0,0,0.88)',
+            color: '#ccc',
+            fontFamily: 'monospace',
+            fontSize: '11px',
+            padding: '8px 12px',
+            height: hovered ? '220px' : 'auto',
+            overflowY: 'auto',
+            zIndex: 100,
+            borderTop: '1px solid #444',
+          }}
+        >
+          <div style={{ display: 'flex', gap: '8px', marginBottom: hovered ? '6px' : 0, alignItems: 'center' }}>
+            <span style={{ flex: 1, color: isRecording ? '#f4a460' : '#888' }}>
+              {statusMsg}{totalEvents > 0 ? ` · ${totalEvents} events` : ''}
+            </span>
+            <button style={btnStyle} onClick={(e) => { e.stopPropagation(); handleClear(); }}>Clear</button>
+            <button style={{ ...btnStyle, color: copied ? '#7fc97f' : '#ccc' }} onClick={(e) => { e.stopPropagation(); handleCopy(); }}>
               {copied ? 'Copied!' : 'Copy JSON'}
             </button>
           </div>
-          {hovered && <pre style={{ margin: 0, overflowX: 'auto', color: '#aaa' }}>{fixture}</pre>}
+          {hovered && <pre style={{ margin: 0, overflowX: 'auto', color: '#aaa' }}>{JSON.stringify(completedPaths, null, 2)}</pre>}
         </div>
       </div>
     );

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -112,6 +112,7 @@ export const Recorder: Story = {
     const [replayCursors, setReplayCursors] = useState<Array<{ x: number; y: number } | null>>([]);
     const [hovered, setHovered] = useState(false);
     const [copied, setCopied] = useState(false);
+    const [isPreviewing, setIsPreviewing] = useState(false);
 
     // Use a ref for the in-progress buffer so the end-click handler reads current data
     const currentEventsRef = useRef<RecordedEvent[]>([]);
@@ -166,9 +167,9 @@ export const Recorder: Story = {
       }
     };
 
-    // Animate replay cursors at ~20fps — only while a recording is active
+    // Animate replay cursors at ~20fps — while recording or previewing (mouse-out)
     useEffect(() => {
-      if (completedPaths.length === 0 || !isRecording) return;
+      if (completedPaths.length === 0 || (!isRecording && !isPreviewing)) return;
       const interval = setInterval(() => {
         const now = Date.now();
         setReplayCursors(completedPaths.map((path, i) => {
@@ -183,12 +184,26 @@ export const Recorder: Story = {
         }));
       }, 50);
       return () => clearInterval(interval);
-    }, [completedPaths, isRecording]);
+    }, [completedPaths, isRecording, isPreviewing]);
+
+    const handleMouseLeave = () => {
+      if (isRecording || completedPaths.length === 0) return;
+      const now = Date.now();
+      replayStartTimesRef.current = completedPaths.map(() => now);
+      setIsPreviewing(true);
+    };
+
+    const handleMouseEnter = () => {
+      if (!isPreviewing) return;
+      setIsPreviewing(false);
+      setReplayCursors([]);
+    };
 
     const handleClear = () => {
       setCompletedPaths([]);
       setReplayCursors([]);
       setCurrentEventsDisplay([]);
+      setIsPreviewing(false);
       currentEventsRef.current = [];
       replayStartTimesRef.current = [];
       userCountRef.current = 0;
@@ -209,7 +224,12 @@ export const Recorder: Story = {
     const totalEvents = completedPaths.reduce((s, p) => s + p.events.length, 0) + currentEventsDisplay.length;
 
     return (
-      <div style={{ position: 'relative', width: '100%', height: '100vh' }} onClick={handleCanvasClick}>
+      <div
+        style={{ position: 'relative', width: '100%', height: '100vh' }}
+        onClick={handleCanvasClick}
+        onMouseLeave={handleMouseLeave}
+        onMouseEnter={handleMouseEnter}
+      >
         <CanvasComposition {...args} onCursorEvent={isRecording ? handleCursorEvent : undefined} />
 
         {/* Replay cursor dots for completed paths */}

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -101,6 +101,7 @@ export const Recorder: Story = {
   render: (args) => {
     const [events, setEvents] = useState<RecordedEvent[]>([]);
     const [copied, setCopied] = useState(false);
+    const [hovered, setHovered] = useState(false);
     const startTimeRef = useRef<number | null>(null);
 
     const handleCursorEvent = useCallback((type: CursorEventType, pos: { x: number; y: number }) => {
@@ -132,7 +133,10 @@ export const Recorder: Story = {
     return (
       <div style={{ position: 'relative', width: '100%', height: '100vh' }}>
         <CanvasComposition {...args} onCursorEvent={handleCursorEvent} />
-        <div style={{
+        <div
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+          style={{
           position: 'absolute',
           bottom: 0,
           left: 0,
@@ -142,19 +146,19 @@ export const Recorder: Story = {
           fontFamily: 'monospace',
           fontSize: '11px',
           padding: '8px 12px',
-          height: '220px',
+          height: hovered ? '220px' : 'auto',
           overflowY: 'auto',
           zIndex: 100,
           borderTop: '1px solid #444',
         }}>
           <div style={{ display: 'flex', gap: '8px', marginBottom: '6px', alignItems: 'center' }}>
-            <span style={{ flex: 1, color: '#888' }}>{events.length} events recorded — move or touch the canvas above</span>
+            <span style={{ flex: 1, color: '#888' }}>{events.length} events recorded</span>
             <button style={btnStyle} onClick={handleClear}>Clear</button>
             <button style={{ ...btnStyle, color: copied ? '#7fc97f' : '#ccc' }} onClick={handleCopy}>
               {copied ? 'Copied!' : 'Copy JSON'}
             </button>
           </div>
-          <pre style={{ margin: 0, overflowX: 'auto', color: '#aaa' }}>{fixture}</pre>
+          {hovered && <pre style={{ margin: 0, overflowX: 'auto', color: '#aaa' }}>{fixture}</pre>}
         </div>
       </div>
     );

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -142,7 +142,7 @@ export const Recorder: Story = {
           fontFamily: 'monospace',
           fontSize: '11px',
           padding: '8px 12px',
-          maxHeight: '220px',
+          height: '220px',
           overflowY: 'auto',
           zIndex: 100,
           borderTop: '1px solid #444',

--- a/stories/SocialMediaPanel.stories.tsx
+++ b/stories/SocialMediaPanel.stories.tsx
@@ -6,7 +6,14 @@ import { SocialMediaConfigProvider } from '../app/context/PanelConfigs';
 import type { SocialConfig } from '../app/types';
 
 const EMPTY_CONFIG: SocialConfig = { default: '', twitter: '', bluesky: '', mastodon: '', instagram: '' };
-const FULL_CONFIG: SocialConfig = {
+const DEFAULT_ONLY_CONFIG: SocialConfig = {
+  default: 'Check out this event!',
+  twitter: '',
+  bluesky: '',
+  mastodon: '',
+  instagram: '',
+};
+const EXTENDED_TWITTER_CONFIG: SocialConfig = {
   default: 'Check out this event!',
   twitter: '#awesome',
   bluesky: '',
@@ -51,14 +58,70 @@ export const EmptyConfig: Story = {
   },
 };
 
-export const WithTwitterConfig: Story = {
-  args: { socialMediaConfig: FULL_CONFIG },
+export const WithDefaultConfig: Story = {
+  args: { socialMediaConfig: DEFAULT_ONLY_CONFIG },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     // default text applies to all platforms, so all four buttons appear
     await expect(canvas.getByText('Share to Twitter / X')).toBeInTheDocument();
     await expect(canvas.getByText('Share to Bluesky')).toBeInTheDocument();
     await expect(canvas.getByText('Share on Mastodon')).toBeInTheDocument();
+    await expect(canvas.getByText('Open Instagram')).toBeInTheDocument();
+  },
+};
+
+export const WithExtendedTwitter: Story = {
+  args: { socialMediaConfig: EXTENDED_TWITTER_CONFIG },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // default + twitter-specific text both set; all four buttons still appear
+    await expect(canvas.getByText('Share to Twitter / X')).toBeInTheDocument();
+    await expect(canvas.getByText('Share to Bluesky')).toBeInTheDocument();
+    await expect(canvas.getByText('Share on Mastodon')).toBeInTheDocument();
+    await expect(canvas.getByText('Open Instagram')).toBeInTheDocument();
+  },
+};
+
+export const WithOnlyTwitter: Story = {
+  args: { socialMediaConfig: { default: '', twitter: '#awesome', bluesky: '', mastodon: '', instagram: '' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Share to Twitter / X')).toBeInTheDocument();
+    await expect(canvas.queryByText('Share to Bluesky')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Share on Mastodon')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Open Instagram')).not.toBeInTheDocument();
+  },
+};
+
+export const WithOnlyBluesky: Story = {
+  args: { socialMediaConfig: { default: '', twitter: '', bluesky: 'Check out this event!', mastodon: '', instagram: '' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText('Share to Twitter / X')).not.toBeInTheDocument();
+    await expect(canvas.getByText('Share to Bluesky')).toBeInTheDocument();
+    await expect(canvas.queryByText('Share on Mastodon')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Open Instagram')).not.toBeInTheDocument();
+  },
+};
+
+export const WithOnlyMastodon: Story = {
+  args: { socialMediaConfig: { default: '', twitter: '', bluesky: '', mastodon: 'Join the conversation!', instagram: '' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText('Share to Twitter / X')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Share to Bluesky')).not.toBeInTheDocument();
+    await expect(canvas.getByText('Share on Mastodon')).toBeInTheDocument();
+    await expect(canvas.queryByText('Open Instagram')).not.toBeInTheDocument();
+  },
+};
+
+export const WithOnlyInstagram: Story = {
+  args: { socialMediaConfig: { default: '', twitter: '', bluesky: '', mastodon: '', instagram: 'Follow us!' } },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.queryByText('Share to Twitter / X')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Share to Bluesky')).not.toBeInTheDocument();
+    await expect(canvas.queryByText('Share on Mastodon')).not.toBeInTheDocument();
     await expect(canvas.getByText('Open Instagram')).toBeInTheDocument();
   },
 };

--- a/stories/SocialMediaPanel.stories.tsx
+++ b/stories/SocialMediaPanel.stories.tsx
@@ -21,9 +21,11 @@ const meta = {
   tags: ['autodocs'],
   decorators: [
     (Story, ctx) => (
-      <SocialMediaConfigProvider value={{ socialMediaConfig: (ctx.args as { socialMediaConfig: SocialConfig | null }).socialMediaConfig }}>
-        <Story />
-      </SocialMediaConfigProvider>
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <SocialMediaConfigProvider value={{ socialMediaConfig: (ctx.args as { socialMediaConfig: SocialConfig | null }).socialMediaConfig }}>
+          <Story />
+        </SocialMediaConfigProvider>
+      </div>
     ),
   ],
   args: {

--- a/stories/StenoPanel.stories.tsx
+++ b/stories/StenoPanel.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import React from 'react';
+import StenoPanel from '../app/components/panels/StenoPanel';
+import { PanelContextProvider } from '../app/context/PanelContext';
+
+const meta = {
+  title: 'Panels/StenoPanel',
+  component: StenoPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story, ctx) => (
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <PanelContextProvider value={ctx.args as never}>
+          <Story />
+        </PanelContextProvider>
+      </div>
+    ),
+  ],
+  args: {
+    room: 'storybook',
+    userId: 'user-1',
+    inviteEdges: {},
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('VTT')).toBeInTheDocument();
+    await expect(canvas.getByText('Plaintext')).toBeInTheDocument();
+    await expect(canvas.getByText('Transcribe')).toBeInTheDocument();
+  },
+};

--- a/stories/StoryTracerPanel.stories.tsx
+++ b/stories/StoryTracerPanel.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import React from 'react';
+import StoryTracerPanel from '../app/components/panels/StoryTracerPanel';
+import { PanelContextProvider } from '../app/context/PanelContext';
+
+const meta = {
+  title: 'Panels/StoryTracerPanel',
+  component: StoryTracerPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story, ctx) => (
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <PanelContextProvider value={ctx.args as never}>
+          <Story />
+        </PanelContextProvider>
+      </div>
+    ),
+  ],
+  args: {
+    room: 'storybook',
+    userId: 'user-1',
+    inviteEdges: {},
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NoTranscript: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/No VTT content yet — use Steno to record a transcript/)).toBeInTheDocument();
+  },
+};

--- a/stories/TreevitesPanel.stories.tsx
+++ b/stories/TreevitesPanel.stories.tsx
@@ -11,9 +11,11 @@ const meta = {
   tags: ['autodocs'],
   decorators: [
     (Story, ctx) => (
-      <PanelContextProvider value={ctx.args as never}>
-        <Story />
-      </PanelContextProvider>
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <PanelContextProvider value={ctx.args as never}>
+          <Story />
+        </PanelContextProvider>
+      </div>
     ),
   ],
   args: {

--- a/stories/VoiceCallPanel.stories.tsx
+++ b/stories/VoiceCallPanel.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import React from 'react';
+import VoiceCallPanel from '../app/components/panels/VoiceCallPanel';
+import { PanelContextProvider } from '../app/context/PanelContext';
+
+const meta = {
+  title: 'Panels/VoiceCallPanel',
+  component: VoiceCallPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story, ctx) => (
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <PanelContextProvider value={ctx.args as never}>
+          <Story />
+        </PanelContextProvider>
+      </div>
+    ),
+  ],
+  args: {
+    room: 'storybook',
+    userId: 'user-1',
+    inviteEdges: {},
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Idle: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Voice calls')).toBeInTheDocument();
+    await expect(canvas.getByText(/Tap to be connected/)).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## Summary

- Add baseline Storybook stories for all panels: GreeterPanel, MapMakerPanel, MapViewerPanel, MoodTonesPanel, StenoPanel, StoryTracerPanel, VoiceCallPanel
- Expand SocialMediaPanel stories: rename `WithTwitterConfig` → `WithDefaultConfig` + `WithExtendedTwitter`; add `WithOnlyTwitter`, `WithOnlyBluesky`, `WithOnlyMastodon`, `WithOnlyInstagram`
- Add GreeterPanel stories covering Unconfigured, WithBadUrl, WithGroupUrl, and WithEventUrl (real Guild.host URLs); add `invalid-url` status with "Contact the app admin" messaging
- Add `WithGaussianBlob` story to MapViewerPanel via a temporary `initialProjection` prop (tracked for removal in #123)
- Fix MapViewerPanel empty-state text centering on narrow portrait screens

## Notes

- `initialProjection` prop on `MapViewerPanel` is a temporary workaround until #123 (fakeable socket mock) is resolved
- Real network requests are made in GreeterPanel stories — no mocking

## Test plan

- [ ] Run `pnpm run storybook` and verify all new stories render without errors
- [ ] Run `pnpm vitest` to confirm story-based tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~150 words of PR description from ~230 words of human prompts across this session)