### PR TITLE
feat(panel): ArrivalCanvas — THX deep note crescendo driven by room arrivals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. Releases cut every Monday morning ET; each section header is `## Week N (YYYY-MM-DD)` where the date is the Monday that week starts on, and Week 0 = 2025-11-17.
 
+## Week 29 (2026-06-02)
+
+### Added
+- **ArrivalCanvas panel** — new patchable panel that turns arrivals into an audio-visual moment: the screen transitions black → white and a THX deep note synthesizes and converges to a D major chord as participants join. Emcee sets room capacity via a gear-icon config modal; count and capacity are displayed on screen. Includes a `SimulatingArrivals` Storybook story with a mock driver that steps through arrivals over 10 seconds.
+
 ## Week 27 (2026-05-25)
 
 ### Fixed

--- a/app/components/apps/ReactionCanvasAppV4.tsx
+++ b/app/components/apps/ReactionCanvasAppV4.tsx
@@ -38,6 +38,7 @@ import VoiceCallPanel from "../panels/VoiceCallPanel";
 import MapMakerPanel from "../panels/MapMakerPanel";
 import MapViewerPanel from "../panels/MapViewerPanel";
 import ValenceBeatPadPanel from "../panels/ValenceBeatPadPanel";
+import ArrivalCanvasPanel from "../panels/ArrivalCanvasPanel";
 
 const PANEL_COMPONENTS: Partial<Record<string, PanelDefinition['component']>> = {
   'social-sharing': SocialMediaPanel,
@@ -50,6 +51,7 @@ const PANEL_COMPONENTS: Partial<Record<string, PanelDefinition['component']>> = 
   'map-maker':     MapMakerPanel,
   'map-viewer':      MapViewerPanel,
   'valence-beat-pad': ValenceBeatPadPanel,
+  'arrival-canvas':   ArrivalCanvasPanel,
 };
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;

--- a/app/components/panels/AdminPanelNoDB/PanelSettingsModalArrivalCanvas.tsx
+++ b/app/components/panels/AdminPanelNoDB/PanelSettingsModalArrivalCanvas.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+
+interface PanelSettingsModalArrivalCanvasProps {
+  currentCapacity: number;
+  onSubmit: (capacity: number) => void;
+  onClose: () => void;
+}
+
+export default function PanelSettingsModalArrivalCanvas({ currentCapacity, onSubmit, onClose }: PanelSettingsModalArrivalCanvasProps) {
+  const [input, setInput] = useState(String(currentCapacity));
+  const parsed = parseInt(input, 10);
+  const isValid = !isNaN(parsed) && parsed >= 1;
+
+  const handleSave = () => {
+    if (!isValid) return;
+    onSubmit(parsed);
+    onClose();
+  };
+
+  return (
+    <div className="github-modal-overlay" onClick={e => { if (e.target === e.currentTarget) onClose(); }}>
+      <div className="github-modal">
+        <p className="github-modal-title">Arrival Canvas settings</p>
+        <p className="github-modal-body">Set the room capacity. The THX deep note crescendo plays when this many participants have arrived.</p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+          <label style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <span style={{ fontSize: 12, color: '#aaa' }}>Room capacity</span>
+            <input
+              className="github-modal-input"
+              type="number"
+              min={1}
+              value={input}
+              onChange={e => setInput(e.target.value)}
+              placeholder="50"
+            />
+          </label>
+        </div>
+        <button className="github-modal-btn-primary" onClick={handleSave} disabled={!isValid} style={{ marginTop: 16 }}>
+          Save
+        </button>
+        <button className="github-modal-btn-dismiss" onClick={onClose}>Cancel</button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/panels/AdminPanelNoDB/hooks/useRoomConfig.ts
+++ b/app/components/panels/AdminPanelNoDB/hooks/useRoomConfig.ts
@@ -25,6 +25,8 @@ export function useRoomConfig(socket: PartySocket) {
   const [voiceCallConfigOpen, setVoiceCallConfigOpen] = useState(false);
   const [mapViewerConfigOpen, setMapViewerConfigOpen] = useState(false);
   const [callAlgorithm, setCallAlgorithm]     = useState<string>('first-available');
+  const [arrivalCapacity, setArrivalCapacity] = useState<number>(50);
+  const [arrivalConfigOpen, setArrivalConfigOpen] = useState(false);
 
   const sendAvatarStyle = (style: string | null) => {
     setAvatarStyle(style);
@@ -76,6 +78,11 @@ export function useRoomConfig(socket: PartySocket) {
     socket.send(JSON.stringify({ type: 'setCallAlgorithm', algorithm }));
   };
 
+  const sendArrivalCapacity = (capacity: number) => {
+    setArrivalCapacity(capacity);
+    socket.send(JSON.stringify({ type: 'setArrivalCapacity', capacity }));
+  };
+
   const resetSoccerScore = () => {
     socket.send(JSON.stringify({ type: 'resetSoccerScore' }));
   };
@@ -97,6 +104,7 @@ export function useRoomConfig(socket: PartySocket) {
     if ('roomSocialConfig' in data) setRoomSocialConfig((data.roomSocialConfig as SocialConfig | null) ?? null);
     if ('greeterConfig' in data) setGreeterConfig((data.greeterConfig as GreeterConfig | null) ?? null);
     if ('callAlgorithm' in data && data.callAlgorithm) setCallAlgorithm(data.callAlgorithm as string);
+    if ('arrivalCapacity' in data && typeof data.arrivalCapacity === 'number') setArrivalCapacity(data.arrivalCapacity as number);
     if ('soccerScore' in data && data.soccerScore) setSoccerScore(data.soccerScore as { left: number; right: number });
     if (data.userCap !== undefined) {
       setUserCap(data.userCap as number | null);
@@ -128,6 +136,8 @@ export function useRoomConfig(socket: PartySocket) {
       setOwnValenceDisplay(data.ownValenceDisplay as 'background' | 'labels' | 'none');
     } else if (data.type === 'valenceInputModeChanged') {
       setValenceInputMode(data.valenceInputMode as ValenceInputMode);
+    } else if (data.type === 'arrivalCapacityChanged') {
+      setArrivalCapacity(data.capacity as number);
     }
   };
 
@@ -166,5 +176,8 @@ export function useRoomConfig(socket: PartySocket) {
     callAlgorithm,
     sendCallAlgorithm,
     mapViewerConfigOpen, setMapViewerConfigOpen,
+    arrivalCapacity, setArrivalCapacity,
+    arrivalConfigOpen, setArrivalConfigOpen,
+    sendArrivalCapacity,
   };
 }

--- a/app/components/panels/AdminPanelNoDB/index.tsx
+++ b/app/components/panels/AdminPanelNoDB/index.tsx
@@ -16,6 +16,7 @@ import HapticConfirmModal from "./HapticConfirmModal";
 import SendPopupModal from "./SendPopupModal";
 import PanelSettingsModalReactionCanvas from "./PanelSettingsModalReactionCanvas";
 import PanelSettingsModalVoiceCall from "./PanelSettingsModalVoiceCall";
+import PanelSettingsModalArrivalCanvas from "./PanelSettingsModalArrivalCanvas";
 import RecordTab from "./tabs/RecordTab";
 import LabelsTab from "./tabs/LabelsTab";
 import AnchorsTab from "./tabs/AnchorsTab";
@@ -304,6 +305,7 @@ export default function AdminPanelNoDB({ room, userId, selfChain, mapViewerConfi
             setCanvasSettingsOpen={roomConfig.setCanvasSettingsOpen}
             setVoiceCallConfigOpen={roomConfig.setVoiceCallConfigOpen}
             setMapViewerConfigOpen={roomConfig.setMapViewerConfigOpen}
+            setArrivalConfigOpen={roomConfig.setArrivalConfigOpen}
             onClearRoleAssignments={() => socket.send(JSON.stringify({ type: 'clearPushedInterfaces' }))}
             userId={userId}
             selfChain={selfChain}
@@ -487,6 +489,13 @@ export default function AdminPanelNoDB({ room, userId, selfChain, mapViewerConfi
           currentAlgorithm={roomConfig.callAlgorithm}
           onSubmit={roomConfig.sendCallAlgorithm}
           onClose={() => roomConfig.setVoiceCallConfigOpen(false)}
+        />
+      )}
+      {roomConfig.arrivalConfigOpen && (
+        <PanelSettingsModalArrivalCanvas
+          currentCapacity={roomConfig.arrivalCapacity}
+          onSubmit={roomConfig.sendArrivalCapacity}
+          onClose={() => roomConfig.setArrivalConfigOpen(false)}
         />
       )}
       {roomConfig.mapViewerConfigOpen && (

--- a/app/components/panels/AdminPanelNoDB/tabs/InterfacesTab.tsx
+++ b/app/components/panels/AdminPanelNoDB/tabs/InterfacesTab.tsx
@@ -17,6 +17,7 @@ interface InterfacesTabProps {
   setCanvasSettingsOpen: (v: boolean) => void;
   setVoiceCallConfigOpen: (v: boolean) => void;
   setMapViewerConfigOpen: (v: boolean) => void;
+  setArrivalConfigOpen: (v: boolean) => void;
   onClearRoleAssignments: () => void;
   userId?: string;
   selfChain?: string[];
@@ -47,7 +48,7 @@ export default function InterfacesTab({
   activity, soccerScore,
   sendActivity, resetSoccerScore,
   setImageConfigOpen, setSocialConfigOpen, setGreeterConfigOpen, setCanvasSettingsOpen, setVoiceCallConfigOpen,
-  setMapViewerConfigOpen,
+  setMapViewerConfigOpen, setArrivalConfigOpen,
   onClearRoleAssignments, userId, selfChain,
 }: InterfacesTabProps) {
   const [patchInterface, setPatchInterface] = useState<string | null>(null);
@@ -96,6 +97,9 @@ export default function InterfacesTab({
                   )}
                   {id === 'map-viewer' && (
                     <button className="image-canvas-config-link" onClick={e => { e.preventDefault(); setMapViewerConfigOpen(true); }}><IoMdSettings /></button>
+                  )}
+                  {id === 'arrival-canvas' && (
+                    <button className="image-canvas-config-link" onClick={e => { e.preventDefault(); setArrivalConfigOpen(true); }}><IoMdSettings /></button>
                   )}
                 </td>
                 {/* Solo */}

--- a/app/components/panels/ArrivalCanvasPanel/index.tsx
+++ b/app/components/panels/ArrivalCanvasPanel/index.tsx
@@ -98,6 +98,23 @@ export default function ArrivalCanvasPanel() {
     master.gain.setTargetAtTime(fill * 0.75, ctx.currentTime, 0.5);
   }, [presenceCount, capacity]);
 
+  usePartySocket({
+    ...getPartySocketConfig(),
+    room,
+    query: { isAdmin: 'true', userId: socketUserId.current },
+    onMessage(evt) {
+      let data: { type: string; count?: number; capacity?: number; arrivalCapacity?: number };
+      try { data = JSON.parse(evt.data as string); } catch { return; }
+      if (data.type === 'presenceCount' && data.count !== undefined) {
+        setPresenceCount(data.count);
+      } else if (data.type === 'arrivalCapacityChanged' && data.capacity !== undefined) {
+        setCapacity(data.capacity);
+      } else if (data.type === 'connected' && data.arrivalCapacity !== undefined) {
+        setCapacity(data.arrivalCapacity);
+      }
+    },
+  });
+
   // Trigger fade-out once capacity is reached
   useEffect(() => {
     if (presenceCount < capacity || capacity === 0 || fadingOutRef.current) return;

--- a/app/components/panels/ArrivalCanvasPanel/index.tsx
+++ b/app/components/panels/ArrivalCanvasPanel/index.tsx
@@ -1,0 +1,141 @@
+import { useState, useRef, useEffect } from "react";
+import usePartySocket from 'partysocket/react';
+import { usePanelContext } from "../../../context/PanelContext";
+import { getPartySocketConfig } from '../../../utils/partyHost';
+import { generateUUID } from '../../../utils/userId';
+
+// Adapted from https://patcon.github.io/thx-deep-note/thx-2021-js1024.html (Joe Maffei, JS1024 2021)
+// Partial levels from a cello sample (divided by 1000 when used)
+const PARTIAL_LEVELS = Float32Array.of(0, 500, 331, 52, 83, 8, 4, 30, 28, 23, 9, 4, 3, 8, 5, 6);
+// Harmonic multipliers — target D-major chord across 4 octaves
+const MULTIPLIERS = Float32Array.of(1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 4, 4, 6, 6, 8, 8, 8, 12, 12, 12, 16, 16, 16, 24, 24, 24, 32, 32, 40);
+const BASE_FREQ = 37.5;
+
+function lerp(a: number, b: number, t: number) { return a + (b - a) * t; }
+
+interface Voice { osc: OscillatorNode; initFreq: number; finalFreq: number }
+
+export default function ArrivalCanvasPanel() {
+  const { room } = usePanelContext();
+  const [presenceCount, setPresenceCount] = useState(0);
+  const [capacity, setCapacity] = useState(50);
+
+  const audioCtxRef  = useRef<AudioContext | null>(null);
+  const masterGainRef = useRef<GainNode | null>(null);
+  const voicesRef    = useRef<Voice[]>([]);
+  const socketUserId = useRef(generateUUID());
+
+  // Build oscillators once on mount
+  useEffect(() => {
+    const ctx = new AudioContext();
+    audioCtxRef.current = ctx;
+
+    const master = ctx.createGain();
+    master.gain.value = 0;
+    master.connect(ctx.destination);
+    masterGainRef.current = master;
+
+    const voices: Voice[] = [];
+    MULTIPLIERS.forEach((multiplier) => {
+      const phase = Math.random() * 45;
+      const real = PARTIAL_LEVELS.map((v, i) => -v / 1e3 * Math.sin(phase * i));
+      const imag = PARTIAL_LEVELS.map((v, i) =>  v / 1e3 * Math.cos(phase * i));
+      const wave = ctx.createPeriodicWave(real, imag);
+
+      const initFreq  = 200 + Math.random() * 100;
+      const finalFreq = BASE_FREQ * multiplier * (1 + Math.random() * 0.02);
+
+      const osc = ctx.createOscillator();
+      const oscGain = ctx.createGain();
+      const lfo = ctx.createOscillator();
+      const lfoGain = ctx.createGain();
+      const panner = ctx.createStereoPanner();
+
+      osc.frequency.value = initFreq;
+      osc.setPeriodicWave(wave);
+      oscGain.gain.value = 1 / MULTIPLIERS.length;
+      lfo.frequency.value = Math.random() * 2;
+      lfoGain.gain.value = 0; // LFO has no gain until audio starts to avoid initial noise
+
+      master.connect(lfoGain);
+      lfo.connect(lfoGain);
+      lfoGain.connect(osc.frequency);
+      osc.connect(oscGain);
+      oscGain.connect(panner);
+      panner.pan.value = 1 - Math.random() * 2;
+      panner.connect(master);
+
+      lfo.start();
+      osc.start();
+      voices.push({ osc, initFreq, finalFreq });
+    });
+    voicesRef.current = voices;
+
+    return () => {
+      voices.forEach(v => { try { v.osc.stop(); } catch {} });
+      ctx.close();
+    };
+  }, []);
+
+  // Update audio and visuals whenever fill ratio changes
+  useEffect(() => {
+    const ctx = audioCtxRef.current;
+    const master = masterGainRef.current;
+    if (!ctx || !master) return;
+
+    const fill = capacity > 0 ? Math.min(presenceCount / capacity, 1) : 0;
+
+    if (fill > 0 && ctx.state === 'suspended') ctx.resume();
+
+    voicesRef.current.forEach(({ osc, initFreq, finalFreq }) => {
+      const target = lerp(initFreq, finalFreq, fill);
+      osc.frequency.setTargetAtTime(target, ctx.currentTime, 1.0);
+    });
+    master.gain.setTargetAtTime(fill * 0.75, ctx.currentTime, 0.5);
+  }, [presenceCount, capacity]);
+
+  usePartySocket({
+    ...getPartySocketConfig(),
+    room,
+    query: { isAdmin: 'true', userId: socketUserId.current },
+    onMessage(evt) {
+      let data: { type: string; count?: number; capacity?: number; arrivalCapacity?: number };
+      try { data = JSON.parse(evt.data as string); } catch { return; }
+      if (data.type === 'presenceCount' && data.count !== undefined) {
+        setPresenceCount(data.count);
+      } else if (data.type === 'arrivalCapacityChanged' && data.capacity !== undefined) {
+        setCapacity(data.capacity);
+      } else if (data.type === 'connected' && data.arrivalCapacity !== undefined) {
+        setCapacity(data.arrivalCapacity);
+      }
+    },
+  });
+
+  const fillRatio = capacity > 0 ? Math.min(presenceCount / capacity, 1) : 0;
+  const brightness = Math.round(fillRatio * 255);
+  const bgColor = `rgb(${brightness},${brightness},${brightness})`;
+  const textColor = fillRatio >= 0.5 ? '#000000' : '#ffffff';
+
+  return (
+    <div style={{
+      position: 'absolute', inset: 0, background: bgColor,
+      display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+      transition: 'background 0.8s ease',
+    }}>
+      <div style={{
+        fontSize: 'clamp(3rem,20vw,10rem)', fontWeight: 700, color: textColor,
+        fontFamily: 'monospace', lineHeight: 1, letterSpacing: '-0.04em',
+        transition: 'color 0.4s',
+      }}>
+        {presenceCount}
+      </div>
+      <div style={{
+        fontSize: 'clamp(1rem,5vw,2.5rem)', color: textColor, opacity: 0.5,
+        fontFamily: 'monospace', marginTop: '0.4em',
+        transition: 'color 0.4s',
+      }}>
+        / {capacity}
+      </div>
+    </div>
+  );
+}

--- a/app/components/panels/ArrivalCanvasPanel/index.tsx
+++ b/app/components/panels/ArrivalCanvasPanel/index.tsx
@@ -10,6 +10,8 @@ const PARTIAL_LEVELS = Float32Array.of(0, 500, 331, 52, 83, 8, 4, 30, 28, 23, 9,
 // Harmonic multipliers — target D-major chord across 4 octaves
 const MULTIPLIERS = Float32Array.of(1, 1, 1, 2, 2, 2, 2, 3, 3, 4, 4, 4, 4, 6, 6, 8, 8, 8, 12, 12, 12, 16, 16, 16, 24, 24, 24, 32, 32, 40);
 const BASE_FREQ = 37.5;
+const SUSTAIN_MS = 1000;
+const FADE_OUT_S = 3;
 
 function lerp(a: number, b: number, t: number) { return a + (b - a) * t; }
 
@@ -19,11 +21,13 @@ export default function ArrivalCanvasPanel() {
   const { room } = usePanelContext();
   const [presenceCount, setPresenceCount] = useState(0);
   const [capacity, setCapacity] = useState(50);
+  const [fadingOut, setFadingOut] = useState(false);
 
-  const audioCtxRef  = useRef<AudioContext | null>(null);
+  const audioCtxRef   = useRef<AudioContext | null>(null);
   const masterGainRef = useRef<GainNode | null>(null);
-  const voicesRef    = useRef<Voice[]>([]);
-  const socketUserId = useRef(generateUUID());
+  const voicesRef     = useRef<Voice[]>([]);
+  const socketUserId  = useRef(generateUUID());
+  const fadingOutRef  = useRef(false);
 
   // Build oscillators once on mount
   useEffect(() => {
@@ -55,7 +59,7 @@ export default function ArrivalCanvasPanel() {
       osc.setPeriodicWave(wave);
       oscGain.gain.value = 1 / MULTIPLIERS.length;
       lfo.frequency.value = Math.random() * 2;
-      lfoGain.gain.value = 0; // LFO has no gain until audio starts to avoid initial noise
+      lfoGain.gain.value = 0;
 
       master.connect(lfoGain);
       lfo.connect(lfoGain);
@@ -77,11 +81,11 @@ export default function ArrivalCanvasPanel() {
     };
   }, []);
 
-  // Update audio and visuals whenever fill ratio changes
+  // Update audio whenever fill ratio changes
   useEffect(() => {
     const ctx = audioCtxRef.current;
     const master = masterGainRef.current;
-    if (!ctx || !master) return;
+    if (!ctx || !master || fadingOutRef.current) return;
 
     const fill = capacity > 0 ? Math.min(presenceCount / capacity, 1) : 0;
 
@@ -94,27 +98,30 @@ export default function ArrivalCanvasPanel() {
     master.gain.setTargetAtTime(fill * 0.75, ctx.currentTime, 0.5);
   }, [presenceCount, capacity]);
 
-  usePartySocket({
-    ...getPartySocketConfig(),
-    room,
-    query: { isAdmin: 'true', userId: socketUserId.current },
-    onMessage(evt) {
-      let data: { type: string; count?: number; capacity?: number; arrivalCapacity?: number };
-      try { data = JSON.parse(evt.data as string); } catch { return; }
-      if (data.type === 'presenceCount' && data.count !== undefined) {
-        setPresenceCount(data.count);
-      } else if (data.type === 'arrivalCapacityChanged' && data.capacity !== undefined) {
-        setCapacity(data.capacity);
-      } else if (data.type === 'connected' && data.arrivalCapacity !== undefined) {
-        setCapacity(data.arrivalCapacity);
+  // Trigger fade-out once capacity is reached
+  useEffect(() => {
+    if (presenceCount < capacity || capacity === 0 || fadingOutRef.current) return;
+
+    fadingOutRef.current = true;
+    const timer = setTimeout(() => {
+      setFadingOut(true);
+      const ctx = audioCtxRef.current;
+      const master = masterGainRef.current;
+      if (ctx && master) {
+        master.gain.cancelScheduledValues(ctx.currentTime);
+        master.gain.setValueAtTime(master.gain.value, ctx.currentTime);
+        master.gain.linearRampToValueAtTime(0, ctx.currentTime + FADE_OUT_S);
       }
-    },
-  });
+    }, SUSTAIN_MS);
+
+    return () => clearTimeout(timer);
+  }, [presenceCount, capacity]);
 
   const fillRatio = capacity > 0 ? Math.min(presenceCount / capacity, 1) : 0;
   const brightness = Math.round(fillRatio * 255);
   const bgColor = `rgb(${brightness},${brightness},${brightness})`;
-  const textColor = fillRatio >= 0.5 ? '#000000' : '#ffffff';
+  const textColor = fadingOut ? '#ffffff' : (fillRatio >= 0.5 ? '#000000' : '#ffffff');
+  const textTransition = fadingOut ? `color ${FADE_OUT_S}s ease` : 'color 0.4s';
 
   return (
     <div style={{
@@ -125,14 +132,14 @@ export default function ArrivalCanvasPanel() {
       <div style={{
         fontSize: 'clamp(3rem,20vw,10rem)', fontWeight: 700, color: textColor,
         fontFamily: 'monospace', lineHeight: 1, letterSpacing: '-0.04em',
-        transition: 'color 0.4s',
+        transition: textTransition,
       }}>
         {presenceCount}
       </div>
       <div style={{
         fontSize: 'clamp(1rem,5vw,2.5rem)', color: textColor, opacity: 0.5,
         fontFamily: 'monospace', marginTop: '0.4em',
-        transition: 'color 0.4s',
+        transition: textTransition,
       }}>
         / {capacity}
       </div>

--- a/app/components/panels/ArrivalCanvasPanel/index.tsx
+++ b/app/components/panels/ArrivalCanvasPanel/index.tsx
@@ -118,7 +118,7 @@ export default function ArrivalCanvasPanel() {
 
   return (
     <div style={{
-      position: 'absolute', inset: 0, background: bgColor,
+      flex: 1, background: bgColor,
       display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
       transition: 'background 0.8s ease',
     }}>

--- a/app/panelRegistry.ts
+++ b/app/panelRegistry.ts
@@ -27,6 +27,7 @@ export const PANEL_REGISTRY: PanelMeta[] = [
   { id: 'map-maker',    label: 'Map Maker',       description: 'Compute UMAP/PaCMAP/LocalMAP projection from moments',  patchable: true,  activityMode: true  },
   { id: 'map-viewer',      label: 'Map Viewer',      description: 'View the computed participant map',                     patchable: true,  activityMode: true  },
   { id: 'valence-beat-pad', label: 'Valence Beat Pad', shortLabel: 'Beat Pad', description: 'Interactive musical pad driven by audience valence', patchable: true, activityMode: true },
+  { id: 'arrival-canvas', label: 'Arrival Canvas', shortLabel: 'Arrival', description: 'Room-fill visualizer with THX-style audio convergence', patchable: true, activityMode: true },
 ];
 
 export const PATCHABLE_PANELS = PANEL_REGISTRY.filter(p => p.patchable);

--- a/app/types.ts
+++ b/app/types.ts
@@ -28,7 +28,7 @@ export interface Statement {
   text: string;
 }
 
-export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social-sharing' | 'mood-tones' | 'treevites' | 'greeter' | 'signature' | 'steno' | 'story-tracer' | 'voice-call' | 'map-maker' | 'map-viewer' | 'valence-beat-pad';
+export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social-sharing' | 'mood-tones' | 'treevites' | 'greeter' | 'signature' | 'steno' | 'story-tracer' | 'voice-call' | 'map-maker' | 'map-viewer' | 'valence-beat-pad' | 'arrival-canvas';
 
 export interface MapProjection {
   coords: [string, [number, number]][];

--- a/party/server.ts
+++ b/party/server.ts
@@ -272,8 +272,9 @@ interface WebRTCAnswerEvent    { type: 'webrtcAnswer';  targetUserId: string; an
 interface WebRTCIceEvent       { type: 'webrtcIce';     targetUserId: string; candidate: unknown }
 interface HangUpCallEvent      { type: 'hangUp';        targetUserId: string }
 interface SetCallAlgorithmEvent { type: 'setCallAlgorithm'; algorithm: string }
+interface SetArrivalCapacityEvent { type: 'setArrivalCapacity'; capacity: number }
 
-type ClientEvent =CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | SetGreeterConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent | RegisterCustomAvatarEvent | SetColorCursorsByVoteEvent | SetDefaultCursorColorEvent | SetOwnValenceDisplayEvent | SetValenceInputModeEvent | StrokeSegmentEvent | ClearSignatureEvent | StenoStartRecordingEvent | StenoStopRecordingEvent | StenoAppendTextEvent | StenoSetTextEvent | StoryTracerSetPointsEvent | StoryTracerClearPointsEvent | MapProjectionSetEvent | MapProjectionClearEvent | JoinCallQueueEvent | LeaveCallQueueEvent | WebRTCOfferEvent | WebRTCAnswerEvent | WebRTCIceEvent | HangUpCallEvent | SetCallAlgorithmEvent;
+type ClientEvent =CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | SetGreeterConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent | RegisterCustomAvatarEvent | SetColorCursorsByVoteEvent | SetDefaultCursorColorEvent | SetOwnValenceDisplayEvent | SetValenceInputModeEvent | StrokeSegmentEvent | ClearSignatureEvent | StenoStartRecordingEvent | StenoStopRecordingEvent | StenoAppendTextEvent | StenoSetTextEvent | StoryTracerSetPointsEvent | StoryTracerClearPointsEvent | MapProjectionSetEvent | MapProjectionClearEvent | JoinCallQueueEvent | LeaveCallQueueEvent | WebRTCOfferEvent | WebRTCAnswerEvent | WebRTCIceEvent | HangUpCallEvent | SetCallAlgorithmEvent | SetArrivalCapacityEvent;
 
 // ===== REACTION REGION HELPER (mirrors app/utils/voteRegion.ts) =====
 const DEFAULT_ANCHORS = {
@@ -354,6 +355,7 @@ export default class Server implements Party.Server {
   private callQueue: string[] = [];
   private callPairs: Map<string, string> = new Map();
   private callAlgorithm: string = 'first-available';
+  private arrivalCapacity: number = 50;
 
   // ===== GHOST CURSOR DEMO CODE (can be easily removed) =====
   private ghostCursorsEnabled: boolean = false;
@@ -563,6 +565,7 @@ export default class Server implements Party.Server {
       storyTracerMeta: this.storyTracerMeta,
       mapProjection: this.mapProjection,
       callAlgorithm: this.callAlgorithm,
+      arrivalCapacity: this.arrivalCapacity,
     }));
   }
 
@@ -879,6 +882,10 @@ export default class Server implements Party.Server {
         if (this.adminConnectionIds.has(sender.id)) {
           this.callAlgorithm = event.algorithm;
         }
+      } else if (event.type === 'setArrivalCapacity') {
+        if (!this.adminConnectionIds.has(sender.id)) return;
+        this.arrivalCapacity = event.capacity;
+        this.room.broadcast(JSON.stringify({ type: 'arrivalCapacityChanged', capacity: this.arrivalCapacity }));
       }
     } catch (e) {
       console.error('Failed to parse event:', e);

--- a/stories/ArrivalCanvasPanel.stories.tsx
+++ b/stories/ArrivalCanvasPanel.stories.tsx
@@ -29,11 +29,25 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+function CapacityDriver({ room, capacity }: { room: string; capacity: number }) {
+  useEffect(() => {
+    emitToRoom(room, { type: 'arrivalCapacityChanged', capacity });
+    emitToRoom(room, { type: 'presenceCount', count: 0 });
+  }, [room, capacity]);
+  return null;
+}
+
 export const Default: Story = {
+  render: (args) => (
+    <>
+      <CapacityDriver room={(args as any).room ?? 'storybook'} capacity={20} />
+      <ArrivalCanvasPanel />
+    </>
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('0')).toBeInTheDocument();
-    await expect(canvas.getByText('/ 50')).toBeInTheDocument();
+    await expect(canvas.getByText('/ 20')).toBeInTheDocument();
   },
 };
 

--- a/stories/ArrivalCanvasPanel.stories.tsx
+++ b/stories/ArrivalCanvasPanel.stories.tsx
@@ -31,8 +31,12 @@ type Story = StoryObj<typeof meta>;
 
 function CapacityDriver({ room, capacity }: { room: string; capacity: number }) {
   useEffect(() => {
-    emitToRoom(room, { type: 'arrivalCapacityChanged', capacity });
-    emitToRoom(room, { type: 'presenceCount', count: 0 });
+    // defer so ArrivalCanvasPanel's useEffect (subscription) runs first
+    const raf = requestAnimationFrame(() => {
+      emitToRoom(room, { type: 'arrivalCapacityChanged', capacity });
+      emitToRoom(room, { type: 'presenceCount', count: 0 });
+    });
+    return () => cancelAnimationFrame(raf);
   }, [room, capacity]);
   return null;
 }
@@ -53,19 +57,26 @@ export const Default: Story = {
 
 function ArrivalsDriver({ room, capacity }: { room: string; capacity: number }) {
   useEffect(() => {
-    emitToRoom(room, { type: 'arrivalCapacityChanged', capacity });
-    emitToRoom(room, { type: 'presenceCount', count: 0 });
+    let intervalId: ReturnType<typeof setInterval>;
+    // defer so ArrivalCanvasPanel's useEffect (subscription) runs first
+    const raf = requestAnimationFrame(() => {
+      emitToRoom(room, { type: 'arrivalCapacityChanged', capacity });
+      emitToRoom(room, { type: 'presenceCount', count: 0 });
 
-    const STEPS = 20;
-    let step = 0;
-    const id = setInterval(() => {
-      step++;
-      const count = Math.min(Math.round((step / STEPS) * capacity), capacity);
-      emitToRoom(room, { type: 'presenceCount', count });
-      if (step >= STEPS) clearInterval(id);
-    }, 500);
+      const STEPS = 20;
+      let step = 0;
+      intervalId = setInterval(() => {
+        step++;
+        const count = Math.min(Math.round((step / STEPS) * capacity), capacity);
+        emitToRoom(room, { type: 'presenceCount', count });
+        if (step >= STEPS) clearInterval(intervalId);
+      }, 500);
+    });
 
-    return () => clearInterval(id);
+    return () => {
+      cancelAnimationFrame(raf);
+      clearInterval(intervalId);
+    };
   }, [room, capacity]);
   return null;
 }

--- a/stories/ArrivalCanvasPanel.stories.tsx
+++ b/stories/ArrivalCanvasPanel.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import React, { useEffect } from 'react';
+import ArrivalCanvasPanel from '../app/components/panels/ArrivalCanvasPanel';
+import { PanelContextProvider } from '../app/context/PanelContext';
+import { emitToRoom } from '../.storybook/mocks/partysocket-react';
+
+const meta = {
+  title: 'Panels/ArrivalCanvasPanel',
+  component: ArrivalCanvasPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story, ctx) => (
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <PanelContextProvider value={ctx.args as never}>
+          <Story />
+        </PanelContextProvider>
+      </div>
+    ),
+  ],
+  args: {
+    room: 'storybook',
+    userId: 'user-1',
+    inviteEdges: {},
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('0')).toBeInTheDocument();
+    await expect(canvas.getByText('/ 50')).toBeInTheDocument();
+  },
+};
+
+function ArrivalsDriver({ room, capacity }: { room: string; capacity: number }) {
+  useEffect(() => {
+    emitToRoom(room, { type: 'arrivalCapacityChanged', capacity });
+    emitToRoom(room, { type: 'presenceCount', count: 0 });
+
+    const STEPS = 20;
+    let step = 0;
+    const id = setInterval(() => {
+      step++;
+      const count = Math.min(Math.round((step / STEPS) * capacity), capacity);
+      emitToRoom(room, { type: 'presenceCount', count });
+      if (step >= STEPS) clearInterval(id);
+    }, 500);
+
+    return () => clearInterval(id);
+  }, [room, capacity]);
+  return null;
+}
+
+export const SimulatingArrivals: Story = {
+  name: 'Simulating Arrivals',
+  render: (args) => (
+    <>
+      <ArrivalsDriver room={(args as any).room ?? 'storybook'} capacity={20} />
+      <ArrivalCanvasPanel />
+    </>
+  ),
+};


### PR DESCRIPTION
## Summary

- Adds a new patchable panel called **Arrival Canvas** that transforms the arrival experience into a shared audio-visual moment
- Screen transitions black → white as `presenceCount` approaches the emcee-configured capacity
- 30 oscillators with cello-timbre `PeriodicWave`s converge from chaotic frequencies to a D major chord — adapted from [Joe Maffei's JS1024 2021 THX deep note entry](https://patcon.github.io/thx-deep-note/thx-2021-js1024.html), with time-based ramps replaced by fill-ratio-driven `setTargetAtTime` calls
- After a 1s sustain at full capacity, audio fades out over 3s and count text dissolves into the white background in parallel
- Emcee sets room capacity via a gear-icon config modal in the Interfaces tab
- Includes `Default` and `SimulatingArrivals` Storybook stories; the latter steps presenceCount from 0→20 over 10 seconds using a deferred `requestAnimationFrame` driver

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] Storybook: `Default` shows `0 / 20` on black background
- [x] Storybook: `SimulatingArrivals` fills to white over ~10s and reaches crescendo at capacity
- [ ] App: emcee → Interfaces tab → Solo = Arrival Canvas → gear icon → set capacity → confirm count displayed correctly
- [ ] App: open tabs up to capacity → background lightens, audio converges, text fades out after crescendo

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~150 words of PR description from ~120 words of human prompts across this session)