### PR TITLE
feat: smooth cursor with avatar support + perf/k6 fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Copy to .env and fill in values for local dev.
+# Production secrets are set via: partykit env add VAR_NAME
+
+# Telegram bot for bat-signal notifications (optional)
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+
+# Set to true to log incoming message rate to the server console (see party/server.ts).
+# Useful for measuring real client send rates before tuning perf thresholds.
+DEBUG=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 29 (2026-06-02)
 
 ### Fixed
+- **Smooth cursor: tune damping to 0.5** — reduces trailing lag while keeping motion smooth.
 - **Smooth cursor: add black stroke for contrast** — smooth cursors now render with `stroke: #000000 / stroke-width: 2` matching actual cursors; playback cursors get the same lighter dashed stroke.
 - **Smooth cursor styling and terminology** — renames `spring*` → `smooth*` / `hideCursors` → `hideActualCursors` throughout Canvas, PerfCanvasApp, V4, V5, and `cursor.ts`; smooth cursors now render with the same color and radius as actual cursors (vote-based coloring, default color, avatar radius); actual cursors are hidden in V4 when smooth cursor is enabled.
 - **Spring cursor in main app** — `SPRING_CURSOR_ENABLED` and `SPRING_CONFIG` constants added to `app/utils/cursor.ts`; V4 canvas now uses spring smoothing by default; PerfCanvasApp slider defaults updated to match.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 29 (2026-06-02)
 
 ### Fixed
+- **Smooth cursor: add black stroke for contrast** — smooth cursors now render with `stroke: #000000 / stroke-width: 2` matching actual cursors; playback cursors get the same lighter dashed stroke.
 - **Smooth cursor styling and terminology** — renames `spring*` → `smooth*` / `hideCursors` → `hideActualCursors` throughout Canvas, PerfCanvasApp, V4, V5, and `cursor.ts`; smooth cursors now render with the same color and radius as actual cursors (vote-based coloring, default color, avatar radius); actual cursors are hidden in V4 when smooth cursor is enabled.
 - **Spring cursor in main app** — `SPRING_CURSOR_ENABLED` and `SPRING_CONFIG` constants added to `app/utils/cursor.ts`; V4 canvas now uses spring smoothing by default; PerfCanvasApp slider defaults updated to match.
 - **Add `DEBUG=true` msg-rate logging to server** — when `DEBUG=true` is set in `.env`, the server logs incoming message rate every second as both msg/s and avg ms between messages; adds `.env.example` documenting all local env vars.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 29 (2026-06-02)
 
 ### Fixed
+- **Spring cursor in main app** — `SPRING_CURSOR_ENABLED` and `SPRING_CONFIG` constants added to `app/utils/cursor.ts`; V4 canvas now uses spring smoothing by default; PerfCanvasApp slider defaults updated to match.
 - **Add `DEBUG=true` msg-rate logging to server** — when `DEBUG=true` is set in `.env`, the server logs incoming message rate every second as both msg/s and avg ms between messages; adds `.env.example` documenting all local env vars.
 - **Standardize cursor send rate to 33ms (~30fps)** — adds `CURSOR_THROTTLE_MS = 33` in `app/utils/cursor.ts` as the single source of truth; `TouchLayer` now defaults to it (was unthrottled), `PerfCanvasApp` uses it when adaptive throttle is off (was also unthrottled), adaptive throttle base slider defaults to it (was 50ms), and the k6 load test mirrors it with a comment.
 - **Perf test CI: install k6 before running** — adds `grafana/setup-k6-action@v1` step so k6 is available on the runner; previously the `run-k6-action` step failed with `spawn k6 ENOENT`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 29 (2026-06-02)
 
+### Added
+- **Smooth cursor: avatar support** — smooth cursors now render DiceBear and custom photo avatars when an avatar style is selected in the emcee Avatars tab; uses circular clip paths in the RAF loop; falls back to a plain dot when no style is set.
+
 ### Fixed
 - **Smooth cursor: tune damping to 0.5** — reduces trailing lag while keeping motion smooth.
 - **Smooth cursor: add black stroke for contrast** — smooth cursors now render with `stroke: #000000 / stroke-width: 2` matching actual cursors; playback cursors get the same lighter dashed stroke.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ### Fixed
 - **Perf test CI: install k6 before running** — adds `grafana/setup-k6-action@v1` step so k6 is available on the runner; previously the `run-k6-action` step failed with `spawn k6 ENOENT`.
+- **k6 load test: migrate from `k6/ws` to `k6/websockets`** — uses the modern global-event-loop module (browser-standard WebSocket API) which supports concurrent connections per VU; replaces socket-scoped `setInterval`/`setTimeout` with globals and tracks connection success via `onopen`/`onclose` instead of checking the response status.
 
 ### Added
 - **Perf test CI workflow** — `deploy:perf` npm script and `.github/workflows/perf-test.yml` deploy to a persistent `perf` PartyKit preview and run the k6 load test suite (200 VUs, 30s) against `wss://perf.whispering-gallery.patcon.partykit.dev/parties/perf/perf-default`; triggered manually or on a daily schedule (skipped if no commits in 24h).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 29 (2026-06-02)
 
+### Fixed
+- **k6 load test: revert from k6/websockets back to k6/ws** — `k6/websockets` global event loop runs for the entire VU lifetime so iterations never complete and the test never terminates; `k6/ws` blocks the VU inside `ws.connect()` until the socket closes, giving clean per-iteration lifecycle; socket-scoped `socket.setInterval/setTimeout` work correctly within the connect callback so there was no reason to migrate in the first place.
+
 ### Added
 - **Smooth cursor: avatar support** — smooth cursors now render DiceBear and custom photo avatars when an avatar style is selected in the emcee Avatars tab; DiceBear uses `?radius=50` for native circular rendering (no SVG clip paths); custom photos still use clip paths; falls back to a plain dot when no style is set.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 29 (2026-06-02)
 
+### Added
+- **`pnpm perf-100` script** — shorthand for `pnpm run perf --vus 100 --duration 30s`.
+
 ### Fixed
 - **k6 load test: revert from k6/websockets back to k6/ws** — `k6/websockets` global event loop runs for the entire VU lifetime so iterations never complete and the test never terminates; `k6/ws` blocks the VU inside `ws.connect()` until the socket closes, giving clean per-iteration lifecycle; socket-scoped `socket.setInterval/setTimeout` work correctly within the connect callback so there was no reason to migrate in the first place.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 29 (2026-06-02)
 
 ### Fixed
+- **Add `DEBUG=true` msg-rate logging to server** — when `DEBUG=true` is set in `.env`, the server logs incoming message rate every second as both msg/s and avg ms between messages; adds `.env.example` documenting all local env vars.
 - **Standardize cursor send rate to 33ms (~30fps)** — adds `CURSOR_THROTTLE_MS = 33` in `app/utils/cursor.ts` as the single source of truth; `TouchLayer` now defaults to it (was unthrottled), `PerfCanvasApp` uses it when adaptive throttle is off (was also unthrottled), adaptive throttle base slider defaults to it (was 50ms), and the k6 load test mirrors it with a comment.
 - **Perf test CI: install k6 before running** — adds `grafana/setup-k6-action@v1` step so k6 is available on the runner; previously the `run-k6-action` step failed with `spawn k6 ENOENT`.
 - **k6 load test: migrate from `k6/ws` to `k6/websockets`** — uses the modern global-event-loop module (browser-standard WebSocket API) which supports concurrent connections per VU; replaces socket-scoped `setInterval`/`setTimeout` with globals and tracks connection success via `onopen`/`onclose` instead of checking the response status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 29 (2026-06-02)
 
 ### Added
-- **Smooth cursor: avatar support** — smooth cursors now render DiceBear and custom photo avatars when an avatar style is selected in the emcee Avatars tab; uses circular clip paths in the RAF loop; falls back to a plain dot when no style is set.
+- **Smooth cursor: avatar support** — smooth cursors now render DiceBear and custom photo avatars when an avatar style is selected in the emcee Avatars tab; DiceBear uses `?radius=50` for native circular rendering (no SVG clip paths); custom photos still use clip paths; falls back to a plain dot when no style is set.
 
 ### Fixed
 - **Smooth cursor: tune damping to 0.5** — reduces trailing lag while keeping motion smooth.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 29 (2026-06-02)
 
 ### Fixed
+- **Smooth cursor styling and terminology** — renames `spring*` → `smooth*` / `hideCursors` → `hideActualCursors` throughout Canvas, PerfCanvasApp, V4, V5, and `cursor.ts`; smooth cursors now render with the same color and radius as actual cursors (vote-based coloring, default color, avatar radius); actual cursors are hidden in V4 when smooth cursor is enabled.
 - **Spring cursor in main app** — `SPRING_CURSOR_ENABLED` and `SPRING_CONFIG` constants added to `app/utils/cursor.ts`; V4 canvas now uses spring smoothing by default; PerfCanvasApp slider defaults updated to match.
 - **Add `DEBUG=true` msg-rate logging to server** — when `DEBUG=true` is set in `.env`, the server logs incoming message rate every second as both msg/s and avg ms between messages; adds `.env.example` documenting all local env vars.
 - **Standardize cursor send rate to 33ms (~30fps)** — adds `CURSOR_THROTTLE_MS = 33` in `app/utils/cursor.ts` as the single source of truth; `TouchLayer` now defaults to it (was unthrottled), `PerfCanvasApp` uses it when adaptive throttle is off (was also unthrottled), adaptive throttle base slider defaults to it (was 50ms), and the k6 load test mirrors it with a comment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 29 (2026-06-02)
 
 ### Fixed
+- **Standardize cursor send rate to 33ms (~30fps)** — adds `CURSOR_THROTTLE_MS = 33` in `app/utils/cursor.ts` as the single source of truth; `TouchLayer` now defaults to it (was unthrottled), `PerfCanvasApp` uses it when adaptive throttle is off (was also unthrottled), adaptive throttle base slider defaults to it (was 50ms), and the k6 load test mirrors it with a comment.
 - **Perf test CI: install k6 before running** — adds `grafana/setup-k6-action@v1` step so k6 is available on the runner; previously the `run-k6-action` step failed with `spawn k6 ENOENT`.
 - **k6 load test: migrate from `k6/ws` to `k6/websockets`** — uses the modern global-event-loop module (browser-standard WebSocket API) which supports concurrent connections per VU; replaces socket-scoped `setInterval`/`setTimeout` with globals and tracks connection success via `onopen`/`onclose` instead of checking the response status.
 

--- a/app/components/apps/PerfCanvasApp.tsx
+++ b/app/components/apps/PerfCanvasApp.tsx
@@ -2,7 +2,7 @@ import { useState, useRef } from "react";
 import Canvas from "../shared/Canvas";
 import TouchLayer from "../shared/TouchLayer";
 import { getPersistentUserId } from "../../utils/userId";
-import { CURSOR_THROTTLE_MS, SPRING_CONFIG } from "../../utils/cursor";
+import { CURSOR_THROTTLE_MS, SMOOTH_CURSOR_CONFIG } from "../../utils/cursor";
 
 const SLIDER_STYLE: React.CSSProperties = { width: 80 };
 const LABEL_STYLE: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: 'rgba(255,255,255,0.7)' };
@@ -34,14 +34,14 @@ export default function PerfCanvasApp() {
   const reactionStateRef = useRef<'positive' | 'negative' | 'neutral' | null>(null);
   const room = getRoomFromUrl();
 
-  const [springEnabled, setSpringEnabled] = useState(false);
-  const [stiffness, setStiffness] = useState(SPRING_CONFIG.stiffness);
-  const [damping, setDamping] = useState(SPRING_CONFIG.damping);
-  const [mass, setMass] = useState(SPRING_CONFIG.mass);
-  const [showActual, setShowActual] = useState(false);
-  const [showSpring, setShowSpring] = useState(true);
+  const [smoothCursorEnabled, setSmoothCursorEnabled] = useState(false);
+  const [stiffness, setStiffness] = useState(SMOOTH_CURSOR_CONFIG.stiffness);
+  const [damping, setDamping] = useState(SMOOTH_CURSOR_CONFIG.damping);
+  const [mass, setMass] = useState(SMOOTH_CURSOR_CONFIG.mass);
+  const [showActualCursor, setShowActualCursor] = useState(false);
+  const [showSmoothCursor, setShowSmoothCursor] = useState(true);
 
-  const springConfig = springEnabled ? { stiffness, damping, mass, showSpring } : undefined;
+  const smoothCursorConfig = smoothCursorEnabled ? { stiffness, damping, mass, showSmoothCursor } : undefined;
 
   const [throttleEnabled, setThrottleEnabled] = useState(false);
   const [throttleBase, setThrottleBase] = useState(CURSOR_THROTTLE_MS);
@@ -61,8 +61,8 @@ export default function PerfCanvasApp() {
         userId={userId}
         onPresenceCount={setPresenceCount}
         disableBackgroundValence
-        springConfig={springConfig}
-        hideCursors={springEnabled && !showActual}
+        cursorSmoothingConfig={smoothCursorConfig}
+        hideActualCursors={smoothCursorEnabled && !showActualCursor}
       />
       <TouchLayer
         party="perf"
@@ -89,18 +89,18 @@ export default function PerfCanvasApp() {
         fontFamily: "monospace", zIndex: 10,
       }}>
         <label style={LABEL_STYLE}>
-          <input type="checkbox" checked={springEnabled} onChange={e => setSpringEnabled(e.target.checked)} />
-          spring cursors
+          <input type="checkbox" checked={smoothCursorEnabled} onChange={e => setSmoothCursorEnabled(e.target.checked)} />
+          smooth cursors
         </label>
-        {springEnabled && (
+        {smoothCursorEnabled && (
           <>
             <label style={LABEL_STYLE}>
-              <input type="checkbox" checked={showActual} onChange={e => setShowActual(e.target.checked)} />
+              <input type="checkbox" checked={showActualCursor} onChange={e => setShowActualCursor(e.target.checked)} />
               show actual
             </label>
             <label style={LABEL_STYLE}>
-              <input type="checkbox" checked={showSpring} onChange={e => setShowSpring(e.target.checked)} />
-              show spring
+              <input type="checkbox" checked={showSmoothCursor} onChange={e => setShowSmoothCursor(e.target.checked)} />
+              show smooth
             </label>
             <label style={LABEL_STYLE}>
               stiffness

--- a/app/components/apps/PerfCanvasApp.tsx
+++ b/app/components/apps/PerfCanvasApp.tsx
@@ -2,6 +2,7 @@ import { useState, useRef } from "react";
 import Canvas from "../shared/Canvas";
 import TouchLayer from "../shared/TouchLayer";
 import { getPersistentUserId } from "../../utils/userId";
+import { CURSOR_THROTTLE_MS } from "../../utils/cursor";
 
 const SLIDER_STYLE: React.CSSProperties = { width: 80 };
 const LABEL_STYLE: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: 'rgba(255,255,255,0.7)' };
@@ -43,14 +44,14 @@ export default function PerfCanvasApp() {
   const springConfig = springEnabled ? { stiffness, damping, mass, showSpring } : undefined;
 
   const [throttleEnabled, setThrottleEnabled] = useState(false);
-  const [throttleBase, setThrottleBase] = useState(50);
+  const [throttleBase, setThrottleBase] = useState(CURSOR_THROTTLE_MS);
   const [throttleScaleStart, setThrottleScaleStart] = useState(300);
   const [throttleScaleEnd, setThrottleScaleEnd] = useState(400);
   const [throttleMax, setThrottleMax] = useState(250);
 
   const throttleMs = throttleEnabled
     ? computeThrottleMs(presenceCount, throttleBase, throttleScaleStart, throttleScaleEnd, throttleMax)
-    : 0;
+    : CURSOR_THROTTLE_MS;
 
   return (
     <div style={{ position: "relative", width: "100%", height: "100dvh", background: "#111", overflow: "hidden" }}>

--- a/app/components/apps/PerfCanvasApp.tsx
+++ b/app/components/apps/PerfCanvasApp.tsx
@@ -2,7 +2,7 @@ import { useState, useRef } from "react";
 import Canvas from "../shared/Canvas";
 import TouchLayer from "../shared/TouchLayer";
 import { getPersistentUserId } from "../../utils/userId";
-import { CURSOR_THROTTLE_MS } from "../../utils/cursor";
+import { CURSOR_THROTTLE_MS, SPRING_CONFIG } from "../../utils/cursor";
 
 const SLIDER_STYLE: React.CSSProperties = { width: 80 };
 const LABEL_STYLE: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: 'rgba(255,255,255,0.7)' };
@@ -35,9 +35,9 @@ export default function PerfCanvasApp() {
   const room = getRoomFromUrl();
 
   const [springEnabled, setSpringEnabled] = useState(false);
-  const [stiffness, setStiffness] = useState(0.12);
-  const [damping, setDamping] = useState(0.75);
-  const [mass, setMass] = useState(1);
+  const [stiffness, setStiffness] = useState(SPRING_CONFIG.stiffness);
+  const [damping, setDamping] = useState(SPRING_CONFIG.damping);
+  const [mass, setMass] = useState(SPRING_CONFIG.mass);
   const [showActual, setShowActual] = useState(false);
   const [showSpring, setShowSpring] = useState(true);
 

--- a/app/components/apps/ReactionCanvasAppV4.tsx
+++ b/app/components/apps/ReactionCanvasAppV4.tsx
@@ -39,7 +39,7 @@ import MapMakerPanel from "../panels/MapMakerPanel";
 import MapViewerPanel from "../panels/MapViewerPanel";
 import ValenceBeatPadPanel from "../panels/ValenceBeatPadPanel";
 import ArrivalCanvasPanel from "../panels/ArrivalCanvasPanel";
-import { SPRING_CURSOR_ENABLED, SPRING_CONFIG } from "../../utils/cursor";
+import { SMOOTH_CURSOR_ENABLED, SMOOTH_CURSOR_CONFIG } from "../../utils/cursor";
 
 const PANEL_COMPONENTS: Partial<Record<string, PanelDefinition['component']>> = {
   'social-sharing': SocialMediaPanel,
@@ -470,7 +470,8 @@ export default function ReactionCanvasAppV4() {
             room={room}
             userId={userId}
             colorCursorsByVote={true}
-            springConfig={SPRING_CURSOR_ENABLED ? { ...SPRING_CONFIG, showSpring: true } : undefined}
+            cursorSmoothingConfig={SMOOTH_CURSOR_ENABLED ? { ...SMOOTH_CURSOR_CONFIG, showSmoothCursor: true } : undefined}
+            hideActualCursors={SMOOTH_CURSOR_ENABLED}
             disableCursorValence={activity === 'image-canvas'}
             disableBackgroundValence={activity === 'image-canvas'}
             onOwnValenceDisplayChange={setOwnValenceDisplay}

--- a/app/components/apps/ReactionCanvasAppV4.tsx
+++ b/app/components/apps/ReactionCanvasAppV4.tsx
@@ -39,6 +39,7 @@ import MapMakerPanel from "../panels/MapMakerPanel";
 import MapViewerPanel from "../panels/MapViewerPanel";
 import ValenceBeatPadPanel from "../panels/ValenceBeatPadPanel";
 import ArrivalCanvasPanel from "../panels/ArrivalCanvasPanel";
+import { SPRING_CURSOR_ENABLED, SPRING_CONFIG } from "../../utils/cursor";
 
 const PANEL_COMPONENTS: Partial<Record<string, PanelDefinition['component']>> = {
   'social-sharing': SocialMediaPanel,
@@ -469,6 +470,7 @@ export default function ReactionCanvasAppV4() {
             room={room}
             userId={userId}
             colorCursorsByVote={true}
+            springConfig={SPRING_CURSOR_ENABLED ? { ...SPRING_CONFIG, showSpring: true } : undefined}
             disableCursorValence={activity === 'image-canvas'}
             disableBackgroundValence={activity === 'image-canvas'}
             onOwnValenceDisplayChange={setOwnValenceDisplay}

--- a/app/components/apps/ReactionCanvasAppV5.tsx
+++ b/app/components/apps/ReactionCanvasAppV5.tsx
@@ -250,7 +250,7 @@ export default function ReactionCanvasAppV5() {
           room={room}
           userId={userId}
           colorCursorsByVote={false}
-          hideCursors={true}
+          hideActualCursors={true}
           currentReactionState={canvasBackgroundReactionState}
           heightOffset={youtubeHeight}
           onRoomLabelsChange={setServerLabels}

--- a/app/components/shared/Canvas.tsx
+++ b/app/components/shared/Canvas.tsx
@@ -126,7 +126,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   const smoothCursorStateRef = useRef<Map<string, { x: number; y: number; vx: number; vy: number }>>(new Map());
   const dimensionsRef = useRef({ width: window.innerWidth, height: window.innerHeight });
 
-  const smoothCursorStyleRef = useRef<Map<string, { color: string; radius: number; stroke: string; strokeDasharray: string; avatarUrl: string | null }>>(new Map());
+  const smoothCursorStyleRef = useRef<Map<string, { color: string; radius: number; stroke: string; strokeDasharray: string; avatarUrl: string | null; needsClip: boolean }>>(new Map());
   const avatarStyleRef = useRef<string | null>(null);
   const customAvatarsRef = useRef<Record<string, string>>({});
 
@@ -200,8 +200,8 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
           const g = d3.select(this);
           const clipId = `sc-clip-${d.id.replace(/\W/g, '_')}`;
 
-          // Manage circular clip path in defs for avatar images
-          if (style.avatarUrl) {
+          // Clip path only needed for custom photos; DiceBear uses ?radius=50 instead
+          if (style.needsClip) {
             let clipPath = defs.select<SVGClipPathElement>(`#${clipId}`);
             if (clipPath.empty()) {
               clipPath = defs.append('clipPath').attr('id', clipId) as d3.Selection<SVGClipPathElement, unknown, null, undefined>;
@@ -231,7 +231,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
               .attr('y', -style.radius)
               .attr('width', avatarSize)
               .attr('height', avatarSize)
-              .attr('clip-path', `url(#${clipId})`);
+              .attr('clip-path', style.needsClip ? `url(#${clipId})` : null);
           } else {
             avatarSel.style('display', 'none');
           }
@@ -263,7 +263,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   useEffect(() => {
     const smallerDim = Math.min(dimensions.width, dimensions.height);
     const radius = avatarStyle ? smallerDim * 0.03 : smallerDim * 0.01;
-    const styleMap = new Map<string, { color: string; radius: number; stroke: string; strokeDasharray: string; avatarUrl: string | null }>();
+    const styleMap = new Map<string, { color: string; radius: number; stroke: string; strokeDasharray: string; avatarUrl: string | null; needsClip: boolean }>();
     for (const [cursorUserId, cursor] of cursors) {
       const isPlayback = cursorUserId.startsWith('replay_');
       let color: string;
@@ -286,20 +286,23 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
       const strokeDasharray = isPlayback ? `${radius * 0.8} ${radius * 0.5}` : 'none';
 
       let avatarUrl: string | null = null;
+      let needsClip = false;
       if (avatarStyle && !isPlayback) {
         const isCustomMode = avatarStyle === 'custom' || avatarStyle.startsWith('custom+');
         if (isCustomMode) {
           avatarUrl = customAvatars[cursorUserId] ?? null;
-          if (!avatarUrl) {
+          if (avatarUrl) {
+            needsClip = true; // custom photos are not self-clipping
+          } else {
             const fallbackStyle = avatarStyle !== 'custom' ? avatarStyle.slice(7) : null;
-            if (fallbackStyle) avatarUrl = `https://api.dicebear.com/9.x/${fallbackStyle}/svg?seed=${encodeURIComponent(cursorUserId)}`;
+            if (fallbackStyle) avatarUrl = `https://api.dicebear.com/9.x/${fallbackStyle}/svg?seed=${encodeURIComponent(cursorUserId)}&radius=50`;
           }
         } else {
-          avatarUrl = `https://api.dicebear.com/9.x/${avatarStyle}/svg?seed=${encodeURIComponent(cursorUserId)}`;
+          avatarUrl = `https://api.dicebear.com/9.x/${avatarStyle}/svg?seed=${encodeURIComponent(cursorUserId)}&radius=50`;
         }
       }
 
-      styleMap.set(cursorUserId, { color, radius, stroke, strokeDasharray, avatarUrl });
+      styleMap.set(cursorUserId, { color, radius, stroke, strokeDasharray, avatarUrl, needsClip });
     }
     smoothCursorStyleRef.current = styleMap;
   }, [cursors, dimensions, anchors, colorCursorsByVote, disableCursorValence, defaultCursorColor, avatarStyle, customAvatars]);
@@ -834,23 +837,12 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
           .attr('r', cursorRadius);
       });
       // Clip paths for fallback DiceBear (users without custom photos, when a base style is set)
-      if (customFallbackStyle) {
-        cursorData.filter(d => !customAvatars[d.cursorUserId]).forEach(d => {
-          defs.append('clipPath')
-            .attr('id', `avatar-clip-${d.cursorUserId}`)
-            .append('circle')
-            .attr('cx', d.x)
-            .attr('cy', d.y)
-            .attr('r', cursorRadius);
-        });
-      }
-
       const avatarSize = cursorRadius * 2;
       const noPhotoGroups = cursorGroups.filter((d: any) => !customAvatars[d.cursorUserId]);
       const photoGroups = cursorGroups.filter((d: any) => !!customAvatars[d.cursorUserId]);
 
       if (customFallbackStyle) {
-        // DiceBear fallback for unregistered users
+        // DiceBear fallback for unregistered users — ?radius=50 makes it circular natively
         noPhotoGroups.append('circle')
           .attr('cx', (d: any) => d.x)
           .attr('cy', (d: any) => d.y)
@@ -860,12 +852,11 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
           .attr('stroke-width', 1.5);
 
         noPhotoGroups.append('image')
-          .attr('href', (d: any) => `https://api.dicebear.com/9.x/${customFallbackStyle}/svg?seed=${encodeURIComponent(d.cursorUserId)}`)
+          .attr('href', (d: any) => `https://api.dicebear.com/9.x/${customFallbackStyle}/svg?seed=${encodeURIComponent(d.cursorUserId)}&radius=50`)
           .attr('x', (d: any) => d.x - cursorRadius)
           .attr('y', (d: any) => d.y - cursorRadius)
           .attr('width', avatarSize)
-          .attr('height', avatarSize)
-          .attr('clip-path', (d: any) => `url(#avatar-clip-${d.cursorUserId})`);
+          .attr('height', avatarSize);
       } else {
         // Dot fallback for unregistered users
         noPhotoGroups.append('circle')
@@ -895,17 +886,6 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
         .attr('height', avatarSize)
         .attr('clip-path', (d: any) => `url(#avatar-clip-${d.cursorUserId})`);
     } else if (avatarStyle) {
-      // Add clip paths to defs for circular avatar masking
-      const defs = svg.append('defs');
-      cursorData.forEach(d => {
-        defs.append('clipPath')
-          .attr('id', `avatar-clip-${d.cursorUserId}`)
-          .append('circle')
-          .attr('cx', d.x)
-          .attr('cy', d.y)
-          .attr('r', cursorRadius);
-      });
-
       // Colored border ring
       cursorGroups.append('circle')
         .attr('cx', d => d.x)
@@ -915,15 +895,14 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
         .attr('stroke', '#000000')
         .attr('stroke-width', 1.5);
 
-      // DiceBear avatar image clipped to circle
+      // DiceBear avatar — ?radius=50 makes it circular natively, no clip path needed
       const avatarSize = cursorRadius * 2;
       cursorGroups.append('image')
-        .attr('href', (d: any) => `https://api.dicebear.com/9.x/${avatarStyle}/svg?seed=${encodeURIComponent(d.cursorUserId)}`)
+        .attr('href', (d: any) => `https://api.dicebear.com/9.x/${avatarStyle}/svg?seed=${encodeURIComponent(d.cursorUserId)}&radius=50`)
         .attr('x', (d: any) => d.x - cursorRadius)
         .attr('y', (d: any) => d.y - cursorRadius)
         .attr('width', avatarSize)
-        .attr('height', avatarSize)
-        .attr('clip-path', (d: any) => `url(#avatar-clip-${d.cursorUserId})`);
+        .attr('height', avatarSize);
     } else {
       cursorGroups.append('circle')
         .attr('cx', d => d.x)

--- a/app/components/shared/Canvas.tsx
+++ b/app/components/shared/Canvas.tsx
@@ -120,11 +120,15 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   // Keep a ref-copy of cursors for the spring RAF loop (avoids RAF closure over stale state)
   const cursorTargetRef = useRef<Map<string, CursorPosition>>(new Map());
   useEffect(() => { cursorTargetRef.current = cursors; }, [cursors]);
+  useEffect(() => { avatarStyleRef.current = avatarStyle; }, [avatarStyle]);
+  useEffect(() => { customAvatarsRef.current = customAvatars; }, [customAvatars]);
 
   const smoothCursorStateRef = useRef<Map<string, { x: number; y: number; vx: number; vy: number }>>(new Map());
   const dimensionsRef = useRef({ width: window.innerWidth, height: window.innerHeight });
 
-  const smoothCursorStyleRef = useRef<Map<string, { color: string; radius: number; stroke: string; strokeDasharray: string }>>(new Map());
+  const smoothCursorStyleRef = useRef<Map<string, { color: string; radius: number; stroke: string; strokeDasharray: string; avatarUrl: string | null }>>(new Map());
+  const avatarStyleRef = useRef<string | null>(null);
+  const customAvatarsRef = useRef<Record<string, string>>({});
 
   // Smooth cursor RAF loop — runs only when cursorSmoothingConfig is provided
   useEffect(() => {
@@ -166,30 +170,71 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
 
       // D3 data join for enter/exit
       const layerSel = d3.select(layer);
+
+      // Ensure defs element exists for clip paths
+      let defs = layerSel.select<SVGDefsElement>('defs');
+      if (defs.empty()) defs = layerSel.insert('defs', ':first-child');
+
       const data = [...state.entries()].map(([id, s]) => ({ id, x: s.x, y: s.y }));
       const groups = layerSel
         .selectAll<SVGGElement, { id: string; x: number; y: number }>('.smooth-cursor')
         .data(data, d => d.id);
 
-      groups.enter()
+      const entered = groups.enter()
         .append('g')
-        .attr('class', 'smooth-cursor')
-        .append('circle');
+        .attr('class', 'smooth-cursor');
+      entered.append('circle');
+      entered.append('image').attr('class', 'sc-avatar').style('display', 'none');
 
-      groups.exit().remove();
+      groups.exit<{ id: string; x: number; y: number }>().each(function(d) {
+        const clipId = `sc-clip-${d.id.replace(/\W/g, '_')}`;
+        defs.select(`#${clipId}`).remove();
+      }).remove();
 
       // Update position and style for all smooth cursors
       layerSel.selectAll<SVGGElement, { id: string; x: number; y: number }>('.smooth-cursor')
         .attr('transform', d => `translate(${d.x},${d.y})`)
-        .select('circle')
         .each(function(d) {
           const style = smoothCursorStyleRef.current.get(d.id);
-          if (style) d3.select(this)
+          if (!style) return;
+          const g = d3.select(this);
+          const clipId = `sc-clip-${d.id.replace(/\W/g, '_')}`;
+
+          // Manage circular clip path in defs for avatar images
+          if (style.avatarUrl) {
+            let clipPath = defs.select<SVGClipPathElement>(`#${clipId}`);
+            if (clipPath.empty()) {
+              clipPath = defs.append('clipPath').attr('id', clipId) as d3.Selection<SVGClipPathElement, unknown, null, undefined>;
+              clipPath.append('circle');
+            }
+            clipPath.select('circle').attr('r', style.radius).attr('cx', 0).attr('cy', 0);
+          } else {
+            defs.select(`#${clipId}`).remove();
+          }
+
+          // Background/fallback circle
+          g.select('circle')
             .attr('r', style.radius)
             .attr('fill', style.color)
             .attr('stroke', style.stroke)
             .attr('stroke-width', 2)
             .attr('stroke-dasharray', style.strokeDasharray);
+
+          // Avatar image (shown only when avatarUrl is set)
+          const avatarSize = style.radius * 2;
+          const avatarSel = g.select('.sc-avatar');
+          if (style.avatarUrl) {
+            avatarSel
+              .style('display', 'block')
+              .attr('href', style.avatarUrl)
+              .attr('x', -style.radius)
+              .attr('y', -style.radius)
+              .attr('width', avatarSize)
+              .attr('height', avatarSize)
+              .attr('clip-path', `url(#${clipId})`);
+          } else {
+            avatarSel.style('display', 'none');
+          }
         });
 
       layer.style.visibility = showSmoothCursor ? 'visible' : 'hidden';
@@ -218,7 +263,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   useEffect(() => {
     const smallerDim = Math.min(dimensions.width, dimensions.height);
     const radius = avatarStyle ? smallerDim * 0.03 : smallerDim * 0.01;
-    const styleMap = new Map<string, { color: string; radius: number; stroke: string; strokeDasharray: string }>();
+    const styleMap = new Map<string, { color: string; radius: number; stroke: string; strokeDasharray: string; avatarUrl: string | null }>();
     for (const [cursorUserId, cursor] of cursors) {
       const isPlayback = cursorUserId.startsWith('replay_');
       let color: string;
@@ -239,10 +284,25 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
       }
       const stroke = isPlayback ? 'hsl(270, 70%, 80%)' : '#000000';
       const strokeDasharray = isPlayback ? `${radius * 0.8} ${radius * 0.5}` : 'none';
-      styleMap.set(cursorUserId, { color, radius, stroke, strokeDasharray });
+
+      let avatarUrl: string | null = null;
+      if (avatarStyle && !isPlayback) {
+        const isCustomMode = avatarStyle === 'custom' || avatarStyle.startsWith('custom+');
+        if (isCustomMode) {
+          avatarUrl = customAvatars[cursorUserId] ?? null;
+          if (!avatarUrl) {
+            const fallbackStyle = avatarStyle !== 'custom' ? avatarStyle.slice(7) : null;
+            if (fallbackStyle) avatarUrl = `https://api.dicebear.com/9.x/${fallbackStyle}/svg?seed=${encodeURIComponent(cursorUserId)}`;
+          }
+        } else {
+          avatarUrl = `https://api.dicebear.com/9.x/${avatarStyle}/svg?seed=${encodeURIComponent(cursorUserId)}`;
+        }
+      }
+
+      styleMap.set(cursorUserId, { color, radius, stroke, strokeDasharray, avatarUrl });
     }
     smoothCursorStyleRef.current = styleMap;
-  }, [cursors, dimensions, anchors, colorCursorsByVote, disableCursorValence, defaultCursorColor, avatarStyle]);
+  }, [cursors, dimensions, anchors, colorCursorsByVote, disableCursorValence, defaultCursorColor, avatarStyle, customAvatars]);
 
   const socket = usePartySocket({
     ...getPartySocketConfig(),

--- a/app/components/shared/Canvas.tsx
+++ b/app/components/shared/Canvas.tsx
@@ -25,7 +25,7 @@ interface CanvasProps {
   userId: string;
   readOnly?: boolean; // When true, connects as admin (excluded from presence count, no cursor sent)
   colorCursorsByVote?: boolean; // Optional prop to enable reaction-based coloring
-  hideCursors?: boolean; // When true, other users' cursors are not rendered (labels/anchors still sync)
+  hideActualCursors?: boolean; // When true, raw cursor dots are not rendered (labels/anchors still sync; use when smooth cursors replace them)
   currentReactionState?: ReactionState; // Current reaction state for background color
   heightOffset?: number; // Pixels to subtract from window.innerHeight (default: statement panel height)
   onPresenceCount?: (count: number) => void;
@@ -63,14 +63,14 @@ interface CanvasProps {
   onUserJoined?: (userId: string) => void;
   onUserLeft?: (userId: string) => void;
   party?: string;
-  springConfig?: SpringConfig;
+  cursorSmoothingConfig?: CursorSmoothingConfig;
 }
 
-interface SpringConfig {
+interface CursorSmoothingConfig {
   stiffness: number;
   damping: number;
   mass: number;
-  showSpring: boolean;
+  showSmoothCursor: boolean;
 }
 
 // Clip an infinite line (defined by two points) to the rectangle [0,w]×[0,h].
@@ -94,9 +94,9 @@ function clipLineToRect(
   return [px + tMin * dx, py + tMin * dy, px + tMax * dx, py + tMax * dy];
 }
 
-export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote: colorCursorsByVoteProp = false, disableCursorValence = false, disableBackgroundValence = false, hideCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onInterfacePushed, onPushedInterfacesCleared, onHapticPushed, onRoomImageUrlChange, onActivityChange, onSocialConfigChange, onGreeterConfigChange, onConnected, onNowLabelChange, onInviteEdges, onOwnValenceDisplayChange, onValenceInputModeChange, onStrokeSegment, onSignatureCleared, onConnectedUsers, onUserJoined, onUserLeft, party = "main", debug = false, springConfig }: CanvasProps) {
+export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote: colorCursorsByVoteProp = false, disableCursorValence = false, disableBackgroundValence = false, hideActualCursors = false, currentReactionState, heightOffset, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onInterfacePushed, onPushedInterfacesCleared, onHapticPushed, onRoomImageUrlChange, onActivityChange, onSocialConfigChange, onGreeterConfigChange, onConnected, onNowLabelChange, onInviteEdges, onOwnValenceDisplayChange, onValenceInputModeChange, onStrokeSegment, onSignatureCleared, onConnectedUsers, onUserJoined, onUserLeft, party = "main", debug = false, cursorSmoothingConfig }: CanvasProps) {
   const svgRef = useRef<SVGSVGElement>(null);
-  const springLayerRef = useRef<SVGSVGElement>(null);
+  const smoothCursorLayerRef = useRef<SVGSVGElement>(null);
   const [cursors, setCursors] = useState<Map<string, CursorPosition>>(new Map());
   const [anchors, setAnchors] = useState<ReactionAnchors>(DEFAULT_ANCHORS);
   const [avatarStyle, setAvatarStyle] = useState<string | null>(null);
@@ -121,26 +121,28 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   const cursorTargetRef = useRef<Map<string, CursorPosition>>(new Map());
   useEffect(() => { cursorTargetRef.current = cursors; }, [cursors]);
 
-  const springStateRef = useRef<Map<string, { x: number; y: number; vx: number; vy: number }>>(new Map());
+  const smoothCursorStateRef = useRef<Map<string, { x: number; y: number; vx: number; vy: number }>>(new Map());
   const dimensionsRef = useRef({ width: window.innerWidth, height: window.innerHeight });
 
-  // Spring cursor RAF loop — runs only when springConfig is provided
+  const smoothCursorStyleRef = useRef<Map<string, { color: string; radius: number }>>(new Map());
+
+  // Smooth cursor RAF loop — runs only when cursorSmoothingConfig is provided
   useEffect(() => {
-    if (!springConfig) {
+    if (!cursorSmoothingConfig) {
       // Clear overlay when disabled
-      if (springLayerRef.current) d3.select(springLayerRef.current).selectAll('*').remove();
+      if (smoothCursorLayerRef.current) d3.select(smoothCursorLayerRef.current).selectAll('*').remove();
       return;
     }
     let rafId: number;
     const tick = () => {
-      const layer = springLayerRef.current;
+      const layer = smoothCursorLayerRef.current;
       if (!layer) { rafId = requestAnimationFrame(tick); return; }
 
-      const { stiffness, damping, mass, showSpring } = springConfig;
+      const { stiffness, damping, mass, showSmoothCursor } = cursorSmoothingConfig;
       const targets = cursorTargetRef.current;
-      const state = springStateRef.current;
+      const state = smoothCursorStateRef.current;
 
-      // Remove spring state for cursors that have left
+      // Remove smooth cursor state for cursors that have left
       for (const id of state.keys()) {
         if (!targets.has(id)) state.delete(id);
       }
@@ -166,32 +168,32 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
       const layerSel = d3.select(layer);
       const data = [...state.entries()].map(([id, s]) => ({ id, x: s.x, y: s.y }));
       const groups = layerSel
-        .selectAll<SVGGElement, { id: string; x: number; y: number }>('.spring-cursor')
+        .selectAll<SVGGElement, { id: string; x: number; y: number }>('.smooth-cursor')
         .data(data, d => d.id);
 
       groups.enter()
         .append('g')
-        .attr('class', 'spring-cursor')
-        .append('circle')
-        .attr('r', 10)
-        .attr('fill', 'none')
-        .attr('stroke', 'rgba(100,200,255,0.85)')
-        .attr('stroke-width', 2)
-        .attr('stroke-dasharray', '4 3');
+        .attr('class', 'smooth-cursor')
+        .append('circle');
 
       groups.exit().remove();
 
-      // Update positions for all spring cursors
-      layerSel.selectAll<SVGGElement, { id: string; x: number; y: number }>('.spring-cursor')
-        .attr('transform', d => `translate(${d.x},${d.y})`);
+      // Update position and style for all smooth cursors
+      layerSel.selectAll<SVGGElement, { id: string; x: number; y: number }>('.smooth-cursor')
+        .attr('transform', d => `translate(${d.x},${d.y})`)
+        .select('circle')
+        .each(function(d) {
+          const style = smoothCursorStyleRef.current.get(d.id);
+          if (style) d3.select(this).attr('r', style.radius).attr('fill', style.color);
+        });
 
-      layer.style.visibility = showSpring ? 'visible' : 'hidden';
+      layer.style.visibility = showSmoothCursor ? 'visible' : 'hidden';
 
       rafId = requestAnimationFrame(tick);
     };
     rafId = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(rafId);
-  }, [springConfig]);
+  }, [cursorSmoothingConfig]);
 
   useEffect(() => {
     if (!imageUrl) { setImageNaturalSize(null); return; }
@@ -206,6 +208,33 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
     height: window.innerHeight - (heightOffset ?? 140)
   });
   useEffect(() => { dimensionsRef.current = dimensions; }, [dimensions]);
+
+  // Precompute per-cursor style (color + radius) so the RAF tick can read it without closure staleness.
+  useEffect(() => {
+    const smallerDim = Math.min(dimensions.width, dimensions.height);
+    const radius = avatarStyle ? smallerDim * 0.03 : smallerDim * 0.01;
+    const styleMap = new Map<string, { color: string; radius: number }>();
+    for (const [cursorUserId, cursor] of cursors) {
+      let color: string;
+      if (cursorUserId.startsWith('replay_')) {
+        color = 'hsl(270, 70%, 65%)';
+      } else if (colorCursorsByVote && !disableCursorValence) {
+        switch (computeReactionRegion(cursor.x, cursor.y, anchors)) {
+          case 'positive': color = 'rgba(0, 255, 0, 0.8)'; break;
+          case 'negative': color = 'rgba(255, 0, 0, 0.8)'; break;
+          case 'neutral':  color = 'rgba(255, 255, 0, 0.8)'; break;
+          default:         color = 'rgba(128, 128, 128, 0.8)';
+        }
+      } else if (!colorCursorsByVote || disableCursorValence) {
+        color = defaultCursorColor;
+      } else {
+        const hue = cursorUserId.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0) % 360;
+        color = `hsl(${hue}, 70%, 50%)`;
+      }
+      styleMap.set(cursorUserId, { color, radius });
+    }
+    smoothCursorStyleRef.current = styleMap;
+  }, [cursors, dimensions, anchors, colorCursorsByVote, disableCursorValence, defaultCursorColor, avatarStyle]);
 
   const socket = usePartySocket({
     ...getPartySocketConfig(),
@@ -668,7 +697,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
     }
 
     // Add cursor positions as colored dots - convert normalized coordinates to pixels
-    if (hideCursors) return;
+    if (hideActualCursors) return;
 
     // When an image is active, map image-relative 0-100 coords to screen pixels
     let toScreenX = (n: number) => (n / 100) * dimensions.width;
@@ -849,7 +878,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
         .text((d: any) => d.cursorUserId.substring(0, 6));
     }
 
-  }, [cursors, dimensions, anchors, debug, hideCursors, avatarStyle, customAvatars, colorCursorsByVote, defaultCursorColor, ownValenceDisplay, activity, ballPos, soccerScore, imageUrl, imageNaturalSize]);
+  }, [cursors, dimensions, anchors, debug, hideActualCursors, avatarStyle, customAvatars, colorCursorsByVote, defaultCursorColor, ownValenceDisplay, activity, ballPos, soccerScore, imageUrl, imageNaturalSize]);
 
   // Handle window resize
   useEffect(() => {
@@ -884,7 +913,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
         }}
       />
       <svg
-        ref={springLayerRef}
+        ref={smoothCursorLayerRef}
         style={{
           position: 'absolute',
           inset: 0,

--- a/app/components/shared/Canvas.tsx
+++ b/app/components/shared/Canvas.tsx
@@ -124,7 +124,7 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   const smoothCursorStateRef = useRef<Map<string, { x: number; y: number; vx: number; vy: number }>>(new Map());
   const dimensionsRef = useRef({ width: window.innerWidth, height: window.innerHeight });
 
-  const smoothCursorStyleRef = useRef<Map<string, { color: string; radius: number }>>(new Map());
+  const smoothCursorStyleRef = useRef<Map<string, { color: string; radius: number; stroke: string; strokeDasharray: string }>>(new Map());
 
   // Smooth cursor RAF loop — runs only when cursorSmoothingConfig is provided
   useEffect(() => {
@@ -184,7 +184,12 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
         .select('circle')
         .each(function(d) {
           const style = smoothCursorStyleRef.current.get(d.id);
-          if (style) d3.select(this).attr('r', style.radius).attr('fill', style.color);
+          if (style) d3.select(this)
+            .attr('r', style.radius)
+            .attr('fill', style.color)
+            .attr('stroke', style.stroke)
+            .attr('stroke-width', 2)
+            .attr('stroke-dasharray', style.strokeDasharray);
         });
 
       layer.style.visibility = showSmoothCursor ? 'visible' : 'hidden';
@@ -213,10 +218,11 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
   useEffect(() => {
     const smallerDim = Math.min(dimensions.width, dimensions.height);
     const radius = avatarStyle ? smallerDim * 0.03 : smallerDim * 0.01;
-    const styleMap = new Map<string, { color: string; radius: number }>();
+    const styleMap = new Map<string, { color: string; radius: number; stroke: string; strokeDasharray: string }>();
     for (const [cursorUserId, cursor] of cursors) {
+      const isPlayback = cursorUserId.startsWith('replay_');
       let color: string;
-      if (cursorUserId.startsWith('replay_')) {
+      if (isPlayback) {
         color = 'hsl(270, 70%, 65%)';
       } else if (colorCursorsByVote && !disableCursorValence) {
         switch (computeReactionRegion(cursor.x, cursor.y, anchors)) {
@@ -231,7 +237,9 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
         const hue = cursorUserId.split('').reduce((acc, char) => acc + char.charCodeAt(0), 0) % 360;
         color = `hsl(${hue}, 70%, 50%)`;
       }
-      styleMap.set(cursorUserId, { color, radius });
+      const stroke = isPlayback ? 'hsl(270, 70%, 80%)' : '#000000';
+      const strokeDasharray = isPlayback ? `${radius * 0.8} ${radius * 0.5}` : 'none';
+      styleMap.set(cursorUserId, { color, radius, stroke, strokeDasharray });
     }
     smoothCursorStyleRef.current = styleMap;
   }, [cursors, dimensions, anchors, colorCursorsByVote, disableCursorValence, defaultCursorColor, avatarStyle]);

--- a/app/components/shared/TouchLayer.tsx
+++ b/app/components/shared/TouchLayer.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useState } from "react";
 import usePartySocket from "partysocket/react";
 import { computeReactionRegion, DEFAULT_ANCHORS } from "../../utils/voteRegion";
 import { getPartySocketConfig } from "../../utils/partyHost";
+import { CURSOR_THROTTLE_MS } from "../../utils/cursor";
 import type { ReactionAnchors } from "../../utils/voteRegion";
 
 interface CursorPosition {
@@ -58,7 +59,7 @@ export default function TouchLayer({
   imageUrl,
   disabled = false,
   party = "main",
-  throttleMs = 0,
+  throttleMs = CURSOR_THROTTLE_MS,
 }: TouchLayerProps) {
   const layerRef = useRef<HTMLDivElement>(null);
   const throttleMsRef = useRef(throttleMs);

--- a/app/utils/cursor.ts
+++ b/app/utils/cursor.ts
@@ -1,0 +1,5 @@
+// ~30fps: smooth for cursor tracking, half the bandwidth of 60fps.
+// All cursor-sending surfaces (TouchLayer, PerfCanvasApp) use this as the
+// base throttle. The k6 load test mirrors this value so perf results
+// reflect real client behaviour.
+export const CURSOR_THROTTLE_MS = 0;

--- a/app/utils/cursor.ts
+++ b/app/utils/cursor.ts
@@ -4,10 +4,10 @@
 // reflect real client behaviour.
 export const CURSOR_THROTTLE_MS = 33;
 
-// Spring cursor smoothing — applied in the main app and perf app.
+// Smooth cursor config — applied in the main app and perf app.
 // Tune these values in PerfCanvasApp's debug UI, then update here.
-export const SPRING_CURSOR_ENABLED = true;
-export const SPRING_CONFIG = {
+export const SMOOTH_CURSOR_ENABLED = true;
+export const SMOOTH_CURSOR_CONFIG = {
   stiffness: 0.12,
   damping: 0.75,
   mass: 1,

--- a/app/utils/cursor.ts
+++ b/app/utils/cursor.ts
@@ -9,6 +9,6 @@ export const CURSOR_THROTTLE_MS = 33;
 export const SMOOTH_CURSOR_ENABLED = true;
 export const SMOOTH_CURSOR_CONFIG = {
   stiffness: 0.12,
-  damping: 0.75,
+  damping: 0.5,
   mass: 1,
 };

--- a/app/utils/cursor.ts
+++ b/app/utils/cursor.ts
@@ -3,3 +3,12 @@
 // base throttle. The k6 load test mirrors this value so perf results
 // reflect real client behaviour.
 export const CURSOR_THROTTLE_MS = 33;
+
+// Spring cursor smoothing — applied in the main app and perf app.
+// Tune these values in PerfCanvasApp's debug UI, then update here.
+export const SPRING_CURSOR_ENABLED = true;
+export const SPRING_CONFIG = {
+  stiffness: 0.12,
+  damping: 0.75,
+  mass: 1,
+};

--- a/app/utils/cursor.ts
+++ b/app/utils/cursor.ts
@@ -2,4 +2,4 @@
 // All cursor-sending surfaces (TouchLayer, PerfCanvasApp) use this as the
 // base throttle. The k6 load test mirrors this value so perf results
 // reflect real client behaviour.
-export const CURSOR_THROTTLE_MS = 0;
+export const CURSOR_THROTTLE_MS = 33;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "perf": "echo 'Observe at: http://localhost:1999/#perf' && k6 run perf/load-test-k6.js",
+    "perf-100": "pnpm run perf --vus 100 --duration 30s",
     "perf:remote": "echo 'Observe at: https://perf.whispering-gallery.patcon.partykit.dev/#perf' && k6 run --env WS_URL=wss://perf.whispering-gallery.patcon.partykit.dev/parties/perf/perf-default perf/load-test-k6.js"
   },
   "dependencies": {

--- a/party/server.ts
+++ b/party/server.ts
@@ -334,6 +334,8 @@ export default class Server implements Party.Server {
   private greeterConfig: { eventUrl: string } | null = null;
   private ballState = { x: 50, y: 50, vx: 2, vy: 1 };
   private soccerScore = { left: 0, right: 0 };
+  private msgCount = 0;
+  private msgRateInterval?: NodeJS.Timeout;
   private githubSubmissions: { username: string; displayName: string | null; avatarUrl: string | null; timestamp: number }[] = [];
   private soccerInterval?: NodeJS.Timeout;
   private cursorPositions = new Map<string, { x: number; y: number }>();
@@ -609,6 +611,19 @@ export default class Server implements Party.Server {
   }
 
   onMessage(message: string, sender: Party.Connection) {
+    // Set DEBUG=true in .env (local) or via `partykit env add` to log incoming message rate.
+    // Useful for measuring real client send rates before tuning perf thresholds.
+    if (this.room.env.DEBUG === 'true') {
+      this.msgCount++;
+      if (!this.msgRateInterval) {
+        this.msgRateInterval = setInterval(() => {
+          const avgMs = this.msgCount > 0 ? Math.round(1000 / this.msgCount) : null;
+          console.log(`[msg-rate] room=${this.room.id} ${this.msgCount} msg/s (~${avgMs ?? '∞'}ms between msgs)`);
+          this.msgCount = 0;
+        }, 1000);
+      }
+    }
+
     try {
       const event: ClientEvent = JSON.parse(message);
 

--- a/perf/load-test-k6.js
+++ b/perf/load-test-k6.js
@@ -31,7 +31,7 @@
  */
 
 import { sleep } from "k6";
-import { WebSocket } from "k6/websockets";
+import ws from "k6/ws";
 import { Counter, Rate, Trend } from "k6/metrics";
 import { textSummary } from "https://jslib.k6.io/k6-summary/0.0.1/index.js";
 
@@ -121,75 +121,73 @@ export default function () {
 
   let presenceCount = 0;
   let lastSent = 0;
-  let opened = false;
 
-  const socket = new WebSocket(WS_URL);
-
-  socket.onopen = () => {
+  // ws.connect() blocks the VU until the socket closes — this is the correct
+  // pattern for k6/ws and gives clean per-iteration lifecycle management.
+  const res = ws.connect(WS_URL, {}, function (socket) {
     connectLatency.add(Date.now() - t0);
-    opened = true;
     connectionSuccess.add(true);
 
-    // Poll at 10ms; actual send rate is governed by computeThrottleMs(presenceCount).
-    // When adaptive throttle is off, computeThrottleMs returns 33ms (~30 fps).
-    const sendInterval = setInterval(() => {
-      const now = Date.now();
-      if (now - lastSent < computeThrottleMs(presenceCount)) return;
-      lastSent = now;
-
-      const tSec = (now - t0) / 1000;
-      const { x, y } = orbitPosition(orbit, tSec);
-      const eventType = Math.random() < 0.1 ? "touch" : "move";
-      socket.send(
-        JSON.stringify({
-          type: eventType,
-          position: { x, y, timestamp: now, userId },
-        })
-      );
-      cursorsSent.add(1);
-    }, 10);
-
-    setTimeout(() => {
-      clearInterval(sendInterval);
-      socket.send(
-        JSON.stringify({
-          type: "remove",
-          position: { x: 0, y: 0, timestamp: Date.now(), userId },
-        })
-      );
-      socket.close();
-    }, closeAfterMs);
-  };
-
-  socket.onmessage = (e) => {
-    try {
-      const msg = JSON.parse(e.data);
-      if (msg.type === "presenceCount") {
-        presenceCount = msg.count;
-      } else if (msg.type === "cursorBatch" && Array.isArray(msg.cursors)) {
-        // Count only cursor events, not presenceCount broadcasts
-        cursorsReceived.add(msg.cursors.length);
-        // Measure end-to-end delivery latency for our own cursor echoed back
+    socket.on("open", () => {
+      // Poll at 10ms; actual send rate is governed by computeThrottleMs(presenceCount).
+      // When adaptive throttle is off, computeThrottleMs returns 33ms (~30 fps).
+      socket.setInterval(() => {
         const now = Date.now();
-        for (const event of msg.cursors) {
-          if (event.position?.userId === userId && event.position?.timestamp) {
-            deliveryLatency.add(now - event.position.timestamp);
+        if (now - lastSent < computeThrottleMs(presenceCount)) return;
+        lastSent = now;
+
+        const tSec = (now - t0) / 1000;
+        const { x, y } = orbitPosition(orbit, tSec);
+        const eventType = Math.random() < 0.1 ? "touch" : "move";
+        socket.send(
+          JSON.stringify({
+            type: eventType,
+            position: { x, y, timestamp: now, userId },
+          })
+        );
+        cursorsSent.add(1);
+      }, 10);
+
+      // Stagger close time 18–22s to avoid synchronized reconnect storms
+      socket.setTimeout(() => {
+        socket.send(
+          JSON.stringify({
+            type: "remove",
+            position: { x: 0, y: 0, timestamp: Date.now(), userId },
+          })
+        );
+        socket.close();
+      }, closeAfterMs);
+    });
+
+    socket.on("message", (data) => {
+      try {
+        const msg = JSON.parse(data);
+        if (msg.type === "presenceCount") {
+          presenceCount = msg.count;
+        } else if (msg.type === "cursorBatch" && Array.isArray(msg.cursors)) {
+          // Count only cursor events, not presenceCount broadcasts
+          cursorsReceived.add(msg.cursors.length);
+          // Measure end-to-end delivery latency for our own cursor echoed back
+          const now = Date.now();
+          for (const event of msg.cursors) {
+            if (event.position?.userId === userId && event.position?.timestamp) {
+              deliveryLatency.add(now - event.position.timestamp);
+            }
           }
         }
-      }
-    } catch (_) {}
-  };
+      } catch (_) {}
+    });
 
-  socket.onerror = (e) => {
-    console.error(`[${userId.slice(0, 8)}] WS error: ${e.message}`);
-  };
+    socket.on("error", (e) => {
+      console.error(`[${userId.slice(0, 8)}] WS error: ${e.error()}`);
+    });
+  });
 
-  socket.onclose = () => {
-    if (!opened) connectionSuccess.add(false);
-  };
+  if (!res || res.status !== 101) connectionSuccess.add(false);
 
-  // Keep VU alive while the socket is open; extra 2s for graceful close handshake
-  sleep((closeAfterMs + 2000) / 1000);
+  // Brief pause between VU iterations so k6 pacing stays smooth
+  sleep(1);
 }
 
 export function handleSummary(data) {

--- a/perf/load-test-k6.js
+++ b/perf/load-test-k6.js
@@ -30,8 +30,8 @@
  *   Perf:  wss://perf.whispering-gallery.patcon.partykit.dev/parties/perf/perf-default
  */
 
-import { check, sleep } from "k6";
-import ws from "k6/ws";
+import { sleep } from "k6";
+import { WebSocket } from "k6/websockets";
 import { Counter, Rate, Trend } from "k6/metrics";
 import { textSummary } from "https://jslib.k6.io/k6-summary/0.0.1/index.js";
 
@@ -116,72 +116,77 @@ export default function () {
   // Stagger close time 18–22s to avoid synchronized reconnect storms across VUs
   const closeAfterMs = 18000 + Math.random() * 4000;
 
-  const res = ws.connect(WS_URL, {}, function (socket) {
+  let presenceCount = 0;
+  let lastSent = 0;
+  let opened = false;
+
+  const socket = new WebSocket(WS_URL);
+
+  socket.onopen = () => {
     connectLatency.add(Date.now() - t0);
+    opened = true;
+    connectionSuccess.add(true);
 
-    let presenceCount = 0;
-    let lastSent = 0;
+    // Poll at 10ms; actual send rate is governed by computeThrottleMs(presenceCount).
+    // When adaptive throttle is off, computeThrottleMs returns 33ms (~30 fps).
+    const sendInterval = setInterval(() => {
+      const now = Date.now();
+      if (now - lastSent < computeThrottleMs(presenceCount)) return;
+      lastSent = now;
 
-    socket.on("open", () => {
-      // Poll at 10ms; actual send rate is governed by computeThrottleMs(presenceCount).
-      // When adaptive throttle is off, computeThrottleMs returns 33ms (~30 fps).
-      socket.setInterval(() => {
+      const tSec = (now - t0) / 1000;
+      const { x, y } = orbitPosition(orbit, tSec);
+      const eventType = Math.random() < 0.1 ? "touch" : "move";
+      socket.send(
+        JSON.stringify({
+          type: eventType,
+          position: { x, y, timestamp: now, userId },
+        })
+      );
+      cursorsSent.add(1);
+    }, 10);
+
+    setTimeout(() => {
+      clearInterval(sendInterval);
+      socket.send(
+        JSON.stringify({
+          type: "remove",
+          position: { x: 0, y: 0, timestamp: Date.now(), userId },
+        })
+      );
+      socket.close();
+    }, closeAfterMs);
+  };
+
+  socket.onmessage = (e) => {
+    try {
+      const msg = JSON.parse(e.data);
+      if (msg.type === "presenceCount") {
+        presenceCount = msg.count;
+      } else if (msg.type === "cursorBatch" && Array.isArray(msg.cursors)) {
+        // Count only cursor events, not presenceCount broadcasts
+        cursorsReceived.add(msg.cursors.length);
+        // Measure end-to-end delivery latency for our own cursor echoed back
         const now = Date.now();
-        if (now - lastSent < computeThrottleMs(presenceCount)) return;
-        lastSent = now;
-
-        const tSec = (now - t0) / 1000;
-        const { x, y } = orbitPosition(orbit, tSec);
-        const eventType = Math.random() < 0.1 ? "touch" : "move";
-        socket.send(
-          JSON.stringify({
-            type: eventType,
-            position: { x, y, timestamp: now, userId },
-          })
-        );
-        cursorsSent.add(1);
-      }, 10);
-
-      socket.setTimeout(() => {
-        socket.send(
-          JSON.stringify({
-            type: "remove",
-            position: { x: 0, y: 0, timestamp: Date.now(), userId },
-          })
-        );
-        socket.close();
-      }, closeAfterMs);
-    });
-
-    socket.on("message", (data) => {
-      try {
-        const msg = JSON.parse(data);
-        if (msg.type === "presenceCount") {
-          presenceCount = msg.count;
-        } else if (msg.type === "cursorBatch" && Array.isArray(msg.cursors)) {
-          // Count only cursor events, not presenceCount broadcasts
-          cursorsReceived.add(msg.cursors.length);
-          // Measure end-to-end delivery latency for our own cursor echoed back
-          const now = Date.now();
-          for (const event of msg.cursors) {
-            if (event.position?.userId === userId && event.position?.timestamp) {
-              deliveryLatency.add(now - event.position.timestamp);
-            }
+        for (const event of msg.cursors) {
+          if (event.position?.userId === userId && event.position?.timestamp) {
+            deliveryLatency.add(now - event.position.timestamp);
           }
         }
-      } catch (_) {}
-    });
+      }
+    } catch (_) {}
+  };
 
-    socket.on("error", (e) => {
-      console.error(`[${userId.slice(0, 8)}] WS error: ${e.error()}`);
-    });
-  });
+  socket.onerror = (e) => {
+    console.error(`[${userId.slice(0, 8)}] WS error: ${e.message}`);
+  };
 
-  const connected = check(res, { "connected successfully": (r) => r && r.status === 101 });
-  connectionSuccess.add(connected);
+  socket.onclose = () => {
+    if (!opened) connectionSuccess.add(false);
+  };
 
-  // Brief pause between VU iterations so k6 pacing stays smooth
-  sleep(1);
+  // Keep VU alive while the socket is open; extra 2s for graceful close handshake
+  sleep((closeAfterMs + 2000) / 1000);
 }
 
 export function handleSummary(data) {

--- a/perf/load-test-k6.js
+++ b/perf/load-test-k6.js
@@ -55,8 +55,11 @@ const THROTTLE_SCALE_END  = parseInt(__ENV.THROTTLE_SCALE_END   || "400", 10); /
 const THROTTLE_MAX        = parseInt(__ENV.THROTTLE_MAX         || "250", 10); // ms at high counts
 
 // Quadratic ease-in: cheap at low counts, accelerating near capacity.
+// Mirrors CURSOR_THROTTLE_MS in app/utils/cursor.ts — keep in sync.
+const CURSOR_THROTTLE_MS = 33;
+
 function computeThrottleMs(count) {
-  if (!ADAPTIVE_THROTTLE)              return 33; // default ~30 fps
+  if (!ADAPTIVE_THROTTLE)              return CURSOR_THROTTLE_MS;
   if (count <= THROTTLE_SCALE_START)   return THROTTLE_BASE;
   if (count >= THROTTLE_SCALE_END)     return THROTTLE_MAX;
   const t = (count - THROTTLE_SCALE_START) / (THROTTLE_SCALE_END - THROTTLE_SCALE_START);


### PR DESCRIPTION
## Summary

- **Smooth cursors enabled in main app** — spring/smooth cursor smoothing is now on by default in V4; cursors use physics-based interpolation (stiffness 0.12, damping 0.5) for fluid motion
- **Smooth cursor avatar support** — smooth cursors now render DiceBear and custom photo avatars matching the emcee Avatars tab selection; DiceBear uses `?radius=50` for native circular rendering (no SVG clip paths needed); custom photos use clip paths as before
- **Cursor send rate standardised to 33ms (~30fps)** — single source of truth in `app/utils/cursor.ts`; TouchLayer was previously unthrottled
- **k6 load test fixed** — reverts the broken `k6/websockets` migration back to `k6/ws`; the global event loop in `k6/websockets` runs for the entire VU lifetime so iterations never complete and the test never terminates; also adds `pnpm perf-100` shorthand

## Test plan

- [ ] Open V4 canvas, observe smooth cursor motion on other participants' cursors
- [ ] Select a DiceBear avatar style in emcee Avatars tab — smooth cursors should show circular avatars immediately
- [ ] Select custom photo mode — custom photos should appear on smooth cursors; unregistered users fall back to DiceBear or dot
- [ ] Run `pnpm perf-100` — should complete in ~50s and exit cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~150 words of PR description from ~300 words of human prompts across this session)