### PR TITLE
feat(storybook): fakeable socket mock + MoodTonesPanel oscillating story

### DIFF
--- a/.storybook/mocks/partysocket-react.ts
+++ b/.storybook/mocks/partysocket-react.ts
@@ -1,10 +1,27 @@
 // Storybook mock for partysocket/react.
-// Prevents components from attempting real WebSocket connections during story rendering.
-export default function usePartySocket(_options: any) {
+// Prevents components from attempting real WebSocket connections during story rendering,
+// while allowing stories to push fake messages via emitToRoom.
+import { useEffect } from 'react';
+import { subscribe, unsubscribe, emitToRoom } from './socketMessageBus';
+
+export { emitToRoom };
+
+export default function usePartySocket({ room, onMessage, onOpen, onClose }: any) {
+  useEffect(() => {
+    onOpen?.();
+    if (!onMessage) return;
+    subscribe(room, onMessage);
+    return () => {
+      unsubscribe(room, onMessage);
+      onClose?.();
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [room]);
+
   return {
     send: () => {},
     close: () => {},
     reconnect: () => {},
-    readyState: 3, // WebSocket.CLOSED
+    readyState: 1, // WebSocket.OPEN — components expecting a live connection behave correctly
   };
 }

--- a/.storybook/mocks/socketMessageBus.ts
+++ b/.storybook/mocks/socketMessageBus.ts
@@ -1,0 +1,18 @@
+type MessageCallback = (evt: MessageEvent) => void;
+
+const bus = new Map<string, Set<MessageCallback>>();
+
+export function subscribe(room: string, cb: MessageCallback) {
+  let set = bus.get(room);
+  if (!set) { set = new Set(); bus.set(room, set); }
+  set.add(cb);
+}
+
+export function unsubscribe(room: string, cb: MessageCallback) {
+  bus.get(room)?.delete(cb);
+}
+
+export function emitToRoom(room: string, data: object) {
+  const payload = JSON.stringify(data);
+  bus.get(room)?.forEach(cb => cb(new MessageEvent('message', { data: payload })));
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 27 (2026-05-25)
 
+### Added
+- **Fakeable Storybook socket mock** — `.storybook/mocks/partysocket-react.ts` now subscribes to a shared message bus; stories can call `emitToRoom(room, data)` from their `play` functions to push fake socket messages into components. `MoodTonesPanel` migrated from a hand-rolled `WebSocket` to `usePartySocket` so it benefits from the same mock. `MapViewerPanel`'s `initialProjection` prop (a Storybook-only hack) removed; its `WithGaussianBlob` story now drives projection via `emitToRoom`. New `OscillatingAudienceMood` story for `MoodTonesPanel` shows the mood slider animating from simulated audience cursor positions. Closes [#123](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/123).
+
+---
+
+
 ### Changed
 - **Unified panel rendering** — the 18-branch conditional render in `ReactionCanvasAppV4` replaced by a `PANEL_COMPONENTS` map; chip-based and activity-based paths unified into a single derived `activePanelId`; canvas visibility check simplified from a long `activity !== X` chain to `!PANEL_COMPONENTS[activity]`.
 - **PanelDefinition type** — `app/panelRegistry.ts` now exports `PanelDefinition` extending `PanelMeta` with a `component: React.ComponentType` field; `inviteEdges` added to `PanelContextValue` and `TreevitesPanel` migrated to context, making all nine non-emcee panels fully prop-free and typeable as `PanelDefinition`.

--- a/app/components/panels/MapViewerPanel/index.tsx
+++ b/app/components/panels/MapViewerPanel/index.tsx
@@ -158,16 +158,10 @@ const btnStyle = (active: boolean, disabled?: boolean): React.CSSProperties => (
   lineHeight: 1,
 });
 
-// TODO: remove initialProjection once Storybook has a proper socket mock that can emit fake messages.
-// See: https://github.com/patcon/polislike-partykit-reaction-canvas/issues/123
-export default function MapViewerPanel({ initialProjection }: { initialProjection?: MapProjection } = {}) {
+export default function MapViewerPanel() {
   const { room, userId } = usePanelContext();
   const { config } = useMapViewerConfig();
-  const [projState, setProjState] = useState<ProjState>(
-    initialProjection
-      ? { history: [{ projection: initialProjection, flipX: false, flipY: false }], idx: 0 }
-      : { history: [], idx: -1 }
-  );
+  const [projState, setProjState] = useState<ProjState>({ history: [], idx: -1 });
   const [moments, setMoments] = useState<MomentSnapshot[]>([]);
   const [connectedUserIds, setConnectedUserIds] = useState<string[]>([]);
   const [liveCursors, setLiveCursors] = useState<Map<string, { x: number; y: number }>>(new Map());

--- a/app/components/panels/MoodTonesPanel/index.tsx
+++ b/app/components/panels/MoodTonesPanel/index.tsx
@@ -1,5 +1,8 @@
 import { useState, useRef, useEffect, useCallback } from "react";
+import usePartySocket from 'partysocket/react';
 import { usePanelContext } from "../../../context/PanelContext";
+import { getPartySocketConfig } from '../../../utils/partyHost';
+import { generateUUID } from '../../../utils/userId';
 
 // ── Types ─────────────────────────────────────────────────────────
 
@@ -226,17 +229,6 @@ function interpolateWaypoints(preset: Preset, t: number): WaypointInterp {
 // ── Audio gain per oscillator type ────────────────────────────────
 const OSC_GAIN: Record<string, number> = { sawtooth: 0.10, square: 0.15, triangle: 0.32, sine: 0.55 };
 
-// ── WebSocket URL ─────────────────────────────────────────────────
-function makeWsUrl(room: string): string {
-  const isLocal = window.location.port === '1999';
-  const host = isLocal ? `${window.location.hostname}:1999` : window.location.host;
-  const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
-  const uid = typeof crypto !== 'undefined' && (crypto as { randomUUID?: () => string }).randomUUID
-    ? (crypto as { randomUUID: () => string }).randomUUID()
-    : Math.random().toString(36).slice(2);
-  return `${proto}://${host}/parties/main/${encodeURIComponent(room)}?isAdmin=true&userId=${uid}`;
-}
-
 // ── Component ─────────────────────────────────────────────────────
 
 interface BarState { height: number; color: [number,number,number]; active: boolean; }
@@ -275,7 +267,7 @@ export default function MoodTonesPanel() {
   const currentChordRef = useRef<number[]>([]);
 
   // WS refs
-  const wsRef           = useRef<WebSocket|null>(null);
+  const socketUserId    = useRef(generateUUID());
   const cursorsRef      = useRef<Map<string,{x:number;y:number;region:string}>>(new Map());
   const cursorRegionsRef= useRef<Map<string,string>>(new Map());
   const audienceSyncRef = useRef(true);
@@ -329,58 +321,35 @@ export default function MoodTonesPanel() {
   }, [audienceSync, valenceMode, applyAudienceMood]);
 
   // ── WebSocket ──────────────────────────────────────────────────
-  useEffect(() => {
-    let reconnectTimer: ReturnType<typeof setTimeout>|null = null;
-    let dead = false;
-
-    function connect() {
-      if (dead) return;
-      setWsStatus('connecting');
-      const socket = new WebSocket(makeWsUrl(room));
-      wsRef.current = socket;
-
-      socket.onopen = () => { if (!dead) setWsStatus('connected'); };
-
-      socket.onmessage = (evt) => {
-        if (dead) return;
-        let data: { type: string; count?: number; position?: { userId: string; x: number; y: number } };
-        try { data = JSON.parse(evt.data as string); } catch { return; }
-        if (data.type === 'presenceCount') {
-          setAudienceCount(data.count ?? 0);
-        } else if (data.type === 'move' || data.type === 'touch') {
-          const { userId, x, y } = data.position!;
-          const region = computeRegion(x, y);
-          const prevRegion = cursorRegionsRef.current.get(userId);
-          cursorsRef.current.set(userId, { x, y, region });
-          if (valenceModeRef.current === 'continuous' || region !== prevRegion) {
-            cursorRegionsRef.current.set(userId, region);
-            applyAudienceMood();
-          }
-        } else if (data.type === 'remove') {
-          const { userId } = data.position!;
-          cursorsRef.current.delete(userId);
-          cursorRegionsRef.current.delete(userId);
+  usePartySocket({
+    ...getPartySocketConfig(),
+    room,
+    query: { isAdmin: 'true', userId: socketUserId.current },
+    onOpen:  () => setWsStatus('connected'),
+    onClose: () => setWsStatus('disconnected'),
+    onError: () => setWsStatus('disconnected'),
+    onMessage(evt) {
+      let data: { type: string; count?: number; position?: { userId: string; x: number; y: number } };
+      try { data = JSON.parse(evt.data as string); } catch { return; }
+      if (data.type === 'presenceCount') {
+        setAudienceCount(data.count ?? 0);
+      } else if (data.type === 'move' || data.type === 'touch') {
+        const { userId, x, y } = data.position!;
+        const region = computeRegion(x, y);
+        const prevRegion = cursorRegionsRef.current.get(userId);
+        cursorsRef.current.set(userId, { x, y, region });
+        if (valenceModeRef.current === 'continuous' || region !== prevRegion) {
+          cursorRegionsRef.current.set(userId, region);
           applyAudienceMood();
         }
-      };
-
-      socket.onerror = () => { if (!dead) setWsStatus('disconnected'); };
-
-      socket.onclose = () => {
-        if (dead) return;
-        setWsStatus('disconnected');
-        reconnectTimer = setTimeout(connect, 3000);
-      };
-    }
-
-    connect();
-
-    return () => {
-      dead = true;
-      if (reconnectTimer) clearTimeout(reconnectTimer);
-      if (wsRef.current) { wsRef.current.onclose = null; wsRef.current.close(); wsRef.current = null; }
-    };
-  }, [room, applyAudienceMood]);
+      } else if (data.type === 'remove') {
+        const { userId } = data.position!;
+        cursorsRef.current.delete(userId);
+        cursorRegionsRef.current.delete(userId);
+        applyAudienceMood();
+      }
+    },
+  });
 
   // ── Audio helpers ──────────────────────────────────────────────
   function makeSawFilter(freq: number, vel: number): BiquadFilterNode {

--- a/stories/MapViewerPanel.stories.tsx
+++ b/stories/MapViewerPanel.stories.tsx
@@ -70,6 +70,7 @@ export const WithGaussianBlob: Story = {
   play: async ({ canvasElement }) => {
     emitToRoom('storybook', { type: 'connected', mapProjection: GAUSSIAN_PROJECTION, connectedUserIds: [], roomAnchors: null });
     const canvas = within(canvasElement);
-    await expect(canvas.getByText(/UMAP/)).toBeInTheDocument();
+    // findByText waits for the async state update triggered by emitToRoom to flush
+    await expect(canvas.findByText(/UMAP/)).resolves.toBeInTheDocument();
   },
 };

--- a/stories/MapViewerPanel.stories.tsx
+++ b/stories/MapViewerPanel.stories.tsx
@@ -5,6 +5,7 @@ import MapViewerPanel from '../app/components/panels/MapViewerPanel';
 import { PanelContextProvider } from '../app/context/PanelContext';
 import { MapViewerConfigProvider } from '../app/context/PanelConfigs';
 import type { MapViewerConfig, MapProjection } from '../app/types';
+import { emitToRoom } from '../.storybook/mocks/partysocket-react';
 
 // Seeded LCG so the blob is deterministic across renders
 function makeSeededRand(seed: number) {
@@ -66,8 +67,8 @@ export const NoProjection: Story = {
 };
 
 export const WithGaussianBlob: Story = {
-  args: { initialProjection: GAUSSIAN_PROJECTION },
   play: async ({ canvasElement }) => {
+    emitToRoom('storybook', { type: 'connected', mapProjection: GAUSSIAN_PROJECTION, connectedUserIds: [], roomAnchors: null });
     const canvas = within(canvasElement);
     await expect(canvas.getByText(/UMAP/)).toBeInTheDocument();
   },

--- a/stories/MoodTonesPanel.stories.tsx
+++ b/stories/MoodTonesPanel.stories.tsx
@@ -48,8 +48,9 @@ export const OscillatingAudienceMood: Story = {
       const t = tick++ / 20; // ~0-1 over 5 seconds at 250ms
       USERS.forEach((userId, i) => {
         const phase = (i / USERS.length) * Math.PI * 2;
-        const x = 0.5 + 0.4 * Math.sin(t * Math.PI * 2 + phase);
-        const y = 0.5 + 0.2 * Math.cos(t * Math.PI * 2 + phase);
+        // Coordinates in 0-100 scale (computeRegion/cursorMoodValue divide by 100 internally)
+        const x = 50 + 40 * Math.sin(t * Math.PI * 2 + phase);
+        const y = 50 + 20 * Math.cos(t * Math.PI * 2 + phase);
         emitToRoom('storybook', { type: 'move', position: { userId, x, y } });
       });
       if (tick % 4 === 0) {

--- a/stories/MoodTonesPanel.stories.tsx
+++ b/stories/MoodTonesPanel.stories.tsx
@@ -3,6 +3,7 @@ import { expect, within } from 'storybook/test';
 import React from 'react';
 import MoodTonesPanel from '../app/components/panels/MoodTonesPanel';
 import { PanelContextProvider } from '../app/context/PanelContext';
+import { emitToRoom } from '../.storybook/mocks/partysocket-react';
 
 const meta = {
   title: 'Panels/MoodTonesPanel',
@@ -33,5 +34,34 @@ export const Default: Story = {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('mood tones')).toBeInTheDocument();
     await expect(canvas.getByText('sad → happy')).toBeInTheDocument();
+  },
+};
+
+export const OscillatingAudienceMood: Story = {
+  name: 'Oscillating Audience Mood',
+  play: async () => {
+    // Emit a few fake cursors moving in a slow sine wave across the canvas.
+    // audienceSync is on by default so the mood slider follows the aggregate position.
+    let tick = 0;
+    const USERS = ['ghost-1', 'ghost-2', 'ghost-3'];
+    const interval = setInterval(() => {
+      const t = tick++ / 20; // ~0-1 over 5 seconds at 250ms
+      USERS.forEach((userId, i) => {
+        const phase = (i / USERS.length) * Math.PI * 2;
+        const x = 0.5 + 0.4 * Math.sin(t * Math.PI * 2 + phase);
+        const y = 0.5 + 0.2 * Math.cos(t * Math.PI * 2 + phase);
+        emitToRoom('storybook', { type: 'move', position: { userId, x, y } });
+      });
+      if (tick % 4 === 0) {
+        emitToRoom('storybook', { type: 'presenceCount', count: USERS.length });
+      }
+    }, 250);
+
+    // Run for 10 seconds then clean up
+    await new Promise(resolve => setTimeout(resolve, 10000));
+    clearInterval(interval);
+    USERS.forEach(userId =>
+      emitToRoom('storybook', { type: 'remove', position: { userId, x: 0, y: 0 } })
+    );
   },
 };

--- a/stories/MoodTonesPanel.stories.tsx
+++ b/stories/MoodTonesPanel.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, within } from 'storybook/test';
-import React from 'react';
+import React, { useEffect } from 'react';
 import MoodTonesPanel from '../app/components/panels/MoodTonesPanel';
 import { PanelContextProvider } from '../app/context/PanelContext';
 import { emitToRoom } from '../.storybook/mocks/partysocket-react';
@@ -37,33 +37,35 @@ export const Default: Story = {
   },
 };
 
+function OscillatingMoodDriver({ room }: { room: string }) {
+  useEffect(() => {
+    const CYCLE = 5000;
+    emitToRoom(room, { type: 'presenceCount', count: 1 });
+    const start = performance.now();
+    let frameId: number;
+    const frame = (now: number) => {
+      const t = (now - start) / CYCLE;
+      // Coordinates in 0-100 scale (computeRegion/cursorMoodValue divide by 100 internally)
+      const x = 50 + 45 * Math.sin(t * Math.PI * 2);
+      const y = 50 + 40 * Math.cos(t * Math.PI * 2);
+      emitToRoom(room, { type: 'move', position: { userId: 'ghost-1', x, y } });
+      frameId = requestAnimationFrame(frame);
+    };
+    frameId = requestAnimationFrame(frame);
+    return () => {
+      cancelAnimationFrame(frameId);
+      emitToRoom(room, { type: 'remove', position: { userId: 'ghost-1', x: 0, y: 0 } });
+    };
+  }, [room]);
+  return null;
+}
+
 export const OscillatingAudienceMood: Story = {
   name: 'Oscillating Audience Mood',
-  play: async () => {
-    // Single cursor sweeps across the canvas in a wide ellipse.
-    // Using one cursor avoids the phase-cancellation problem: with N equally-spaced
-    // phases, cursorMoodValue's linearity makes the average always equal cursorMoodValue(50,50).
-    // audienceSync is on by default so the mood slider follows the cursor.
-    emitToRoom('storybook', { type: 'presenceCount', count: 1 });
-    const DURATION = 10000;
-    const CYCLE = 5000; // one full mood cycle in ms
-    const start = performance.now();
-    await new Promise<void>(resolve => {
-      const frame = (now: number) => {
-        const elapsed = now - start;
-        if (elapsed >= DURATION) {
-          emitToRoom('storybook', { type: 'remove', position: { userId: 'ghost-1', x: 0, y: 0 } });
-          resolve();
-          return;
-        }
-        const t = elapsed / CYCLE;
-        // Coordinates in 0-100 scale (computeRegion/cursorMoodValue divide by 100 internally)
-        const x = 50 + 45 * Math.sin(t * Math.PI * 2);
-        const y = 50 + 40 * Math.cos(t * Math.PI * 2);
-        emitToRoom('storybook', { type: 'move', position: { userId: 'ghost-1', x, y } });
-        requestAnimationFrame(frame);
-      };
-      requestAnimationFrame(frame);
-    });
-  },
+  render: (args) => (
+    <>
+      <OscillatingMoodDriver room={(args as any).room ?? 'storybook'} />
+      <MoodTonesPanel />
+    </>
+  ),
 };

--- a/stories/MoodTonesPanel.stories.tsx
+++ b/stories/MoodTonesPanel.stories.tsx
@@ -45,18 +45,25 @@ export const OscillatingAudienceMood: Story = {
     // phases, cursorMoodValue's linearity makes the average always equal cursorMoodValue(50,50).
     // audienceSync is on by default so the mood slider follows the cursor.
     emitToRoom('storybook', { type: 'presenceCount', count: 1 });
-    let tick = 0;
-    const interval = setInterval(() => {
-      const t = tick++ / 20; // completes one cycle per 5 seconds at 250ms
-      // Coordinates in 0-100 scale (computeRegion/cursorMoodValue divide by 100 internally)
-      const x = 50 + 45 * Math.sin(t * Math.PI * 2);
-      const y = 50 + 40 * Math.cos(t * Math.PI * 2);
-      emitToRoom('storybook', { type: 'move', position: { userId: 'ghost-1', x, y } });
-    }, 250);
-
-    // Run for 10 seconds then clean up
-    await new Promise(resolve => setTimeout(resolve, 10000));
-    clearInterval(interval);
-    emitToRoom('storybook', { type: 'remove', position: { userId: 'ghost-1', x: 0, y: 0 } });
+    const DURATION = 10000;
+    const CYCLE = 5000; // one full mood cycle in ms
+    const start = performance.now();
+    await new Promise<void>(resolve => {
+      const frame = (now: number) => {
+        const elapsed = now - start;
+        if (elapsed >= DURATION) {
+          emitToRoom('storybook', { type: 'remove', position: { userId: 'ghost-1', x: 0, y: 0 } });
+          resolve();
+          return;
+        }
+        const t = elapsed / CYCLE;
+        // Coordinates in 0-100 scale (computeRegion/cursorMoodValue divide by 100 internally)
+        const x = 50 + 45 * Math.sin(t * Math.PI * 2);
+        const y = 50 + 40 * Math.cos(t * Math.PI * 2);
+        emitToRoom('storybook', { type: 'move', position: { userId: 'ghost-1', x, y } });
+        requestAnimationFrame(frame);
+      };
+      requestAnimationFrame(frame);
+    });
   },
 };

--- a/stories/MoodTonesPanel.stories.tsx
+++ b/stories/MoodTonesPanel.stories.tsx
@@ -40,29 +40,23 @@ export const Default: Story = {
 export const OscillatingAudienceMood: Story = {
   name: 'Oscillating Audience Mood',
   play: async () => {
-    // Emit a few fake cursors moving in a slow sine wave across the canvas.
-    // audienceSync is on by default so the mood slider follows the aggregate position.
+    // Single cursor sweeps across the canvas in a wide ellipse.
+    // Using one cursor avoids the phase-cancellation problem: with N equally-spaced
+    // phases, cursorMoodValue's linearity makes the average always equal cursorMoodValue(50,50).
+    // audienceSync is on by default so the mood slider follows the cursor.
+    emitToRoom('storybook', { type: 'presenceCount', count: 1 });
     let tick = 0;
-    const USERS = ['ghost-1', 'ghost-2', 'ghost-3'];
     const interval = setInterval(() => {
-      const t = tick++ / 20; // ~0-1 over 5 seconds at 250ms
-      USERS.forEach((userId, i) => {
-        const phase = (i / USERS.length) * Math.PI * 2;
-        // Coordinates in 0-100 scale (computeRegion/cursorMoodValue divide by 100 internally)
-        const x = 50 + 40 * Math.sin(t * Math.PI * 2 + phase);
-        const y = 50 + 20 * Math.cos(t * Math.PI * 2 + phase);
-        emitToRoom('storybook', { type: 'move', position: { userId, x, y } });
-      });
-      if (tick % 4 === 0) {
-        emitToRoom('storybook', { type: 'presenceCount', count: USERS.length });
-      }
+      const t = tick++ / 20; // completes one cycle per 5 seconds at 250ms
+      // Coordinates in 0-100 scale (computeRegion/cursorMoodValue divide by 100 internally)
+      const x = 50 + 45 * Math.sin(t * Math.PI * 2);
+      const y = 50 + 40 * Math.cos(t * Math.PI * 2);
+      emitToRoom('storybook', { type: 'move', position: { userId: 'ghost-1', x, y } });
     }, 250);
 
     // Run for 10 seconds then clean up
     await new Promise(resolve => setTimeout(resolve, 10000));
     clearInterval(interval);
-    USERS.forEach(userId =>
-      emitToRoom('storybook', { type: 'remove', position: { userId, x: 0, y: 0 } })
-    );
+    emitToRoom('storybook', { type: 'remove', position: { userId: 'ghost-1', x: 0, y: 0 } });
   },
 };


### PR DESCRIPTION
## Summary

- Adds a shared message bus (`.storybook/mocks/socketMessageBus.ts`) so Storybook stories can push fake socket messages into components via `emitToRoom(room, data)`
- Upgrades the `partysocket/react` mock to subscribe each component's `onMessage` to the bus, and call `onOpen` on mount so components see a connected socket
- Migrates `MoodTonesPanel` from a hand-rolled `WebSocket` + reconnect loop to `usePartySocket`, matching all other panels and making it mockable
- Removes `MapViewerPanel`'s `initialProjection` prop (a Storybook-only hack with a TODO comment pointing at this issue) — its story now seeds state via `emitToRoom`
- Adds an `OscillatingAudienceMood` story for `MoodTonesPanel` that runs a continuous rAF loop driving a single fake cursor around an ellipse, making the mood slider animate smoothly — no `play` function, no Interactions tab entry

Closes #123

## Test plan

- [ ] Open Storybook → `Panels/MoodTonesPanel` → `Oscillating Audience Mood`: slider should animate continuously and smoothly without starting audio
- [ ] Open Storybook → `Panels/MapViewerPanel` → `With Gaussian Blob`: scatter plot should render (no `initialProjection` prop needed)
- [ ] `pnpm vitest` passes
- [ ] `pnpm tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~150 words of PR description from ~120 words of human prompts across this session)