### PR TITLE
feat(neighbor): NeighborPanel — code entry + live graph viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ### Fixed
 - **NeighborPanel graph** — "node not found" crash (and resulting WSOD) when a link referenced a user ID missing from the nodes array due to server/timing inconsistency; D3 link mutation also caused the same crash on second map open; both resolved by normalising and filtering links in `freshLinks()` before passing to any simulation.
+- **NeighborPanel graph** — nodes now appear/disappear in real time: `userJoined` adds a dot immediately (no need to leave and re-open the graph); `userLeft` removes the dot and any associated edges; `neighborEdgesCleared` also clears all dots; `neighborEdgeAdded` now drives ref updates + `restartSim` directly instead of the unreliable live-patch path.
 - **NeighborPanel graph view** — added ↺ refresh button to re-randomise the force layout; added ±180° rotation slider beside the flip buttons; removed active-state highlighting from flip buttons since orientation has no canonical "true" state.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ### Fixed
 - **NeighborPanel graph** — "node not found" crash (and resulting WSOD) when a link referenced a user ID missing from the nodes array due to server/timing inconsistency; D3 link mutation also caused the same crash on second map open; both resolved by normalising and filtering links in `freshLinks()` before passing to any simulation.
 - **NeighborPanel graph** — nodes now appear/disappear in real time: `userJoined` adds a dot immediately (no need to leave and re-open the graph); `userLeft` removes the dot and any associated edges; `neighborEdgesCleared` also clears all dots; `neighborEdgeAdded` now drives ref updates + `restartSim` directly instead of the unreliable live-patch path.
+- **NeighborPanel graph** — joining users and their prior edges now merge into the live simulation without resetting it; `userJoined` adds the node directly via `addNodeLive`; the subsequent snapshot response merges new nodes/edges incrementally (`addEdgeLive`-style, no flash); `restartSim` is only called on initial graph open or full clears.
 - **NeighborPanel graph view** — added ↺ refresh button to re-randomise the force layout; added ±180° rotation slider beside the flip buttons; removed active-state highlighting from flip buttons since orientation has no canonical "true" state.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 29 (2026-06-02)
 
+### Added
+- **NeighborPanel** — new panel for building a live social graph of nearby audience members; participants see their own 4-digit code and enter neighbours' codes via an on-screen keypad; emcee can view a D3 force-directed map of all connections in real time ([#134](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/134))
+
 ### Changed
 - **Perf test CI: add `party` and `room` inputs** — `workflow_dispatch` now accepts a `party` dropdown (`perf`/`main`, default `perf`) and a `room` text field (default `default`); WS URL is constructed dynamically from these inputs. Renames the hard-coded `perf-default` room to `default` throughout the k6 script, `perf:remote` npm script, and `PerfCanvasApp`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 29 (2026-06-02)
 
 ### Changed
-- **NeighborPanel graph view** — nodes are now coloured by live reaction-canvas valence (green/red/yellow) using the same `computeReactionRegion` logic as other projection maps; grey for users with no cursor data yet; own node stays blue.
+- **NeighborPanel graph view** — nodes are now coloured by live reaction-canvas valence (green/red/yellow) using the same `computeReactionRegion` logic as other projection maps; grey for users with no cursor data yet; no special "you are here" highlight for own node.
 - **NeighborPanel graph view** — added ↺ refresh button to re-randomise the force layout; added ±180° rotation slider beside the flip buttons; removed active-state highlighting from flip buttons since orientation has no canonical "true" state.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 29 (2026-06-02)
 
+### Changed
+- **NeighborPanel graph view** — added ↺ refresh button to re-randomise the force layout; added ±180° rotation slider beside the flip buttons; removed active-state highlighting from flip buttons since orientation has no canonical "true" state.
+
 ### Added
 - **NeighborPanel** — new panel for building a live social graph of nearby audience members; participants see their own 4-digit code and enter neighbours' codes via an on-screen keypad; emcee can view a D3 force-directed map of all connections in real time ([#134](https://github.com/patcon/polislike-partykit-reaction-canvas/issues/134))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ### Changed
 - **NeighborPanel graph view** — nodes are now coloured by live reaction-canvas valence (green/red/yellow) using the same `computeReactionRegion` logic as other projection maps; grey for users with no cursor data yet; no special "you are here" highlight for own node.
+- **NeighborPanel graph view** — new nodes spawn at SVG centre instead of top-left; removed tick-handler coordinate clamping so dragging works correctly when graph is rotated.
+
+### Fixed
+- **NeighborPanel graph** — "node not found" crash (and resulting WSOD) when a link referenced a user ID missing from the nodes array due to server/timing inconsistency; D3 link mutation also caused the same crash on second map open; both resolved by normalising and filtering links in `freshLinks()` before passing to any simulation.
 - **NeighborPanel graph view** — added ↺ refresh button to re-randomise the force layout; added ±180° rotation slider beside the flip buttons; removed active-state highlighting from flip buttons since orientation has no canonical "true" state.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 29 (2026-06-02)
 
 ### Changed
+- **NeighborPanel graph view** — nodes are now coloured by live reaction-canvas valence (green/red/yellow) using the same `computeReactionRegion` logic as other projection maps; grey for users with no cursor data yet; own node stays blue.
 - **NeighborPanel graph view** — added ↺ refresh button to re-randomise the force layout; added ±180° rotation slider beside the flip buttons; removed active-state highlighting from flip buttons since orientation has no canonical "true" state.
 
 ### Added

--- a/app/components/apps/ReactionCanvasAppV4.tsx
+++ b/app/components/apps/ReactionCanvasAppV4.tsx
@@ -39,6 +39,7 @@ import MapMakerPanel from "../panels/MapMakerPanel";
 import MapViewerPanel from "../panels/MapViewerPanel";
 import ValenceBeatPadPanel from "../panels/ValenceBeatPadPanel";
 import ArrivalCanvasPanel from "../panels/ArrivalCanvasPanel";
+import NeighborPanel from "../panels/NeighborPanel";
 import { SMOOTH_CURSOR_ENABLED, SMOOTH_CURSOR_CONFIG } from "../../utils/cursor";
 
 const PANEL_COMPONENTS: Partial<Record<string, PanelDefinition['component']>> = {
@@ -53,6 +54,7 @@ const PANEL_COMPONENTS: Partial<Record<string, PanelDefinition['component']>> = 
   'map-viewer':      MapViewerPanel,
   'valence-beat-pad': ValenceBeatPadPanel,
   'arrival-canvas':   ArrivalCanvasPanel,
+  'neighbor':         NeighborPanel,
 };
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;

--- a/app/components/modals/PanelSettingsModalMapViewer.tsx
+++ b/app/components/modals/PanelSettingsModalMapViewer.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { idbGet } from "../../utils/idbStorage";
 import type { MapViewerConfig } from "../../types";
 import type { MomentSnapshot } from "../panels/AdminPanelNoDB/types";
+import { VOTE_COLORS, USER_STATUS_COLORS, USER_STATUS_LABELS, MISSING_COLOR } from "../../constants/userStatus";
 
 interface PanelSettingsModalMapViewerProps {
   room: string;
@@ -72,26 +73,26 @@ export default function PanelSettingsModalMapViewer({ room, current, onSubmit, o
           {showVoteLegend && (
             <div style={{ display: 'flex', gap: 12, fontSize: 12, color: '#888', alignItems: 'center', flexWrap: 'wrap' }}>
               <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#2ecc71', display: 'inline-block' }} /> agree
+                <span style={{ width: 10, height: 10, borderRadius: '50%', background: VOTE_COLORS.positive, display: 'inline-block' }} /> agree
               </span>
               <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#e74c3c', display: 'inline-block' }} /> disagree
+                <span style={{ width: 10, height: 10, borderRadius: '50%', background: VOTE_COLORS.negative, display: 'inline-block' }} /> disagree
               </span>
               <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#f1c40f', display: 'inline-block' }} /> pass
+                <span style={{ width: 10, height: 10, borderRadius: '50%', background: VOTE_COLORS.neutral, display: 'inline-block' }} /> pass
               </span>
               {colorMode === 'moment' && (
                 <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                  <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#b0b0b0', display: 'inline-block' }} /> missing
+                  <span style={{ width: 10, height: 10, borderRadius: '50%', background: MISSING_COLOR, display: 'inline-block' }} /> missing
                 </span>
               )}
               {colorMode === 'now' && (
                 <>
                   <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                    <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#888', display: 'inline-block' }} /> idle
+                    <span style={{ width: 10, height: 10, borderRadius: '50%', background: USER_STATUS_COLORS.idle, display: 'inline-block' }} /> {USER_STATUS_LABELS.idle}
                   </span>
                   <span style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
-                    <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#444', display: 'inline-block' }} /> offline
+                    <span style={{ width: 10, height: 10, borderRadius: '50%', background: USER_STATUS_COLORS.offline, display: 'inline-block' }} /> {USER_STATUS_LABELS.offline}
                   </span>
                 </>
               )}

--- a/app/components/panels/MapViewerPanel/index.tsx
+++ b/app/components/panels/MapViewerPanel/index.tsx
@@ -9,16 +9,9 @@ import { computeReactionRegion, DEFAULT_ANCHORS } from '../../../utils/voteRegio
 import type { ReactionAnchors } from '../../../utils/voteRegion';
 import type { MapProjection, MapViewerConfig } from '../../../types';
 import type { MomentSnapshot } from '../AdminPanelNoDB/types';
+import { VOTE_COLORS, USER_STATUS_COLORS, USER_STATUS_LABELS, MISSING_COLOR } from '../../../constants/userStatus';
 
-const VOTE_COLORS: Record<string, string> = {
-  positive: '#2ecc71',
-  negative: '#e74c3c',
-  neutral:  '#f1c40f',
-};
-const MISSING_COLOR = '#b0b0b0';
 const DEFAULT_COLOR = '#4a8';
-const CONNECTED_IDLE_COLOR = '#888';
-const DISCONNECTED_COLOR = '#333';
 
 
 function ScatterPlot({ data, selfId, colorById, flipX, flipY }: { data: [string, [number, number]][]; selfId: string; colorById?: Record<string, string>; flipX?: boolean; flipY?: boolean }) {
@@ -44,8 +37,8 @@ function ScatterPlot({ data, selfId, colorById, flipX, flipY }: { data: [string,
       .sort(([a], [b]) => {
         const priority = (id: string) => {
           const c = colorById?.[id];
-          if (!c || c === DISCONNECTED_COLOR) return 0;
-          if (c === CONNECTED_IDLE_COLOR) return 1;
+          if (!c || c === USER_STATUS_COLORS.offline) return 0;
+          if (c === USER_STATUS_COLORS.idle) return 1;
           return 2;
         };
         return priority(a) - priority(b);
@@ -245,11 +238,11 @@ export default function MapViewerPanel() {
         const cursor = liveCursors.get(id);
         if (cursor) {
           const region = computeReactionRegion(cursor.x, cursor.y, effectiveAnchors);
-          map[id] = region ? (VOTE_COLORS[region] ?? CONNECTED_IDLE_COLOR) : CONNECTED_IDLE_COLOR;
+          map[id] = region ? (VOTE_COLORS[region] ?? USER_STATUS_COLORS.idle) : USER_STATUS_COLORS.idle;
         } else if (connectedUserIds.includes(id)) {
-          map[id] = CONNECTED_IDLE_COLOR;
+          map[id] = USER_STATUS_COLORS.idle;
         } else {
-          map[id] = DISCONNECTED_COLOR;
+          map[id] = USER_STATUS_COLORS.offline;
         }
       }
       return map;
@@ -330,7 +323,12 @@ export default function MapViewerPanel() {
             <span style={{ fontSize: 10, color: '#555', minWidth: 28, textAlign: 'center' }}>{activeMomentIdx + 1}/{moments.length}</span>
             <button onClick={() => setMomentPageIdx(Math.max(0, activeMomentIdx - 1))} disabled={activeMomentIdx <= 0} title="Previous moment" style={btnStyle(false, activeMomentIdx <= 0)}>‹</button>
             <button onClick={() => setMomentPageIdx(Math.min(moments.length - 1, activeMomentIdx + 1))} disabled={activeMomentIdx >= moments.length - 1} title="Next moment" style={btnStyle(false, activeMomentIdx >= moments.length - 1)}>›</button>
-            {([['#2ecc71', 'agree'], ['#e74c3c', 'disagree'], ['#f1c40f', 'pass'], ['#b0b0b0', 'missing']] as [string, string][]).map(([color, label]) => (
+            {([
+                [VOTE_COLORS.positive, 'agree'],
+                [VOTE_COLORS.negative, 'disagree'],
+                [VOTE_COLORS.neutral,  'pass'],
+                [MISSING_COLOR,        'missing'],
+              ] as [string, string][]).map(([color, label]) => (
               <span key={label} style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
                 <span style={{ width: 8, height: 8, borderRadius: '50%', background: color, display: 'inline-block' }} />
                 <span>{label}</span>
@@ -341,7 +339,13 @@ export default function MapViewerPanel() {
         {showNowLegend && (
           <span style={{ display: 'flex', gap: 10, alignItems: 'center' }}>
             <span style={{ color: '#777' }}>live</span>
-            {([['#2ecc71', 'agree'], ['#e74c3c', 'disagree'], ['#f1c40f', 'pass'], ['#888', 'idle'], ['#444', 'offline']] as [string, string][]).map(([color, label]) => (
+            {([
+              [VOTE_COLORS.positive, 'agree'],
+              [VOTE_COLORS.negative, 'disagree'],
+              [VOTE_COLORS.neutral,  'pass'],
+              [USER_STATUS_COLORS.idle,    USER_STATUS_LABELS.idle],
+              [USER_STATUS_COLORS.offline, USER_STATUS_LABELS.offline],
+            ] as [string, string][]).map(([color, label]) => (
               <span key={label} style={{ display: 'flex', alignItems: 'center', gap: 3 }}>
                 <span style={{ width: 8, height: 8, borderRadius: '50%', background: color, display: 'inline-block' }} />
                 <span>{label}</span>

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -4,6 +4,8 @@ import * as d3 from 'd3';
 import { usePanelContext } from '../../../context/PanelContext';
 import { getPartySocketConfig } from '../../../utils/partyHost';
 import { generateUUID } from '../../../utils/userId';
+import { computeReactionRegion, DEFAULT_ANCHORS } from '../../../utils/voteRegion';
+import type { ReactionAnchors } from '../../../utils/voteRegion';
 
 type View = 'entry' | 'graph';
 type EdgeError = 'not_found' | 'self' | 'duplicate';
@@ -16,6 +18,7 @@ const KEYPAD_KEYS = ['1','2','3','4','5','6','7','8','9','←','0','✕'];
 const EDGE_COLOR = '#555';
 const EDGE_FLASH_COLOR = '#4ade80';
 const EDGE_FLASH_MS = 800;
+const VOTE_COLORS = { positive: '#2ecc71', negative: '#e74c3c', neutral: '#f1c40f' };
 
 const ERROR_MESSAGES: Record<EdgeError, string> = {
   not_found: 'Code not found — try again',
@@ -47,6 +50,21 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
   const paddingRef = useRef(20);
   const sizeRef = useRef({ width: 320, height: 280 });
   const statusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const liveCursorsRef = useRef<Map<string, { x: number; y: number }>>(new Map());
+  const anchorsRef = useRef<ReactionAnchors>(DEFAULT_ANCHORS);
+
+  function getNodeColor(uid: string): string {
+    if (uid === socketUserId.current) return '#4f9cf9';
+    const pos = liveCursorsRef.current.get(uid);
+    if (!pos) return '#888';
+    const region = computeReactionRegion(pos.x, pos.y, anchorsRef.current);
+    return region ? VOTE_COLORS[region] : '#888';
+  }
+
+  function updateNodeColors() {
+    nodeGroupRef.current?.selectAll<SVGCircleElement, D3Node>('circle')
+      .attr('fill', d => getNodeColor(d.id));
+  }
 
   const addEdgeLive = useCallback((link: D3Link) => {
     const sim = simRef.current;
@@ -69,7 +87,7 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
         .data(nodesRef.current, d => d.id)
         .join(enter => enter.append('circle')
           .attr('r', 8)
-          .attr('fill', d => d.id === socketUserId.current ? '#4f9cf9' : '#aaa')
+          .attr('fill', d => getNodeColor(d.id))
           .attr('stroke', '#fff')
           .attr('stroke-width', 1.5)
           .call(makeDrag(sim))
@@ -101,6 +119,17 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       const msg = JSON.parse(evt.data);
       if (msg.type === 'connected') {
         if (msg.myNeighborCode) setMyCode(msg.myNeighborCode);
+        if (msg.roomAnchors) anchorsRef.current = msg.roomAnchors;
+      } else if (msg.type === 'roomAnchorsChanged') {
+        anchorsRef.current = msg.anchors ?? DEFAULT_ANCHORS;
+        updateNodeColors();
+      } else if (msg.type === 'move' || msg.type === 'touch') {
+        const { userId, x, y } = msg.position;
+        liveCursorsRef.current.set(userId, { x, y });
+        updateNodeColors();
+      } else if (msg.type === 'remove') {
+        liveCursorsRef.current.delete(msg.position.userId);
+        updateNodeColors();
       } else if (msg.type === 'neighborEdgesSnapshot') {
         setEdges(msg.edges ?? []);
         const userIds = Object.keys(msg.allCodes ?? {});
@@ -214,7 +243,7 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       .data(nodesRef.current, d => d.id)
       .join('circle')
       .attr('r', 8)
-      .attr('fill', d => d.id === socketUserId.current ? '#4f9cf9' : '#aaa')
+      .attr('fill', d => getNodeColor(d.id))
       .attr('stroke', '#fff')
       .attr('stroke-width', 1.5)
       .call(makeDrag(sim));

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -187,7 +187,6 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       } else if (msg.type === 'neighborEdgesCleared') {
         setEdges([]);
         linksRef.current = [];
-        nodesRef.current = [];
         restartSim();
       } else if (msg.type === 'neighborEdgeError') {
         setErrorReason(msg.reason as EdgeError);

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -33,11 +33,14 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
   const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
   const [errorReason, setErrorReason] = useState<EdgeError | null>(null);
   const [edges, setEdges] = useState<Edge[]>([]);
+  const [flipH, setFlipH] = useState(false);
+  const [flipV, setFlipV] = useState(false);
 
   const svgRef = useRef<SVGSVGElement>(null);
   const simRef = useRef<d3.Simulation<D3Node, D3Link> | null>(null);
   const nodesRef = useRef<D3Node[]>([]);
   const linksRef = useRef<D3Link[]>([]);
+  const transformGroupRef = useRef<d3.Selection<SVGGElement, unknown, null, undefined> | null>(null);
   const linkGroupRef = useRef<d3.Selection<SVGGElement, unknown, null, undefined> | null>(null);
   const nodeGroupRef = useRef<d3.Selection<SVGGElement, unknown, null, undefined> | null>(null);
   const paddingRef = useRef(20);
@@ -193,8 +196,10 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       .force('collide', d3.forceCollide(14));
     simRef.current = sim;
 
-    linkGroupRef.current = svg.append('g');
-    nodeGroupRef.current = svg.append('g');
+    const tg = svg.append('g');
+    transformGroupRef.current = tg;
+    linkGroupRef.current = tg.append('g');
+    nodeGroupRef.current = tg.append('g');
 
     linkGroupRef.current
       .selectAll<SVGLineElement, D3Link>('line')
@@ -234,6 +239,17 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
     return () => { simRef.current?.stop(); };
   }, [view, restartSim]);
 
+  useEffect(() => {
+    if (!transformGroupRef.current) return;
+    const { width, height } = sizeRef.current;
+    const cx = width / 2, cy = height / 2;
+    const scaleX = flipH ? -1 : 1;
+    const scaleY = flipV ? -1 : 1;
+    transformGroupRef.current.attr('transform',
+      `translate(${cx},${cy}) scale(${scaleX},${scaleY}) translate(${-cx},${-cy})`
+    );
+  }, [flipH, flipV]);
+
   useEffect(() => () => clearStatusTimer(), []);
 
   if (view === 'graph') {
@@ -253,7 +269,23 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
             Clear all connections
           </button>
         </div>
-        <svg ref={svgRef} style={{ flex: 1, width: '100%', background: '#1a1a1a', borderRadius: 8 }} />
+        <div style={{ flex: 1, position: 'relative' }}>
+          <svg ref={svgRef} style={{ width: '100%', height: '100%', background: '#1a1a1a', borderRadius: 8 }} />
+          <div style={{ position: 'absolute', bottom: 8, right: 8, display: 'flex', gap: 4 }}>
+            <button
+              onClick={() => setFlipH(f => !f)}
+              style={{ fontSize: 11, padding: '2px 8px', borderRadius: 4, border: '1px solid #444', background: flipH ? '#2a4a7f' : 'rgba(20,20,20,0.8)', color: '#ccc', cursor: 'pointer' }}
+            >
+              ↔
+            </button>
+            <button
+              onClick={() => setFlipV(f => !f)}
+              style={{ fontSize: 11, padding: '2px 8px', borderRadius: 4, border: '1px solid #444', background: flipV ? '#2a4a7f' : 'rgba(20,20,20,0.8)', color: '#ccc', cursor: 'pointer' }}
+            >
+              ↕
+            </button>
+          </div>
+        </div>
         <p style={{ textAlign: 'center', fontSize: 11, color: '#666', marginTop: 6 }}>
           {edges.length === 0 ? 'No connections yet' : `${edges.length} connection${edges.length === 1 ? '' : 's'}`}
         </p>

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -125,10 +125,13 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
 
     svg.selectAll('*').remove();
 
+    const padding = 20;
+
     const sim = d3.forceSimulation<D3Node>(nodesRef.current)
       .force('link', d3.forceLink<D3Node, D3Link>(linksRef.current).id(d => d.id).distance(60))
-      .force('charge', d3.forceManyBody().strength(-80))
-      .force('center', d3.forceCenter(width / 2, height / 2))
+      .force('charge', d3.forceManyBody().strength(-120))
+      .force('x', d3.forceX(width / 2).strength(0.07))
+      .force('y', d3.forceY(height / 2).strength(0.07))
       .force('collide', d3.forceCollide(14));
     simRef.current = sim;
 
@@ -164,6 +167,10 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       );
 
     sim.on('tick', () => {
+      for (const n of nodesRef.current) {
+        n.x = Math.max(padding, Math.min(width - padding, n.x ?? width / 2));
+        n.y = Math.max(padding, Math.min(height - padding, n.y ?? height / 2));
+      }
       svg.selectAll<SVGLineElement, D3Link>('line')
         .attr('x1', d => (d.source as D3Node).x ?? 0)
         .attr('y1', d => (d.source as D3Node).y ?? 0)

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -77,6 +77,21 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       .attr('fill', d => getNodeColor(d.id));
   }
 
+  function addNodeLive(uid: string) {
+    const sim = simRef.current;
+    const nodeGroup = nodeGroupRef.current;
+    if (!sim || !nodeGroup) return;
+    sim.nodes(nodesRef.current);
+    nodeGroup.selectAll<SVGCircleElement, D3Node>('circle')
+      .data(nodesRef.current, d => d.id)
+      .join(enter => enter.append('circle')
+        .attr('r', 8).attr('fill', d => getNodeColor(d.id))
+        .attr('stroke', '#fff').attr('stroke-width', 1.5)
+        .call(makeDrag(sim))
+      );
+    sim.alpha(0.3).restart();
+  }
+
   const addEdgeLive = useCallback((link: D3Link) => {
     const sim = simRef.current;
     const linkGroup = linkGroupRef.current;
@@ -147,7 +162,7 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
         if (!nodesRef.current.find(n => n.id === uid)) {
           const { width, height } = sizeRef.current;
           nodesRef.current = [...nodesRef.current, { id: uid, x: width / 2, y: height / 2 }];
-          restartSim();
+          addNodeLive(uid);
         }
         socket.send(JSON.stringify({ type: 'requestNeighborEdges' }));
       } else if (msg.type === 'userLeft') {
@@ -162,13 +177,47 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
         const allIds = [...new Set([...Object.keys(msg.allCodes ?? {}), ...edgeUserIds])];
         const { width, height } = sizeRef.current;
         const cx = width / 2, cy = height / 2;
-        nodesRef.current = allIds.map(id => ({ id, x: cx, y: cy, ...(nodesRef.current.find(n => n.id === id) ?? {}) }));
-        linksRef.current = (msg.edges ?? []).map((e: Edge) => ({
-          id: `${e.userA}|${e.userB}`,
-          source: e.userA,
-          target: e.userB,
-        }));
-        restartSim();
+        const sim = simRef.current;
+        const nodeGroup = nodeGroupRef.current;
+        const linkGroup = linkGroupRef.current;
+        if (sim && nodeGroup && linkGroup) {
+          // Live sim running — merge incrementally, no restart
+          let nodesChanged = false;
+          for (const id of allIds) {
+            if (!nodesRef.current.find(n => n.id === id)) {
+              nodesRef.current = [...nodesRef.current, { id, x: cx, y: cy }];
+              nodesChanged = true;
+            }
+          }
+          if (nodesChanged) {
+            sim.nodes(nodesRef.current);
+            nodeGroup.selectAll<SVGCircleElement, D3Node>('circle')
+              .data(nodesRef.current, d => d.id)
+              .join(enter => enter.append('circle')
+                .attr('r', 8).attr('fill', d => getNodeColor(d.id))
+                .attr('stroke', '#fff').attr('stroke-width', 1.5)
+                .call(makeDrag(sim))
+              );
+          }
+          const newLinks = (msg.edges ?? [])
+            .filter((e: Edge) => !linksRef.current.find(l => l.id === `${e.userA}|${e.userB}`))
+            .map((e: Edge) => ({ id: `${e.userA}|${e.userB}`, source: e.userA, target: e.userB }));
+          if (newLinks.length > 0) {
+            linksRef.current = [...freshLinks(), ...newLinks];
+            (sim.force('link') as d3.ForceLink<D3Node, D3Link>).links(linksRef.current);
+            linkGroup.selectAll<SVGLineElement, D3Link>('line')
+              .data(linksRef.current, d => d.id)
+              .join(enter => enter.append('line').attr('stroke', EDGE_COLOR).attr('stroke-width', 1.5));
+            sim.alpha(0.3).restart();
+          }
+        } else {
+          // No live sim — update refs so restartSim picks them up
+          nodesRef.current = allIds.map(id => ({ id, x: cx, y: cy, ...(nodesRef.current.find(n => n.id === id) ?? {}) }));
+          linksRef.current = (msg.edges ?? []).map((e: Edge) => ({
+            id: `${e.userA}|${e.userB}`, source: e.userA, target: e.userB,
+          }));
+          restartSim();
+        }
       } else if (msg.type === 'neighborEdgeAdded') {
         const edge: Edge = { userA: msg.userA, userB: msg.userB };
         setEdges(prev => [...prev, edge]);

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -35,6 +35,7 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
   const [edges, setEdges] = useState<Edge[]>([]);
   const [flipH, setFlipH] = useState(false);
   const [flipV, setFlipV] = useState(false);
+  const [rotation, setRotation] = useState(0);
 
   const svgRef = useRef<SVGSVGElement>(null);
   const simRef = useRef<d3.Simulation<D3Node, D3Link> | null>(null);
@@ -246,9 +247,9 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
     const scaleX = flipH ? -1 : 1;
     const scaleY = flipV ? -1 : 1;
     transformGroupRef.current.attr('transform',
-      `translate(${cx},${cy}) scale(${scaleX},${scaleY}) translate(${-cx},${-cy})`
+      `translate(${cx},${cy}) rotate(${rotation}) scale(${scaleX},${scaleY}) translate(${-cx},${-cy})`
     );
-  }, [flipH, flipV]);
+  }, [flipH, flipV, rotation]);
 
   useEffect(() => () => clearStatusTimer(), []);
 
@@ -271,16 +272,31 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
         </div>
         <div style={{ flex: 1, position: 'relative' }}>
           <svg ref={svgRef} style={{ width: '100%', height: '100%', background: '#1a1a1a', borderRadius: 8 }} />
-          <div style={{ position: 'absolute', bottom: 8, right: 8, display: 'flex', gap: 4 }}>
+          <div style={{ position: 'absolute', bottom: 8, right: 8, display: 'flex', alignItems: 'center', gap: 4 }}>
+            <button
+              onClick={() => restartSim()}
+              title="Refresh layout"
+              style={{ fontSize: 11, padding: '2px 6px', borderRadius: 4, border: '1px solid #444', background: 'rgba(20,20,20,0.8)', color: '#ccc', cursor: 'pointer' }}
+            >
+              ↺
+            </button>
+            <input
+              type="range"
+              min={-180}
+              max={180}
+              value={rotation}
+              onChange={e => setRotation(Number(e.target.value))}
+              style={{ width: 120, maxWidth: 200, cursor: 'pointer', accentColor: '#4f9cf9' }}
+            />
             <button
               onClick={() => setFlipH(f => !f)}
-              style={{ fontSize: 11, padding: '2px 8px', borderRadius: 4, border: '1px solid #444', background: flipH ? '#2a4a7f' : 'rgba(20,20,20,0.8)', color: '#ccc', cursor: 'pointer' }}
+              style={{ fontSize: 11, padding: '2px 8px', borderRadius: 4, border: '1px solid #444', background: 'rgba(20,20,20,0.8)', color: '#ccc', cursor: 'pointer' }}
             >
               ↔
             </button>
             <button
               onClick={() => setFlipV(f => !f)}
-              style={{ fontSize: 11, padding: '2px 8px', borderRadius: 4, border: '1px solid #444', background: flipV ? '#2a4a7f' : 'rgba(20,20,20,0.8)', color: '#ccc', cursor: 'pointer' }}
+              style={{ fontSize: 11, padding: '2px 8px', borderRadius: 4, border: '1px solid #444', background: 'rgba(20,20,20,0.8)', color: '#ccc', cursor: 'pointer' }}
             >
               ↕
             </button>

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -13,6 +13,9 @@ interface D3Node extends d3.SimulationNodeDatum { id: string }
 interface D3Link extends d3.SimulationLinkDatum<D3Node> { id: string }
 
 const KEYPAD_KEYS = ['1','2','3','4','5','6','7','8','9','←','0','✓'];
+const EDGE_COLOR = '#555';
+const EDGE_FLASH_COLOR = '#4ade80';
+const EDGE_FLASH_MS = 800;
 
 const ERROR_MESSAGES: Record<EdgeError, string> = {
   not_found: 'Code not found — try again',
@@ -30,13 +33,61 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
   const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
   const [errorReason, setErrorReason] = useState<EdgeError | null>(null);
   const [edges, setEdges] = useState<Edge[]>([]);
-  const [allCodes, setAllCodes] = useState<Record<string, string>>({});
 
   const svgRef = useRef<SVGSVGElement>(null);
   const simRef = useRef<d3.Simulation<D3Node, D3Link> | null>(null);
   const nodesRef = useRef<D3Node[]>([]);
   const linksRef = useRef<D3Link[]>([]);
+  const linkGroupRef = useRef<d3.Selection<SVGGElement, unknown, null, undefined> | null>(null);
+  const nodeGroupRef = useRef<d3.Selection<SVGGElement, unknown, null, undefined> | null>(null);
+  const paddingRef = useRef(20);
+  const sizeRef = useRef({ width: 320, height: 280 });
   const statusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const addEdgeLive = useCallback((link: D3Link) => {
+    const sim = simRef.current;
+    const linkGroup = linkGroupRef.current;
+    const nodeGroup = nodeGroupRef.current;
+    if (!sim || !linkGroup || !nodeGroup) return;
+
+    // Add any new nodes to the simulation
+    let nodesChanged = false;
+    for (const uid of [link.source as string, link.target as string]) {
+      if (!nodesRef.current.find(n => n.id === uid)) {
+        nodesRef.current = [...nodesRef.current, { id: uid }];
+        nodesChanged = true;
+      }
+    }
+    if (nodesChanged) {
+      sim.nodes(nodesRef.current);
+      nodeGroup
+        .selectAll<SVGCircleElement, D3Node>('circle')
+        .data(nodesRef.current, d => d.id)
+        .join(enter => enter.append('circle')
+          .attr('r', 8)
+          .attr('fill', d => d.id === socketUserId.current ? '#4f9cf9' : '#aaa')
+          .attr('stroke', '#fff')
+          .attr('stroke-width', 1.5)
+          .call(makeDrag(sim))
+        );
+    }
+
+    // Add the new link and flash its color
+    linksRef.current = [...linksRef.current, link];
+    (sim.force('link') as d3.ForceLink<D3Node, D3Link>).links(linksRef.current);
+
+    linkGroup
+      .selectAll<SVGLineElement, D3Link>('line')
+      .data(linksRef.current, d => d.id)
+      .join(enter => enter.append('line')
+        .attr('stroke', EDGE_FLASH_COLOR)
+        .attr('stroke-width', 1.5)
+        .transition().duration(EDGE_FLASH_MS)
+        .attr('stroke', EDGE_COLOR)
+      );
+
+    sim.alpha(0.3).restart();
+  }, []);
 
   const socket = usePartySocket({
     ...getPartySocketConfig(),
@@ -48,7 +99,6 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
         if (msg.myNeighborCode) setMyCode(msg.myNeighborCode);
       } else if (msg.type === 'neighborEdgesSnapshot') {
         setEdges(msg.edges ?? []);
-        setAllCodes(msg.allCodes ?? {});
         const userIds = Object.keys(msg.allCodes ?? {});
         nodesRef.current = userIds.map(id => ({ id, ...(nodesRef.current.find(n => n.id === id) ?? {}) }));
         linksRef.current = (msg.edges ?? []).map((e: Edge) => ({
@@ -62,13 +112,7 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
         setEdges(prev => [...prev, edge]);
         const id = `${msg.userA}|${msg.userB}`;
         if (!linksRef.current.find(l => l.id === id)) {
-          linksRef.current = [...linksRef.current, { id, source: msg.userA, target: msg.userB }];
-          for (const uid of [msg.userA, msg.userB]) {
-            if (!nodesRef.current.find(n => n.id === uid)) {
-              nodesRef.current = [...nodesRef.current, { id: uid }];
-            }
-          }
-          restartSim();
+          addEdgeLive({ id, source: msg.userA, target: msg.userB });
         }
       } else if (msg.type === 'neighborEdgesCleared') {
         setEdges([]);
@@ -117,15 +161,29 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
   }
 
   // ===== D3 graph =====
+  function makeDrag(sim: d3.Simulation<D3Node, D3Link>) {
+    return d3.drag<SVGCircleElement, D3Node>()
+      .on('start', (event, d) => {
+        if (!event.active) sim.alphaTarget(0.3).restart();
+        d.fx = d.x; d.fy = d.y;
+      })
+      .on('drag', (event, d) => { d.fx = event.x; d.fy = event.y; })
+      .on('end', (event, d) => {
+        if (!event.active) sim.alphaTarget(0);
+        d.fx = null; d.fy = null;
+      });
+  }
+
   const restartSim = useCallback(() => {
     if (!svgRef.current) return;
     const svg = d3.select(svgRef.current);
     const width = svgRef.current.clientWidth || 320;
     const height = svgRef.current.clientHeight || 280;
+    const padding = 20;
+    sizeRef.current = { width, height };
+    paddingRef.current = padding;
 
     svg.selectAll('*').remove();
-
-    const padding = 20;
 
     const sim = d3.forceSimulation<D3Node>(nodesRef.current)
       .force('link', d3.forceLink<D3Node, D3Link>(linksRef.current).id(d => d.id).distance(60))
@@ -135,54 +193,40 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       .force('collide', d3.forceCollide(14));
     simRef.current = sim;
 
-    const linkSel = svg.append('g')
-      .selectAll<SVGLineElement, D3Link>('line')
-      .data(linksRef.current)
-      .join('line')
-      .attr('stroke', '#888')
-      .attr('stroke-width', 1.5)
-      .style('opacity', 0)
-      .transition().duration(400)
-      .style('opacity', 1);
+    linkGroupRef.current = svg.append('g');
+    nodeGroupRef.current = svg.append('g');
 
-    const nodeSel = svg.append('g')
+    linkGroupRef.current
+      .selectAll<SVGLineElement, D3Link>('line')
+      .data(linksRef.current, d => d.id)
+      .join('line')
+      .attr('stroke', EDGE_COLOR)
+      .attr('stroke-width', 1.5);
+
+    nodeGroupRef.current
       .selectAll<SVGCircleElement, D3Node>('circle')
-      .data(nodesRef.current)
+      .data(nodesRef.current, d => d.id)
       .join('circle')
       .attr('r', 8)
       .attr('fill', d => d.id === socketUserId.current ? '#4f9cf9' : '#aaa')
       .attr('stroke', '#fff')
       .attr('stroke-width', 1.5)
-      .call(
-        d3.drag<SVGCircleElement, D3Node>()
-          .on('start', (event, d) => {
-            if (!event.active) sim.alphaTarget(0.3).restart();
-            d.fx = d.x; d.fy = d.y;
-          })
-          .on('drag', (event, d) => { d.fx = event.x; d.fy = event.y; })
-          .on('end', (event, d) => {
-            if (!event.active) sim.alphaTarget(0);
-            d.fx = null; d.fy = null;
-          })
-      );
+      .call(makeDrag(sim));
 
     sim.on('tick', () => {
       for (const n of nodesRef.current) {
         n.x = Math.max(padding, Math.min(width - padding, n.x ?? width / 2));
         n.y = Math.max(padding, Math.min(height - padding, n.y ?? height / 2));
       }
-      svg.selectAll<SVGLineElement, D3Link>('line')
+      linkGroupRef.current?.selectAll<SVGLineElement, D3Link>('line')
         .attr('x1', d => (d.source as D3Node).x ?? 0)
         .attr('y1', d => (d.source as D3Node).y ?? 0)
         .attr('x2', d => (d.target as D3Node).x ?? 0)
         .attr('y2', d => (d.target as D3Node).y ?? 0);
-      svg.selectAll<SVGCircleElement, D3Node>('circle')
+      nodeGroupRef.current?.selectAll<SVGCircleElement, D3Node>('circle')
         .attr('cx', d => d.x ?? 0)
         .attr('cy', d => d.y ?? 0);
     });
-
-    // suppress unused var warnings — selections are used imperatively
-    void linkSel; void nodeSel;
   }, []);
 
   useEffect(() => {

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -53,6 +53,18 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
   const liveCursorsRef = useRef<Map<string, { x: number; y: number }>>(new Map());
   const anchorsRef = useRef<ReactionAnchors>(DEFAULT_ANCHORS);
 
+  // D3 mutates link source/target from string IDs to node objects; normalize back and drop any links
+  // whose endpoints are missing from nodesRef (server/timing inconsistency guard)
+  function freshLinks(): D3Link[] {
+    const nodeIds = new Set(nodesRef.current.map(n => n.id));
+    return linksRef.current.flatMap(l => {
+      const src = typeof l.source === 'object' ? (l.source as D3Node).id : l.source as string;
+      const tgt = typeof l.target === 'object' ? (l.target as D3Node).id : l.target as string;
+      if (!nodeIds.has(src) || !nodeIds.has(tgt)) return [];
+      return [{ id: l.id, source: src, target: tgt }];
+    });
+  }
+
   function getNodeColor(uid: string): string {
     const pos = liveCursorsRef.current.get(uid);
     if (!pos) return '#888';
@@ -75,7 +87,8 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
     let nodesChanged = false;
     for (const uid of [link.source as string, link.target as string]) {
       if (!nodesRef.current.find(n => n.id === uid)) {
-        nodesRef.current = [...nodesRef.current, { id: uid }];
+        const { width, height } = sizeRef.current;
+        nodesRef.current = [...nodesRef.current, { id: uid, x: width / 2, y: height / 2 }];
         nodesChanged = true;
       }
     }
@@ -94,7 +107,7 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
     }
 
     // Add the new link and flash its color
-    linksRef.current = [...linksRef.current, link];
+    linksRef.current = [...freshLinks(), link];
     (sim.force('link') as d3.ForceLink<D3Node, D3Link>).links(linksRef.current);
 
     linkGroup
@@ -132,7 +145,9 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       } else if (msg.type === 'neighborEdgesSnapshot') {
         setEdges(msg.edges ?? []);
         const userIds = Object.keys(msg.allCodes ?? {});
-        nodesRef.current = userIds.map(id => ({ id, ...(nodesRef.current.find(n => n.id === id) ?? {}) }));
+        const { width, height } = sizeRef.current;
+        const cx = width / 2, cy = height / 2;
+        nodesRef.current = userIds.map(id => ({ id, x: cx, y: cy, ...(nodesRef.current.find(n => n.id === id) ?? {}) }));
         linksRef.current = (msg.edges ?? []).map((e: Edge) => ({
           id: `${e.userA}|${e.userB}`,
           source: e.userA,
@@ -217,6 +232,7 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
 
     svg.selectAll('*').remove();
 
+    linksRef.current = freshLinks();
     const sim = d3.forceSimulation<D3Node>(nodesRef.current)
       .force('link', d3.forceLink<D3Node, D3Link>(linksRef.current).id(d => d.id).distance(60))
       .force('charge', d3.forceManyBody().strength(-120))
@@ -248,10 +264,6 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       .call(makeDrag(sim));
 
     sim.on('tick', () => {
-      for (const n of nodesRef.current) {
-        n.x = Math.max(padding, Math.min(width - padding, n.x ?? width / 2));
-        n.y = Math.max(padding, Math.min(height - padding, n.y ?? height / 2));
-      }
       linkGroupRef.current?.selectAll<SVGLineElement, D3Link>('line')
         .attr('x1', d => (d.source as D3Node).x ?? 0)
         .attr('y1', d => (d.source as D3Node).y ?? 0)

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -1,0 +1,272 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import usePartySocket from 'partysocket/react';
+import * as d3 from 'd3';
+import { usePanelContext } from '../../../context/PanelContext';
+import { getPartySocketConfig } from '../../../utils/partyHost';
+import { generateUUID } from '../../../utils/userId';
+
+type View = 'entry' | 'graph';
+type EdgeError = 'not_found' | 'self' | 'duplicate';
+
+interface Edge { userA: string; userB: string }
+interface D3Node extends d3.SimulationNodeDatum { id: string }
+interface D3Link extends d3.SimulationLinkDatum<D3Node> { id: string }
+
+const KEYPAD_KEYS = ['1','2','3','4','5','6','7','8','9','←','0','✓'];
+
+const ERROR_MESSAGES: Record<EdgeError, string> = {
+  not_found: 'Code not found — try again',
+  self: "That's your own code",
+  duplicate: 'Already connected',
+};
+
+export default function NeighborPanel({ initialView = 'entry' as View }: { initialView?: View }) {
+  const { room, userId } = usePanelContext();
+  const socketUserId = useRef(userId ?? generateUUID());
+
+  const [view, setView] = useState<View>(initialView);
+  const [digits, setDigits] = useState('');
+  const [myCode, setMyCode] = useState<string | null>(null);
+  const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
+  const [errorReason, setErrorReason] = useState<EdgeError | null>(null);
+  const [edges, setEdges] = useState<Edge[]>([]);
+  const [allCodes, setAllCodes] = useState<Record<string, string>>({});
+
+  const svgRef = useRef<SVGSVGElement>(null);
+  const simRef = useRef<d3.Simulation<D3Node, D3Link> | null>(null);
+  const nodesRef = useRef<D3Node[]>([]);
+  const linksRef = useRef<D3Link[]>([]);
+  const statusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const socket = usePartySocket({
+    ...getPartySocketConfig(),
+    room,
+    query: { userId: socketUserId.current },
+    onMessage(evt) {
+      const msg = JSON.parse(evt.data);
+      if (msg.type === 'connected') {
+        if (msg.myNeighborCode) setMyCode(msg.myNeighborCode);
+      } else if (msg.type === 'neighborEdgesSnapshot') {
+        setEdges(msg.edges ?? []);
+        setAllCodes(msg.allCodes ?? {});
+        const userIds = Object.keys(msg.allCodes ?? {});
+        nodesRef.current = userIds.map(id => ({ id, ...(nodesRef.current.find(n => n.id === id) ?? {}) }));
+        linksRef.current = (msg.edges ?? []).map((e: Edge) => ({
+          id: `${e.userA}|${e.userB}`,
+          source: e.userA,
+          target: e.userB,
+        }));
+        restartSim();
+      } else if (msg.type === 'neighborEdgeAdded') {
+        const edge: Edge = { userA: msg.userA, userB: msg.userB };
+        setEdges(prev => [...prev, edge]);
+        const id = `${msg.userA}|${msg.userB}`;
+        if (!linksRef.current.find(l => l.id === id)) {
+          linksRef.current = [...linksRef.current, { id, source: msg.userA, target: msg.userB }];
+          for (const uid of [msg.userA, msg.userB]) {
+            if (!nodesRef.current.find(n => n.id === uid)) {
+              nodesRef.current = [...nodesRef.current, { id: uid }];
+            }
+          }
+          restartSim();
+        }
+      } else if (msg.type === 'neighborEdgesCleared') {
+        setEdges([]);
+        linksRef.current = [];
+        restartSim();
+      } else if (msg.type === 'neighborEdgeError') {
+        setErrorReason(msg.reason as EdgeError);
+        setStatus('error');
+        clearStatusTimer();
+        statusTimerRef.current = setTimeout(() => setStatus('idle'), 3000);
+      }
+    },
+  });
+
+  function clearStatusTimer() {
+    if (statusTimerRef.current) clearTimeout(statusTimerRef.current);
+  }
+
+  function submitCode(code: string) {
+    if (code.length !== 4) return;
+    socket.send(JSON.stringify({ type: 'neighborEdge', from: socketUserId.current, toCode: code }));
+    setDigits('');
+    clearStatusTimer();
+    setStatus('success');
+    statusTimerRef.current = setTimeout(() => setStatus('idle'), 2000);
+  }
+
+  function handleKey(key: string) {
+    if (key === '←') {
+      setDigits(d => d.slice(0, -1));
+      return;
+    }
+    if (key === '✓') {
+      submitCode(digits);
+      return;
+    }
+    if (digits.length >= 4) return;
+    const next = digits + key;
+    setDigits(next);
+    if (next.length === 4) submitCode(next);
+  }
+
+  function openGraph() {
+    socket.send(JSON.stringify({ type: 'requestNeighborEdges' }));
+    setView('graph');
+  }
+
+  // ===== D3 graph =====
+  const restartSim = useCallback(() => {
+    if (!svgRef.current) return;
+    const svg = d3.select(svgRef.current);
+    const width = svgRef.current.clientWidth || 320;
+    const height = svgRef.current.clientHeight || 280;
+
+    svg.selectAll('*').remove();
+
+    const sim = d3.forceSimulation<D3Node>(nodesRef.current)
+      .force('link', d3.forceLink<D3Node, D3Link>(linksRef.current).id(d => d.id).distance(60))
+      .force('charge', d3.forceManyBody().strength(-80))
+      .force('center', d3.forceCenter(width / 2, height / 2))
+      .force('collide', d3.forceCollide(14));
+    simRef.current = sim;
+
+    const linkSel = svg.append('g')
+      .selectAll<SVGLineElement, D3Link>('line')
+      .data(linksRef.current)
+      .join('line')
+      .attr('stroke', '#888')
+      .attr('stroke-width', 1.5)
+      .style('opacity', 0)
+      .transition().duration(400)
+      .style('opacity', 1);
+
+    const nodeSel = svg.append('g')
+      .selectAll<SVGCircleElement, D3Node>('circle')
+      .data(nodesRef.current)
+      .join('circle')
+      .attr('r', 8)
+      .attr('fill', d => d.id === socketUserId.current ? '#4f9cf9' : '#aaa')
+      .attr('stroke', '#fff')
+      .attr('stroke-width', 1.5)
+      .call(
+        d3.drag<SVGCircleElement, D3Node>()
+          .on('start', (event, d) => {
+            if (!event.active) sim.alphaTarget(0.3).restart();
+            d.fx = d.x; d.fy = d.y;
+          })
+          .on('drag', (event, d) => { d.fx = event.x; d.fy = event.y; })
+          .on('end', (event, d) => {
+            if (!event.active) sim.alphaTarget(0);
+            d.fx = null; d.fy = null;
+          })
+      );
+
+    sim.on('tick', () => {
+      svg.selectAll<SVGLineElement, D3Link>('line')
+        .attr('x1', d => (d.source as D3Node).x ?? 0)
+        .attr('y1', d => (d.source as D3Node).y ?? 0)
+        .attr('x2', d => (d.target as D3Node).x ?? 0)
+        .attr('y2', d => (d.target as D3Node).y ?? 0);
+      svg.selectAll<SVGCircleElement, D3Node>('circle')
+        .attr('cx', d => d.x ?? 0)
+        .attr('cy', d => d.y ?? 0);
+    });
+
+    // suppress unused var warnings — selections are used imperatively
+    void linkSel; void nodeSel;
+  }, []);
+
+  useEffect(() => {
+    if (view === 'graph') restartSim();
+    return () => { simRef.current?.stop(); };
+  }, [view, restartSim]);
+
+  useEffect(() => () => clearStatusTimer(), []);
+
+  if (view === 'graph') {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100%', padding: '12px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+          <button
+            onClick={() => setView('entry')}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#4f9cf9', fontSize: 14 }}
+          >
+            ← Back
+          </button>
+          <button
+            onClick={() => socket.send(JSON.stringify({ type: 'clearNeighborEdges' }))}
+            style={{ background: 'none', border: '1px solid #888', borderRadius: 4, cursor: 'pointer', color: '#ccc', fontSize: 12, padding: '2px 8px' }}
+          >
+            Clear all connections
+          </button>
+        </div>
+        <svg ref={svgRef} style={{ flex: 1, width: '100%', background: '#1a1a1a', borderRadius: 8 }} />
+        <p style={{ textAlign: 'center', fontSize: 11, color: '#666', marginTop: 6 }}>
+          {edges.length === 0 ? 'No connections yet' : `${edges.length} connection${edges.length === 1 ? '' : 's'}`}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '16px 12px', height: '100%' }}>
+      <div style={{ marginBottom: 12, textAlign: 'center' }}>
+        <div style={{ fontSize: 13, color: '#aaa', marginBottom: 4 }}>Your code</div>
+        <div style={{ fontSize: 36, fontWeight: 700, letterSpacing: '0.15em', fontVariantNumeric: 'tabular-nums' }}>
+          {myCode ?? '····'}
+        </div>
+      </div>
+
+      <div style={{ fontSize: 13, color: '#ccc', marginBottom: 8 }}>Enter a neighbour's code</div>
+
+      <div style={{
+        fontSize: 28,
+        fontVariantNumeric: 'tabular-nums',
+        letterSpacing: '0.2em',
+        minHeight: 40,
+        marginBottom: 10,
+        color: digits.length === 4 ? '#fff' : '#888',
+      }}>
+        {digits.padEnd(4, '·')}
+      </div>
+
+      {status === 'success' && (
+        <div style={{ color: '#4ade80', fontSize: 13, marginBottom: 8 }}>Got it!</div>
+      )}
+      {status === 'error' && errorReason && (
+        <div style={{ color: '#f87171', fontSize: 13, marginBottom: 8 }}>{ERROR_MESSAGES[errorReason]}</div>
+      )}
+      {status === 'idle' && <div style={{ height: 29, marginBottom: 8 }} />}
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 56px)', gap: 8 }}>
+        {KEYPAD_KEYS.map(key => (
+          <button
+            key={key}
+            onClick={() => handleKey(key)}
+            style={{
+              height: 52,
+              fontSize: key === '←' || key === '✓' ? 18 : 22,
+              fontWeight: 600,
+              borderRadius: 8,
+              border: '1px solid #444',
+              background: key === '✓' ? '#2563eb' : '#2a2a2a',
+              color: '#fff',
+              cursor: 'pointer',
+            }}
+          >
+            {key}
+          </button>
+        ))}
+      </div>
+
+      <button
+        onClick={openGraph}
+        style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#666', fontSize: 12, marginTop: 16, textDecoration: 'underline' }}
+      >
+        See the map →
+      </button>
+    </div>
+  );
+}

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -301,13 +301,6 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
         <div style={{ flex: 1, position: 'relative' }}>
           <svg ref={svgRef} style={{ width: '100%', height: '100%', background: '#1a1a1a', borderRadius: 8 }} />
           <div style={{ position: 'absolute', bottom: 8, right: 8, display: 'flex', alignItems: 'center', gap: 4 }}>
-            <button
-              onClick={() => restartSim()}
-              title="Refresh layout"
-              style={{ fontSize: 11, padding: '2px 6px', borderRadius: 4, border: '1px solid #444', background: 'rgba(20,20,20,0.8)', color: '#ccc', cursor: 'pointer' }}
-            >
-              ↺
-            </button>
             <input
               type="range"
               min={-180}
@@ -327,6 +320,13 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
               style={{ fontSize: 11, padding: '2px 8px', borderRadius: 4, border: '1px solid #444', background: 'rgba(20,20,20,0.8)', color: '#ccc', cursor: 'pointer' }}
             >
               ↕
+            </button>
+            <button
+              onClick={() => restartSim()}
+              title="Refresh layout"
+              style={{ fontSize: 11, padding: '2px 6px', borderRadius: 4, border: '1px solid #444', background: 'rgba(20,20,20,0.8)', color: '#ccc', cursor: 'pointer' }}
+            >
+              ↺
             </button>
           </div>
         </div>

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -12,7 +12,7 @@ interface Edge { userA: string; userB: string }
 interface D3Node extends d3.SimulationNodeDatum { id: string }
 interface D3Link extends d3.SimulationLinkDatum<D3Node> { id: string }
 
-const KEYPAD_KEYS = ['1','2','3','4','5','6','7','8','9','←','0','✓'];
+const KEYPAD_KEYS = ['1','2','3','4','5','6','7','8','9','←','0','✕'];
 const EDGE_COLOR = '#555';
 const EDGE_FLASH_COLOR = '#4ade80';
 const EDGE_FLASH_MS = 800;
@@ -145,8 +145,8 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       setDigits(d => d.slice(0, -1));
       return;
     }
-    if (key === '✓') {
-      submitCode(digits);
+    if (key === '✕') {
+      setDigits('');
       return;
     }
     if (digits.length >= 4) return;
@@ -262,7 +262,7 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
   }
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '16px 12px', height: '100%' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '16px 12px', height: '100%', position: 'relative' }}>
       <div style={{ marginBottom: 12, textAlign: 'center' }}>
         <div style={{ fontSize: 13, color: '#aaa', marginBottom: 4 }}>Your code</div>
         <div style={{ fontSize: 36, fontWeight: 700, letterSpacing: '0.15em', fontVariantNumeric: 'tabular-nums' }}>
@@ -298,11 +298,11 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
             onClick={() => handleKey(key)}
             style={{
               height: 52,
-              fontSize: key === '←' || key === '✓' ? 18 : 22,
+              fontSize: key === '←' || key === '✕' ? 18 : 22,
               fontWeight: 600,
               borderRadius: 8,
               border: '1px solid #444',
-              background: key === '✓' ? '#2563eb' : '#2a2a2a',
+              background: '#2a2a2a',
               color: '#fff',
               cursor: 'pointer',
             }}
@@ -314,9 +314,9 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
 
       <button
         onClick={openGraph}
-        style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#666', fontSize: 12, marginTop: 16, textDecoration: 'underline' }}
+        style={{ position: 'absolute', bottom: 10, right: 12, background: 'none', border: 'none', cursor: 'pointer', color: '#444', fontSize: 11, textDecoration: 'underline', opacity: 0.5 }}
       >
-        See the map →
+        map
       </button>
     </div>
   );

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -54,7 +54,6 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
   const anchorsRef = useRef<ReactionAnchors>(DEFAULT_ANCHORS);
 
   function getNodeColor(uid: string): string {
-    if (uid === socketUserId.current) return '#4f9cf9';
     const pos = liveCursorsRef.current.get(uid);
     if (!pos) return '#888';
     const region = computeReactionRegion(pos.x, pos.y, anchorsRef.current);

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -149,6 +149,7 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
           nodesRef.current = [...nodesRef.current, { id: uid, x: width / 2, y: height / 2 }];
           restartSim();
         }
+        socket.send(JSON.stringify({ type: 'requestNeighborEdges' }));
       } else if (msg.type === 'userLeft') {
         const uid: string = msg.userId;
         liveCursorsRef.current.delete(uid);

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -142,12 +142,26 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       } else if (msg.type === 'remove') {
         liveCursorsRef.current.delete(msg.position.userId);
         updateNodeColors();
+      } else if (msg.type === 'userJoined') {
+        const uid: string = msg.userId;
+        if (!nodesRef.current.find(n => n.id === uid)) {
+          const { width, height } = sizeRef.current;
+          nodesRef.current = [...nodesRef.current, { id: uid, x: width / 2, y: height / 2 }];
+          restartSim();
+        }
+      } else if (msg.type === 'userLeft') {
+        const uid: string = msg.userId;
+        liveCursorsRef.current.delete(uid);
+        nodesRef.current = nodesRef.current.filter(n => n.id !== uid);
+        linksRef.current = freshLinks().filter(l => l.source !== uid && l.target !== uid);
+        restartSim();
       } else if (msg.type === 'neighborEdgesSnapshot') {
         setEdges(msg.edges ?? []);
-        const userIds = Object.keys(msg.allCodes ?? {});
+        const edgeUserIds = (msg.edges ?? []).flatMap((e: Edge) => [e.userA, e.userB]);
+        const allIds = [...new Set([...Object.keys(msg.allCodes ?? {}), ...edgeUserIds])];
         const { width, height } = sizeRef.current;
         const cx = width / 2, cy = height / 2;
-        nodesRef.current = userIds.map(id => ({ id, x: cx, y: cy, ...(nodesRef.current.find(n => n.id === id) ?? {}) }));
+        nodesRef.current = allIds.map(id => ({ id, x: cx, y: cy, ...(nodesRef.current.find(n => n.id === id) ?? {}) }));
         linksRef.current = (msg.edges ?? []).map((e: Edge) => ({
           id: `${e.userA}|${e.userB}`,
           source: e.userA,
@@ -159,11 +173,20 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
         setEdges(prev => [...prev, edge]);
         const id = `${msg.userA}|${msg.userB}`;
         if (!linksRef.current.find(l => l.id === id)) {
-          addEdgeLive({ id, source: msg.userA, target: msg.userB });
+          const { width, height } = sizeRef.current;
+          const cx = width / 2, cy = height / 2;
+          for (const uid of [msg.userA, msg.userB]) {
+            if (!nodesRef.current.find(n => n.id === uid)) {
+              nodesRef.current = [...nodesRef.current, { id: uid, x: cx, y: cy }];
+            }
+          }
+          linksRef.current = [...freshLinks(), { id, source: msg.userA, target: msg.userB }];
+          restartSim();
         }
       } else if (msg.type === 'neighborEdgesCleared') {
         setEdges([]);
         linksRef.current = [];
+        nodesRef.current = [];
         restartSim();
       } else if (msg.type === 'neighborEdgeError') {
         setErrorReason(msg.reason as EdgeError);

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -174,15 +174,7 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
         setEdges(prev => [...prev, edge]);
         const id = `${msg.userA}|${msg.userB}`;
         if (!linksRef.current.find(l => l.id === id)) {
-          const { width, height } = sizeRef.current;
-          const cx = width / 2, cy = height / 2;
-          for (const uid of [msg.userA, msg.userB]) {
-            if (!nodesRef.current.find(n => n.id === uid)) {
-              nodesRef.current = [...nodesRef.current, { id: uid, x: cx, y: cy }];
-            }
-          }
-          linksRef.current = [...freshLinks(), { id, source: msg.userA, target: msg.userB }];
-          restartSim();
+          addEdgeLive({ id, source: msg.userA, target: msg.userB });
         }
       } else if (msg.type === 'neighborEdgesCleared') {
         setEdges([]);

--- a/app/components/panels/NeighborPanel/index.tsx
+++ b/app/components/panels/NeighborPanel/index.tsx
@@ -6,19 +6,16 @@ import { getPartySocketConfig } from '../../../utils/partyHost';
 import { generateUUID } from '../../../utils/userId';
 import { computeReactionRegion, DEFAULT_ANCHORS } from '../../../utils/voteRegion';
 import type { ReactionAnchors } from '../../../utils/voteRegion';
+import { VOTE_COLORS, USER_STATUS_COLORS, EDGE_COLOR, EDGE_FLASH_COLOR, EDGE_FLASH_MS } from '../../../constants/userStatus';
 
 type View = 'entry' | 'graph';
 type EdgeError = 'not_found' | 'self' | 'duplicate';
 
 interface Edge { userA: string; userB: string }
-interface D3Node extends d3.SimulationNodeDatum { id: string }
+interface D3Node extends d3.SimulationNodeDatum { id: string; offline?: boolean }
 interface D3Link extends d3.SimulationLinkDatum<D3Node> { id: string }
 
 const KEYPAD_KEYS = ['1','2','3','4','5','6','7','8','9','←','0','✕'];
-const EDGE_COLOR = '#555';
-const EDGE_FLASH_COLOR = '#4ade80';
-const EDGE_FLASH_MS = 800;
-const VOTE_COLORS = { positive: '#2ecc71', negative: '#e74c3c', neutral: '#f1c40f' };
 
 const ERROR_MESSAGES: Record<EdgeError, string> = {
   not_found: 'Code not found — try again',
@@ -39,6 +36,8 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
   const [flipH, setFlipH] = useState(false);
   const [flipV, setFlipV] = useState(false);
   const [rotation, setRotation] = useState(0);
+  const [showOffline, setShowOffline] = useState(true);
+  const showOfflineRef = useRef(true);
 
   const svgRef = useRef<SVGSVGElement>(null);
   const simRef = useRef<d3.Simulation<D3Node, D3Link> | null>(null);
@@ -65,16 +64,34 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
     });
   }
 
-  function getNodeColor(uid: string): string {
-    const pos = liveCursorsRef.current.get(uid);
-    if (!pos) return '#888';
+  function getNodeColor(node: D3Node): string {
+    if (node.offline) return USER_STATUS_COLORS.offline;
+    const pos = liveCursorsRef.current.get(node.id);
+    if (!pos) return USER_STATUS_COLORS.idle;
     const region = computeReactionRegion(pos.x, pos.y, anchorsRef.current);
-    return region ? VOTE_COLORS[region] : '#888';
+    return region ? VOTE_COLORS[region] : USER_STATUS_COLORS.idle;
+  }
+
+  function getLinkDisplay(d: D3Link): string | null {
+    if (showOfflineRef.current) return null;
+    const srcId = typeof d.source === 'object' ? (d.source as D3Node).id : d.source as string;
+    const tgtId = typeof d.target === 'object' ? (d.target as D3Node).id : d.target as string;
+    const srcOffline = nodesRef.current.find(n => n.id === srcId)?.offline;
+    const tgtOffline = nodesRef.current.find(n => n.id === tgtId)?.offline;
+    return (srcOffline || tgtOffline) ? 'none' : null;
   }
 
   function updateNodeColors() {
     nodeGroupRef.current?.selectAll<SVGCircleElement, D3Node>('circle')
-      .attr('fill', d => getNodeColor(d.id));
+      .attr('fill', d => getNodeColor(d));
+  }
+
+  function updateVisibility() {
+    const show = showOfflineRef.current;
+    nodeGroupRef.current?.selectAll<SVGCircleElement, D3Node>('circle')
+      .attr('display', d => (!show && d.offline) ? 'none' : null);
+    linkGroupRef.current?.selectAll<SVGLineElement, D3Link>('line')
+      .attr('display', d => getLinkDisplay(d));
   }
 
   function addNodeLive(uid: string) {
@@ -85,8 +102,9 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
     nodeGroup.selectAll<SVGCircleElement, D3Node>('circle')
       .data(nodesRef.current, d => d.id)
       .join(enter => enter.append('circle')
-        .attr('r', 8).attr('fill', d => getNodeColor(d.id))
+        .attr('r', 8).attr('fill', d => getNodeColor(d))
         .attr('stroke', '#fff').attr('stroke-width', 1.5)
+        .attr('display', d => (!showOfflineRef.current && d.offline) ? 'none' : null)
         .call(makeDrag(sim))
       );
     sim.alpha(0.3).restart();
@@ -114,9 +132,10 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
         .data(nodesRef.current, d => d.id)
         .join(enter => enter.append('circle')
           .attr('r', 8)
-          .attr('fill', d => getNodeColor(d.id))
+          .attr('fill', d => getNodeColor(d))
           .attr('stroke', '#fff')
           .attr('stroke-width', 1.5)
+          .attr('display', d => (!showOfflineRef.current && d.offline) ? 'none' : null)
           .call(makeDrag(sim))
         );
     }
@@ -131,6 +150,7 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       .join(enter => enter.append('line')
         .attr('stroke', EDGE_FLASH_COLOR)
         .attr('stroke-width', 1.5)
+        .attr('display', d => getLinkDisplay(d))
         .transition().duration(EDGE_FLASH_MS)
         .attr('stroke', EDGE_COLOR)
       );
@@ -159,7 +179,15 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
         updateNodeColors();
       } else if (msg.type === 'userJoined') {
         const uid: string = msg.userId;
-        if (!nodesRef.current.find(n => n.id === uid)) {
+        const existing = nodesRef.current.find(n => n.id === uid);
+        if (existing) {
+          existing.offline = false;
+          nodeGroupRef.current?.selectAll<SVGCircleElement, D3Node>('circle')
+            .filter(d => d.id === uid)
+            .attr('fill', getNodeColor(existing))
+            .attr('display', null);
+          updateVisibility();
+        } else {
           const { width, height } = sizeRef.current;
           nodesRef.current = [...nodesRef.current, { id: uid, x: width / 2, y: height / 2 }];
           addNodeLive(uid);
@@ -168,9 +196,15 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       } else if (msg.type === 'userLeft') {
         const uid: string = msg.userId;
         liveCursorsRef.current.delete(uid);
-        nodesRef.current = nodesRef.current.filter(n => n.id !== uid);
-        linksRef.current = freshLinks().filter(l => l.source !== uid && l.target !== uid);
-        restartSim();
+        const node = nodesRef.current.find(n => n.id === uid);
+        if (node) {
+          node.offline = true;
+          nodeGroupRef.current?.selectAll<SVGCircleElement, D3Node>('circle')
+            .filter(d => d.id === uid)
+            .attr('fill', USER_STATUS_COLORS.offline)
+            .attr('display', showOfflineRef.current ? null : 'none');
+          updateVisibility();
+        }
       } else if (msg.type === 'neighborEdgesSnapshot') {
         setEdges(msg.edges ?? []);
         const edgeUserIds = (msg.edges ?? []).flatMap((e: Edge) => [e.userA, e.userB]);
@@ -194,8 +228,9 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
             nodeGroup.selectAll<SVGCircleElement, D3Node>('circle')
               .data(nodesRef.current, d => d.id)
               .join(enter => enter.append('circle')
-                .attr('r', 8).attr('fill', d => getNodeColor(d.id))
+                .attr('r', 8).attr('fill', d => getNodeColor(d))
                 .attr('stroke', '#fff').attr('stroke-width', 1.5)
+                .attr('display', d => (!showOfflineRef.current && d.offline) ? 'none' : null)
                 .call(makeDrag(sim))
               );
           }
@@ -207,7 +242,10 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
             (sim.force('link') as d3.ForceLink<D3Node, D3Link>).links(linksRef.current);
             linkGroup.selectAll<SVGLineElement, D3Link>('line')
               .data(linksRef.current, d => d.id)
-              .join(enter => enter.append('line').attr('stroke', EDGE_COLOR).attr('stroke-width', 1.5));
+              .join(enter => enter.append('line')
+                .attr('stroke', EDGE_COLOR).attr('stroke-width', 1.5)
+                .attr('display', d => getLinkDisplay(d))
+              );
             sim.alpha(0.3).restart();
           }
         } else {
@@ -315,16 +353,18 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       .data(linksRef.current, d => d.id)
       .join('line')
       .attr('stroke', EDGE_COLOR)
-      .attr('stroke-width', 1.5);
+      .attr('stroke-width', 1.5)
+      .attr('display', d => getLinkDisplay(d));
 
     nodeGroupRef.current
       .selectAll<SVGCircleElement, D3Node>('circle')
       .data(nodesRef.current, d => d.id)
       .join('circle')
       .attr('r', 8)
-      .attr('fill', d => getNodeColor(d.id))
+      .attr('fill', d => getNodeColor(d))
       .attr('stroke', '#fff')
       .attr('stroke-width', 1.5)
+      .attr('display', d => (!showOfflineRef.current && d.offline) ? 'none' : null)
       .call(makeDrag(sim));
 
     sim.on('tick', () => {
@@ -367,12 +407,28 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
           >
             ← Back
           </button>
-          <button
-            onClick={() => socket.send(JSON.stringify({ type: 'clearNeighborEdges' }))}
-            style={{ background: 'none', border: '1px solid #888', borderRadius: 4, cursor: 'pointer', color: '#ccc', fontSize: 12, padding: '2px 8px' }}
-          >
-            Clear all connections
-          </button>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <label style={{ color: '#ccc', fontSize: 12, display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}>
+              <input
+                type="checkbox"
+                checked={showOffline}
+                onChange={e => {
+                  const val = e.target.checked;
+                  setShowOffline(val);
+                  showOfflineRef.current = val;
+                  updateVisibility();
+                }}
+                style={{ cursor: 'pointer' }}
+              />
+              show offline
+            </label>
+            <button
+              onClick={() => socket.send(JSON.stringify({ type: 'clearNeighborEdges' }))}
+              style={{ background: 'none', border: '1px solid #888', borderRadius: 4, cursor: 'pointer', color: '#ccc', fontSize: 12, padding: '2px 8px' }}
+            >
+              Clear all connections
+            </button>
+          </div>
         </div>
         <div style={{ flex: 1, position: 'relative' }}>
           <svg ref={svgRef} style={{ width: '100%', height: '100%', background: '#1a1a1a', borderRadius: 8 }} />

--- a/app/constants/userStatus.ts
+++ b/app/constants/userStatus.ts
@@ -1,0 +1,21 @@
+export const VOTE_COLORS = {
+  positive: '#2ecc71',
+  negative: '#e74c3c',
+  neutral:  '#f1c40f',
+} as const;
+
+export const USER_STATUS_COLORS = {
+  idle:    '#888',   // connected WebSocket, no active cursor
+  offline: '#333',   // WebSocket disconnected, was in graph
+} as const;
+
+export const USER_STATUS_LABELS = {
+  idle:    'idle',
+  offline: 'offline',
+} as const;
+
+export const MISSING_COLOR = '#b0b0b0';
+
+export const EDGE_COLOR       = '#555';
+export const EDGE_FLASH_COLOR = '#4ade80';
+export const EDGE_FLASH_MS    = 800;

--- a/app/panelRegistry.ts
+++ b/app/panelRegistry.ts
@@ -28,6 +28,7 @@ export const PANEL_REGISTRY: PanelMeta[] = [
   { id: 'map-viewer',      label: 'Map Viewer',      description: 'View the computed participant map',                     patchable: true,  activityMode: true  },
   { id: 'valence-beat-pad', label: 'Valence Beat Pad', shortLabel: 'Beat Pad', description: 'Interactive musical pad driven by audience valence', patchable: true, activityMode: true },
   { id: 'arrival-canvas', label: 'Arrival Canvas', shortLabel: 'Arrival', description: 'Room-fill visualizer with THX-style audio convergence', patchable: true, activityMode: true },
+  { id: 'neighbor', label: 'Neighbor Network', shortLabel: 'Neighbor', description: 'Social graph of nearby audience members', patchable: true, activityMode: true },
 ];
 
 export const PATCHABLE_PANELS = PANEL_REGISTRY.filter(p => p.patchable);

--- a/app/types.ts
+++ b/app/types.ts
@@ -28,7 +28,7 @@ export interface Statement {
   text: string;
 }
 
-export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social-sharing' | 'mood-tones' | 'treevites' | 'greeter' | 'signature' | 'steno' | 'story-tracer' | 'voice-call' | 'map-maker' | 'map-viewer' | 'valence-beat-pad' | 'arrival-canvas';
+export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social-sharing' | 'mood-tones' | 'treevites' | 'greeter' | 'signature' | 'steno' | 'story-tracer' | 'voice-call' | 'map-maker' | 'map-viewer' | 'valence-beat-pad' | 'arrival-canvas' | 'neighbor';
 
 export interface MapProjection {
   coords: [string, [number, number]][];

--- a/party/server.ts
+++ b/party/server.ts
@@ -274,7 +274,11 @@ interface HangUpCallEvent      { type: 'hangUp';        targetUserId: string }
 interface SetCallAlgorithmEvent { type: 'setCallAlgorithm'; algorithm: string }
 interface SetArrivalCapacityEvent { type: 'setArrivalCapacity'; capacity: number }
 
-type ClientEvent =CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | SetGreeterConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent | RegisterCustomAvatarEvent | SetColorCursorsByVoteEvent | SetDefaultCursorColorEvent | SetOwnValenceDisplayEvent | SetValenceInputModeEvent | StrokeSegmentEvent | ClearSignatureEvent | StenoStartRecordingEvent | StenoStopRecordingEvent | StenoAppendTextEvent | StenoSetTextEvent | StoryTracerSetPointsEvent | StoryTracerClearPointsEvent | MapProjectionSetEvent | MapProjectionClearEvent | JoinCallQueueEvent | LeaveCallQueueEvent | WebRTCOfferEvent | WebRTCAnswerEvent | WebRTCIceEvent | HangUpCallEvent | SetCallAlgorithmEvent | SetArrivalCapacityEvent;
+interface NeighborEdgeEvent      { type: 'neighborEdge';         from: string; toCode: string }
+interface RequestNeighborEdgesEvent { type: 'requestNeighborEdges' }
+interface ClearNeighborEdgesEvent   { type: 'clearNeighborEdges' }
+
+type ClientEvent =CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | SetGreeterConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent | RegisterCustomAvatarEvent | SetColorCursorsByVoteEvent | SetDefaultCursorColorEvent | SetOwnValenceDisplayEvent | SetValenceInputModeEvent | StrokeSegmentEvent | ClearSignatureEvent | StenoStartRecordingEvent | StenoStopRecordingEvent | StenoAppendTextEvent | StenoSetTextEvent | StoryTracerSetPointsEvent | StoryTracerClearPointsEvent | MapProjectionSetEvent | MapProjectionClearEvent | JoinCallQueueEvent | LeaveCallQueueEvent | WebRTCOfferEvent | WebRTCAnswerEvent | WebRTCIceEvent | HangUpCallEvent | SetCallAlgorithmEvent | SetArrivalCapacityEvent | NeighborEdgeEvent | RequestNeighborEdgesEvent | ClearNeighborEdgesEvent;
 
 // ===== REACTION REGION HELPER (mirrors app/utils/voteRegion.ts) =====
 const DEFAULT_ANCHORS = {
@@ -358,6 +362,8 @@ export default class Server implements Party.Server {
   private callPairs: Map<string, string> = new Map();
   private callAlgorithm: string = 'first-available';
   private arrivalCapacity: number = 50;
+  private neighborCodes = new Map<string, string>(); // userId → 4-digit code
+  private neighborEdges = new Set<string>();          // canonical "userA|userB" strings
 
   // ===== GHOST CURSOR DEMO CODE (can be easily removed) =====
   private ghostCursorsEnabled: boolean = false;
@@ -414,6 +420,15 @@ export default class Server implements Party.Server {
     if (saved.storyTracerMeta !== undefined) this.storyTracerMeta = saved.storyTracerMeta ?? null;
     if (saved.greeterConfig !== undefined) this.greeterConfig = saved.greeterConfig ?? null;
     if (saved.mapProjection !== undefined) this.mapProjection = saved.mapProjection ?? null;
+  }
+
+  private generateNeighborCode(): string {
+    const used = new Set(this.neighborCodes.values());
+    let code: string;
+    do {
+      code = String(Math.floor(Math.random() * 10000)).padStart(4, '0');
+    } while (used.has(code));
+    return code;
   }
 
   private async persistState(): Promise<void> {
@@ -496,6 +511,9 @@ export default class Server implements Party.Server {
 
     const userId = url.searchParams.get('userId') ?? conn.id;
     this.connectionUserMap.set(conn.id, userId);
+    if (!this.neighborCodes.has(userId)) {
+      this.neighborCodes.set(userId, this.generateNeighborCode());
+    }
     if (isViewer) {
       this.viewerConnectionIds.add(conn.id);
     }
@@ -568,6 +586,7 @@ export default class Server implements Party.Server {
       mapProjection: this.mapProjection,
       callAlgorithm: this.callAlgorithm,
       arrivalCapacity: this.arrivalCapacity,
+      myNeighborCode: this.neighborCodes.get(userId) ?? null,
     }));
   }
 
@@ -585,7 +604,10 @@ export default class Server implements Party.Server {
       ? [...this.connectionUserMap.values()].some(uid => uid === userId)
       : false;
 
-    if (userId && !userStillConnected) this.cursorPositions.delete(userId);
+    if (userId && !userStillConnected) {
+      this.cursorPositions.delete(userId);
+      this.neighborCodes.delete(userId);
+    }
 
     if (!isAdmin && userId && !userStillConnected) {
       this.room.broadcast(JSON.stringify({ type: 'userLeft', userId, wasViewer }));
@@ -901,6 +923,37 @@ export default class Server implements Party.Server {
         if (!this.adminConnectionIds.has(sender.id)) return;
         this.arrivalCapacity = event.capacity;
         this.room.broadcast(JSON.stringify({ type: 'arrivalCapacityChanged', capacity: this.arrivalCapacity }));
+      } else if (event.type === 'neighborEdge') {
+        const fromUserId = this.connectionUserMap.get(sender.id);
+        if (!fromUserId) return;
+        const toCode = event.toCode;
+        if (this.neighborCodes.get(fromUserId) === toCode) {
+          sender.send(JSON.stringify({ type: 'neighborEdgeError', reason: 'self' }));
+          return;
+        }
+        let toUserId: string | null = null;
+        for (const [uid, code] of this.neighborCodes) {
+          if (code === toCode) { toUserId = uid; break; }
+        }
+        if (!toUserId) {
+          sender.send(JSON.stringify({ type: 'neighborEdgeError', reason: 'not_found' }));
+          return;
+        }
+        const canonical = [fromUserId, toUserId].sort().join('|');
+        if (this.neighborEdges.has(canonical)) {
+          sender.send(JSON.stringify({ type: 'neighborEdgeError', reason: 'duplicate' }));
+          return;
+        }
+        this.neighborEdges.add(canonical);
+        const [userA, userB] = canonical.split('|');
+        this.room.broadcast(JSON.stringify({ type: 'neighborEdgeAdded', userA, userB }));
+      } else if (event.type === 'requestNeighborEdges') {
+        const edges = [...this.neighborEdges].map(e => { const [userA, userB] = e.split('|'); return { userA, userB }; });
+        const allCodes = Object.fromEntries(this.neighborCodes);
+        sender.send(JSON.stringify({ type: 'neighborEdgesSnapshot', edges, allCodes }));
+      } else if (event.type === 'clearNeighborEdges') {
+        this.neighborEdges.clear();
+        this.room.broadcast(JSON.stringify({ type: 'neighborEdgesCleared' }));
       }
     } catch (e) {
       console.error('Failed to parse event:', e);

--- a/stories/NeighborPanel.stories.tsx
+++ b/stories/NeighborPanel.stories.tsx
@@ -1,0 +1,229 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import React, { useEffect } from 'react';
+import NeighborPanel from '../app/components/panels/NeighborPanel';
+import { PanelContextProvider } from '../app/context/PanelContext';
+import { emitToRoom } from '../.storybook/mocks/partysocket-react';
+
+const ROOM = 'storybook-neighbor';
+
+const meta = {
+  title: 'Panels/NeighborPanel',
+  component: NeighborPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story, ctx) => (
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <PanelContextProvider value={ctx.args as never}>
+          <Story />
+        </PanelContextProvider>
+      </div>
+    ),
+  ],
+  args: {
+    room: ROOM,
+    userId: 'user-0-0',
+    inviteEdges: {},
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ===== Grid helper =====
+function makeCode(n: number) {
+  return String(n).padStart(4, '0');
+}
+
+function generateGrid(rows: number, cols: number) {
+  return Array.from({ length: rows * cols }, (_, i) => ({
+    userId: `user-${Math.floor(i / cols)}-${i % cols}`,
+    code: makeCode(i + 1),
+    row: Math.floor(i / cols),
+    col: i % cols,
+    rows,
+    cols,
+  }));
+}
+
+// Ease-in-out cubic
+function easeInOut(t: number) {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
+
+function easedDelay(index: number, total: number, totalMs: number) {
+  const t = index / Math.max(total - 1, 1);
+  return easeInOut(t) * totalMs;
+}
+
+// ===== 2-neighbour driver =====
+function TwoNeighbourDriver({ room, rows, cols }: { room: string; rows: number; cols: number }) {
+  useEffect(() => {
+    const seats = generateGrid(rows, cols);
+    const allCodes = Object.fromEntries(seats.map(s => [s.userId, s.code]));
+
+    const edges: Array<{ userA: string; userB: string }> = [];
+    const edgeSet = new Set<string>();
+
+    for (const seat of seats) {
+      const candidates: Array<{ userId: string }> = [];
+      // left or right (one of them, random)
+      const lr = [
+        seat.col > 0 ? seats[seat.row * cols + seat.col - 1] : null,
+        seat.col < cols - 1 ? seats[seat.row * cols + seat.col + 1] : null,
+      ].filter(Boolean) as typeof seats;
+      if (lr.length) candidates.push(lr[Math.floor(Math.random() * lr.length)]);
+      // front or back (one of them, random)
+      const fb = [
+        seat.row > 0 ? seats[(seat.row - 1) * cols + seat.col] : null,
+        seat.row < rows - 1 ? seats[(seat.row + 1) * cols + seat.col] : null,
+      ].filter(Boolean) as typeof seats;
+      if (fb.length) candidates.push(fb[Math.floor(Math.random() * fb.length)]);
+
+      for (const target of candidates) {
+        const key = [seat.userId, target.userId].sort().join('|');
+        if (!edgeSet.has(key)) {
+          edgeSet.add(key);
+          const [userA, userB] = key.split('|');
+          edges.push({ userA, userB });
+        }
+      }
+    }
+
+    const TOTAL_MS = 18000;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+
+    const raf = requestAnimationFrame(() => {
+      emitToRoom(room, { type: 'connected', myNeighborCode: '0001' });
+      emitToRoom(room, { type: 'neighborEdgesSnapshot', edges: [], allCodes });
+
+      edges.forEach((edge, i) => {
+        const delay = easedDelay(i, edges.length, TOTAL_MS) + Math.random() * 200;
+        timers.push(setTimeout(() => {
+          emitToRoom(room, { type: 'neighborEdgeAdded', userA: edge.userA, userB: edge.userB });
+        }, delay));
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(raf);
+      timers.forEach(clearTimeout);
+    };
+  }, [room, rows, cols]);
+  return null;
+}
+
+// ===== 3-neighbour driver =====
+function ThreeNeighbourDriver({ room, rows, cols }: { room: string; rows: number; cols: number }) {
+  useEffect(() => {
+    const seats = generateGrid(rows, cols);
+    const allCodes = Object.fromEntries(seats.map(s => [s.userId, s.code]));
+
+    const edges: Array<{ userA: string; userB: string }> = [];
+    const edgeSet = new Set<string>();
+
+    for (const seat of seats) {
+      const allAdjacent = [
+        // cardinal
+        seat.col > 0 ? seats[seat.row * cols + seat.col - 1] : null,
+        seat.col < cols - 1 ? seats[seat.row * cols + seat.col + 1] : null,
+        seat.row > 0 ? seats[(seat.row - 1) * cols + seat.col] : null,
+        seat.row < rows - 1 ? seats[(seat.row + 1) * cols + seat.col] : null,
+        // diagonals
+        seat.row > 0 && seat.col > 0 ? seats[(seat.row - 1) * cols + seat.col - 1] : null,
+        seat.row > 0 && seat.col < cols - 1 ? seats[(seat.row - 1) * cols + seat.col + 1] : null,
+        seat.row < rows - 1 && seat.col > 0 ? seats[(seat.row + 1) * cols + seat.col - 1] : null,
+        seat.row < rows - 1 && seat.col < cols - 1 ? seats[(seat.row + 1) * cols + seat.col + 1] : null,
+      ].filter(Boolean) as typeof seats;
+
+      // shuffle and take up to 3
+      const shuffled = allAdjacent.sort(() => Math.random() - 0.5).slice(0, 3);
+      for (const target of shuffled) {
+        const key = [seat.userId, target.userId].sort().join('|');
+        if (!edgeSet.has(key)) {
+          edgeSet.add(key);
+          const [userA, userB] = key.split('|');
+          edges.push({ userA, userB });
+        }
+      }
+    }
+
+    const TOTAL_MS = 20000;
+    const timers: ReturnType<typeof setTimeout>[] = [];
+
+    const raf = requestAnimationFrame(() => {
+      emitToRoom(room, { type: 'connected', myNeighborCode: '0001' });
+      emitToRoom(room, { type: 'neighborEdgesSnapshot', edges: [], allCodes });
+
+      edges.forEach((edge, i) => {
+        const delay = easedDelay(i, edges.length, TOTAL_MS) + Math.random() * 200;
+        timers.push(setTimeout(() => {
+          emitToRoom(room, { type: 'neighborEdgeAdded', userA: edge.userA, userB: edge.userB });
+        }, delay));
+      });
+    });
+
+    return () => {
+      cancelAnimationFrame(raf);
+      timers.forEach(clearTimeout);
+    };
+  }, [room, rows, cols]);
+  return null;
+}
+
+// ===== Stories =====
+
+export const EntryView: Story = {
+  name: 'Entry view (default)',
+  render: (args) => {
+    const room = (args as any).room ?? ROOM;
+    return (
+      <>
+        <EntryDriver room={room} />
+        <NeighborPanel />
+      </>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Your code')).toBeInTheDocument();
+    await expect(canvas.getByText("Enter a neighbour's code")).toBeInTheDocument();
+  },
+};
+
+function EntryDriver({ room }: { room: string }) {
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      emitToRoom(room, { type: 'connected', myNeighborCode: '4827' });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [room]);
+  return null;
+}
+
+export const TwoNeighbourScan: Story = {
+  name: '2-neighbour scan (graph view)',
+  render: (args) => {
+    const room = (args as any).room ?? ROOM;
+    return (
+      <>
+        <TwoNeighbourDriver room={room} rows={5} cols={6} />
+        <NeighborPanel initialView="graph" />
+      </>
+    );
+  },
+};
+
+export const ThreeNeighbourScan: Story = {
+  name: '3-neighbour scan (graph view)',
+  render: (args) => {
+    const room = (args as any).room ?? ROOM;
+    return (
+      <>
+        <ThreeNeighbourDriver room={room} rows={5} cols={6} />
+        <NeighborPanel initialView="graph" />
+      </>
+    );
+  },
+};

--- a/stories/NeighborPanel.stories.tsx
+++ b/stories/NeighborPanel.stories.tsx
@@ -7,6 +7,8 @@ import { emitToRoom } from '../.storybook/mocks/partysocket-react';
 
 const ROOM = 'storybook-neighbor';
 
+type Strategy = 'cardinal' | 'all';
+
 const meta = {
   title: 'Panels/NeighborPanel',
   component: NeighborPanel,
@@ -22,7 +24,9 @@ const meta = {
     ),
   ],
   argTypes: {
-    totalMs: { control: { type: 'number', min: 1000, step: 1000 }, description: 'Total animation duration (ms)' },
+    totalMs:   { control: { type: 'number', min: 1000, step: 1000 }, description: 'Total animation duration (ms)' },
+    neighbors: { control: { type: 'number', min: 0, max: 8, step: 0.5 }, description: 'Neighbours per person — integer = exact count, fraction = probability of one more (e.g. 2.7 = always 2, 70% chance of 3)' },
+    strategy:  { control: { type: 'select' }, options: ['cardinal', 'all'] as Strategy[], description: '"cardinal" scans only up/down/left/right; "all" also includes diagonals' },
   },
   args: {
     room: ROOM,
@@ -39,7 +43,9 @@ function makeCode(n: number) {
   return String(n).padStart(4, '0');
 }
 
-function generateGrid(rows: number, cols: number) {
+type Seat = { userId: string; code: string; row: number; col: number; rows: number; cols: number };
+
+function generateGrid(rows: number, cols: number): Seat[] {
   return Array.from({ length: rows * cols }, (_, i) => ({
     userId: `user-${Math.floor(i / cols)}-${i % cols}`,
     code: makeCode(i + 1),
@@ -48,6 +54,23 @@ function generateGrid(rows: number, cols: number) {
     rows,
     cols,
   }));
+}
+
+function getAdjacent(seat: Seat, seats: Seat[], strategy: Strategy): Seat[] {
+  const { row, col, rows, cols } = seat;
+  const cardinal = [
+    row > 0             ? seats[(row - 1) * cols + col]     : null,
+    row < rows - 1      ? seats[(row + 1) * cols + col]     : null,
+    col > 0             ? seats[row * cols + col - 1]       : null,
+    col < cols - 1      ? seats[row * cols + col + 1]       : null,
+  ];
+  const diagonals = strategy === 'all' ? [
+    row > 0 && col > 0             ? seats[(row - 1) * cols + col - 1] : null,
+    row > 0 && col < cols - 1      ? seats[(row - 1) * cols + col + 1] : null,
+    row < rows - 1 && col > 0      ? seats[(row + 1) * cols + col - 1] : null,
+    row < rows - 1 && col < cols - 1 ? seats[(row + 1) * cols + col + 1] : null,
+  ] : [];
+  return [...cardinal, ...diagonals].filter(Boolean) as Seat[];
 }
 
 // Ease-in-out cubic
@@ -60,8 +83,22 @@ function easedDelay(index: number, total: number, totalMs: number) {
   return easeInOut(t) * totalMs;
 }
 
-// ===== 2-neighbour driver =====
-function TwoNeighbourDriver({ room, rows, cols, totalMs = 8000 }: { room: string; rows: number; cols: number; totalMs?: number }) {
+// ===== Unified graph driver =====
+function GraphDriver({
+  room,
+  rows,
+  cols,
+  neighbors = 2,
+  strategy = 'cardinal',
+  totalMs = 8000,
+}: {
+  room: string;
+  rows: number;
+  cols: number;
+  neighbors?: number;
+  strategy?: Strategy;
+  totalMs?: number;
+}) {
   useEffect(() => {
     const seats = generateGrid(rows, cols);
     const allCodes = Object.fromEntries(seats.map(s => [s.userId, s.code]));
@@ -69,22 +106,13 @@ function TwoNeighbourDriver({ room, rows, cols, totalMs = 8000 }: { room: string
     const edges: Array<{ userA: string; userB: string }> = [];
     const edgeSet = new Set<string>();
 
-    for (const seat of seats) {
-      const candidates: Array<{ userId: string }> = [];
-      // left or right (one of them, random)
-      const lr = [
-        seat.col > 0 ? seats[seat.row * cols + seat.col - 1] : null,
-        seat.col < cols - 1 ? seats[seat.row * cols + seat.col + 1] : null,
-      ].filter(Boolean) as typeof seats;
-      if (lr.length) candidates.push(lr[Math.floor(Math.random() * lr.length)]);
-      // front or back (one of them, random)
-      const fb = [
-        seat.row > 0 ? seats[(seat.row - 1) * cols + seat.col] : null,
-        seat.row < rows - 1 ? seats[(seat.row + 1) * cols + seat.col] : null,
-      ].filter(Boolean) as typeof seats;
-      if (fb.length) candidates.push(fb[Math.floor(Math.random() * fb.length)]);
+    const guaranteed = Math.floor(neighbors);
+    const extraProb = neighbors - guaranteed;
 
-      for (const target of candidates) {
+    for (const seat of seats) {
+      const adjacent = getAdjacent(seat, seats, strategy).sort(() => Math.random() - 0.5);
+      const count = guaranteed + (Math.random() < extraProb ? 1 : 0);
+      for (const target of adjacent.slice(0, count)) {
         const key = [seat.userId, target.userId].sort().join('|');
         if (!edgeSet.has(key)) {
           edgeSet.add(key);
@@ -112,64 +140,7 @@ function TwoNeighbourDriver({ room, rows, cols, totalMs = 8000 }: { room: string
       cancelAnimationFrame(raf);
       timers.forEach(clearTimeout);
     };
-  }, [room, rows, cols, totalMs]);
-  return null;
-}
-
-// ===== 3-neighbour driver =====
-function ThreeNeighbourDriver({ room, rows, cols, totalMs = 8000 }: { room: string; rows: number; cols: number; totalMs?: number }) {
-  useEffect(() => {
-    const seats = generateGrid(rows, cols);
-    const allCodes = Object.fromEntries(seats.map(s => [s.userId, s.code]));
-
-    const edges: Array<{ userA: string; userB: string }> = [];
-    const edgeSet = new Set<string>();
-
-    for (const seat of seats) {
-      const allAdjacent = [
-        // cardinal
-        seat.col > 0 ? seats[seat.row * cols + seat.col - 1] : null,
-        seat.col < cols - 1 ? seats[seat.row * cols + seat.col + 1] : null,
-        seat.row > 0 ? seats[(seat.row - 1) * cols + seat.col] : null,
-        seat.row < rows - 1 ? seats[(seat.row + 1) * cols + seat.col] : null,
-        // diagonals
-        seat.row > 0 && seat.col > 0 ? seats[(seat.row - 1) * cols + seat.col - 1] : null,
-        seat.row > 0 && seat.col < cols - 1 ? seats[(seat.row - 1) * cols + seat.col + 1] : null,
-        seat.row < rows - 1 && seat.col > 0 ? seats[(seat.row + 1) * cols + seat.col - 1] : null,
-        seat.row < rows - 1 && seat.col < cols - 1 ? seats[(seat.row + 1) * cols + seat.col + 1] : null,
-      ].filter(Boolean) as typeof seats;
-
-      // shuffle and take up to 3
-      const shuffled = allAdjacent.sort(() => Math.random() - 0.5).slice(0, 3);
-      for (const target of shuffled) {
-        const key = [seat.userId, target.userId].sort().join('|');
-        if (!edgeSet.has(key)) {
-          edgeSet.add(key);
-          const [userA, userB] = key.split('|');
-          edges.push({ userA, userB });
-        }
-      }
-    }
-
-    const timers: ReturnType<typeof setTimeout>[] = [];
-
-    const raf = requestAnimationFrame(() => {
-      emitToRoom(room, { type: 'connected', myNeighborCode: '0001' });
-      emitToRoom(room, { type: 'neighborEdgesSnapshot', edges: [], allCodes });
-
-      edges.forEach((edge, i) => {
-        const delay = easedDelay(i, edges.length, totalMs) + Math.random() * 200;
-        timers.push(setTimeout(() => {
-          emitToRoom(room, { type: 'neighborEdgeAdded', userA: edge.userA, userB: edge.userB });
-        }, delay));
-      });
-    });
-
-    return () => {
-      cancelAnimationFrame(raf);
-      timers.forEach(clearTimeout);
-    };
-  }, [room, rows, cols, totalMs]);
+  }, [room, rows, cols, neighbors, strategy, totalMs]);
   return null;
 }
 
@@ -203,30 +174,28 @@ function EntryDriver({ room }: { room: string }) {
   return null;
 }
 
-export const TwoNeighbourScan: Story = {
-  name: '2-neighbour scan (graph view)',
-  args: { totalMs: 8000 } as any,
+export const CardinalScan: Story = {
+  name: 'Cardinal scan — 2 neighbours (graph view)',
+  args: { totalMs: 8000, neighbors: 2, strategy: 'cardinal' } as any,
   render: (args) => {
-    const room = (args as any).room ?? ROOM;
-    const totalMs = (args as any).totalMs ?? 8000;
+    const a = args as any;
     return (
       <>
-        <TwoNeighbourDriver room={room} rows={5} cols={6} totalMs={totalMs} />
+        <GraphDriver room={a.room ?? ROOM} rows={5} cols={6} neighbors={a.neighbors} strategy={a.strategy} totalMs={a.totalMs} />
         <NeighborPanel initialView="graph" />
       </>
     );
   },
 };
 
-export const ThreeNeighbourScan: Story = {
-  name: '3-neighbour scan (graph view)',
-  args: { totalMs: 8000 } as any,
+export const DiagonalScan: Story = {
+  name: 'Diagonal scan — 2.5 neighbours (graph view)',
+  args: { totalMs: 8000, neighbors: 2.5, strategy: 'all' } as any,
   render: (args) => {
-    const room = (args as any).room ?? ROOM;
-    const totalMs = (args as any).totalMs ?? 8000;
+    const a = args as any;
     return (
       <>
-        <ThreeNeighbourDriver room={room} rows={5} cols={6} totalMs={totalMs} />
+        <GraphDriver room={a.room ?? ROOM} rows={5} cols={6} neighbors={a.neighbors} strategy={a.strategy} totalMs={a.totalMs} />
         <NeighborPanel initialView="graph" />
       </>
     );

--- a/stories/NeighborPanel.stories.tsx
+++ b/stories/NeighborPanel.stories.tsx
@@ -7,7 +7,7 @@ import { emitToRoom } from '../.storybook/mocks/partysocket-react';
 
 const ROOM = 'storybook-neighbor';
 
-type Strategy = 'cardinal' | 'all';
+type Strategy = 'cardinal' | 'all' | 'front-right';
 
 const meta = {
   title: 'Panels/NeighborPanel',
@@ -26,7 +26,7 @@ const meta = {
   argTypes: {
     totalMs:   { control: { type: 'number', min: 1000, step: 1000 }, description: 'Total animation duration (ms)' },
     neighbors: { control: { type: 'number', min: 0, max: 8, step: 0.5 }, description: 'Neighbours per person — integer = exact count, fraction = probability of one more (e.g. 2.7 = always 2, 70% chance of 3)' },
-    strategy:  { control: { type: 'select' }, options: ['cardinal', 'all'] as Strategy[], description: '"cardinal" scans only up/down/left/right; "all" also includes diagonals' },
+    strategy:  { control: { type: 'select' }, options: ['cardinal', 'all', 'front-right'] as Strategy[], description: '"cardinal" picks randomly from up/down/left/right; "all" also includes diagonals; "front-right" prioritizes front then right, falls back randomly' },
   },
   args: {
     room: ROOM,
@@ -56,21 +56,25 @@ function generateGrid(rows: number, cols: number): Seat[] {
   }));
 }
 
+function shuffle<T>(arr: T[]): T[] {
+  return arr.sort(() => Math.random() - 0.5);
+}
+
 function getAdjacent(seat: Seat, seats: Seat[], strategy: Strategy): Seat[] {
   const { row, col, rows, cols } = seat;
-  const cardinal = [
-    row > 0             ? seats[(row - 1) * cols + col]     : null,
-    row < rows - 1      ? seats[(row + 1) * cols + col]     : null,
-    col > 0             ? seats[row * cols + col - 1]       : null,
-    col < cols - 1      ? seats[row * cols + col + 1]       : null,
-  ];
+  const at = (r: number, c: number) => (r >= 0 && r < rows && c >= 0 && c < cols) ? seats[r * cols + c] : null;
+
+  if (strategy === 'front-right') {
+    const priority = [at(row - 1, col), at(row, col + 1)].filter(Boolean) as Seat[];
+    const rest = shuffle([at(row + 1, col), at(row, col - 1)].filter(Boolean) as Seat[]);
+    return [...priority, ...rest];
+  }
+
+  const cardinal = [at(row - 1, col), at(row + 1, col), at(row, col - 1), at(row, col + 1)];
   const diagonals = strategy === 'all' ? [
-    row > 0 && col > 0             ? seats[(row - 1) * cols + col - 1] : null,
-    row > 0 && col < cols - 1      ? seats[(row - 1) * cols + col + 1] : null,
-    row < rows - 1 && col > 0      ? seats[(row + 1) * cols + col - 1] : null,
-    row < rows - 1 && col < cols - 1 ? seats[(row + 1) * cols + col + 1] : null,
+    at(row - 1, col - 1), at(row - 1, col + 1), at(row + 1, col - 1), at(row + 1, col + 1),
   ] : [];
-  return [...cardinal, ...diagonals].filter(Boolean) as Seat[];
+  return shuffle([...cardinal, ...diagonals].filter(Boolean) as Seat[]);
 }
 
 // Ease-in-out cubic
@@ -110,7 +114,7 @@ function GraphDriver({
     const extraProb = neighbors - guaranteed;
 
     for (const seat of seats) {
-      const adjacent = getAdjacent(seat, seats, strategy).sort(() => Math.random() - 0.5);
+      const adjacent = getAdjacent(seat, seats, strategy);
       const count = guaranteed + (Math.random() < extraProb ? 1 : 0);
       for (const target of adjacent.slice(0, count)) {
         const key = [seat.userId, target.userId].sort().join('|');
@@ -191,6 +195,20 @@ export const CardinalScan: Story = {
 export const DiagonalScan: Story = {
   name: 'Diagonal scan — 2.5 neighbours (graph view)',
   args: { totalMs: 8000, neighbors: 2.5, strategy: 'all' } as any,
+  render: (args) => {
+    const a = args as any;
+    return (
+      <>
+        <GraphDriver room={a.room ?? ROOM} rows={5} cols={6} neighbors={a.neighbors} strategy={a.strategy} totalMs={a.totalMs} />
+        <NeighborPanel initialView="graph" />
+      </>
+    );
+  },
+};
+
+export const FrontRightScan: Story = {
+  name: 'Front-right priority — 2 neighbours (graph view)',
+  args: { totalMs: 8000, neighbors: 2, strategy: 'front-right' } as any,
   render: (args) => {
     const a = args as any;
     return (

--- a/stories/NeighborPanel.stories.tsx
+++ b/stories/NeighborPanel.stories.tsx
@@ -25,8 +25,8 @@ const meta = {
   ],
   argTypes: {
     totalMs:   { control: { type: 'number', min: 1000, step: 1000 }, description: 'Total animation duration (ms)' },
-    neighbors: { control: { type: 'number', min: 0, max: 8, step: 0.5 }, description: 'Neighbours per person — integer = exact count, fraction = probability of one more (e.g. 2.7 = always 2, 70% chance of 3)' },
-    strategy:  { control: { type: 'select' }, options: ['cardinal', 'all', 'front-right'] as Strategy[], description: '"cardinal" picks randomly from up/down/left/right; "all" also includes diagonals; "front-right" prioritizes front then right, falls back randomly' },
+    neighbors: { name: 'avg neighbors connected', control: { type: 'number', min: 0, max: 8, step: 0.5 }, description: 'Neighbours per person — integer = exact count, fraction = probability of one more (e.g. 2.7 = always 2, 70% chance of 3)' },
+    strategy:  { name: 'neighbor selection strategy', control: { type: 'select' }, options: ['cardinal', 'all', 'front-right'] as Strategy[], description: '"cardinal" picks randomly from up/down/left/right; "all" also includes diagonals; "front-right" prioritizes front then right, falls back randomly' },
   },
   args: {
     room: ROOM,

--- a/stories/NeighborPanel.stories.tsx
+++ b/stories/NeighborPanel.stories.tsx
@@ -91,7 +91,7 @@ function TwoNeighbourDriver({ room, rows, cols }: { room: string; rows: number; 
       }
     }
 
-    const TOTAL_MS = 18000;
+    const TOTAL_MS = 8000;
     const timers: ReturnType<typeof setTimeout>[] = [];
 
     const raf = requestAnimationFrame(() => {
@@ -149,7 +149,7 @@ function ThreeNeighbourDriver({ room, rows, cols }: { room: string; rows: number
       }
     }
 
-    const TOTAL_MS = 20000;
+    const TOTAL_MS = 8000;
     const timers: ReturnType<typeof setTimeout>[] = [];
 
     const raf = requestAnimationFrame(() => {

--- a/stories/NeighborPanel.stories.tsx
+++ b/stories/NeighborPanel.stories.tsx
@@ -21,6 +21,9 @@ const meta = {
       </div>
     ),
   ],
+  argTypes: {
+    totalMs: { control: { type: 'number', min: 1000, step: 1000 }, description: 'Total animation duration (ms)' },
+  },
   args: {
     room: ROOM,
     userId: 'user-0-0',
@@ -58,7 +61,7 @@ function easedDelay(index: number, total: number, totalMs: number) {
 }
 
 // ===== 2-neighbour driver =====
-function TwoNeighbourDriver({ room, rows, cols }: { room: string; rows: number; cols: number }) {
+function TwoNeighbourDriver({ room, rows, cols, totalMs = 8000 }: { room: string; rows: number; cols: number; totalMs?: number }) {
   useEffect(() => {
     const seats = generateGrid(rows, cols);
     const allCodes = Object.fromEntries(seats.map(s => [s.userId, s.code]));
@@ -91,7 +94,6 @@ function TwoNeighbourDriver({ room, rows, cols }: { room: string; rows: number; 
       }
     }
 
-    const TOTAL_MS = 8000;
     const timers: ReturnType<typeof setTimeout>[] = [];
 
     const raf = requestAnimationFrame(() => {
@@ -99,7 +101,7 @@ function TwoNeighbourDriver({ room, rows, cols }: { room: string; rows: number; 
       emitToRoom(room, { type: 'neighborEdgesSnapshot', edges: [], allCodes });
 
       edges.forEach((edge, i) => {
-        const delay = easedDelay(i, edges.length, TOTAL_MS) + Math.random() * 200;
+        const delay = easedDelay(i, edges.length, totalMs) + Math.random() * 200;
         timers.push(setTimeout(() => {
           emitToRoom(room, { type: 'neighborEdgeAdded', userA: edge.userA, userB: edge.userB });
         }, delay));
@@ -110,12 +112,12 @@ function TwoNeighbourDriver({ room, rows, cols }: { room: string; rows: number; 
       cancelAnimationFrame(raf);
       timers.forEach(clearTimeout);
     };
-  }, [room, rows, cols]);
+  }, [room, rows, cols, totalMs]);
   return null;
 }
 
 // ===== 3-neighbour driver =====
-function ThreeNeighbourDriver({ room, rows, cols }: { room: string; rows: number; cols: number }) {
+function ThreeNeighbourDriver({ room, rows, cols, totalMs = 8000 }: { room: string; rows: number; cols: number; totalMs?: number }) {
   useEffect(() => {
     const seats = generateGrid(rows, cols);
     const allCodes = Object.fromEntries(seats.map(s => [s.userId, s.code]));
@@ -149,7 +151,6 @@ function ThreeNeighbourDriver({ room, rows, cols }: { room: string; rows: number
       }
     }
 
-    const TOTAL_MS = 8000;
     const timers: ReturnType<typeof setTimeout>[] = [];
 
     const raf = requestAnimationFrame(() => {
@@ -157,7 +158,7 @@ function ThreeNeighbourDriver({ room, rows, cols }: { room: string; rows: number
       emitToRoom(room, { type: 'neighborEdgesSnapshot', edges: [], allCodes });
 
       edges.forEach((edge, i) => {
-        const delay = easedDelay(i, edges.length, TOTAL_MS) + Math.random() * 200;
+        const delay = easedDelay(i, edges.length, totalMs) + Math.random() * 200;
         timers.push(setTimeout(() => {
           emitToRoom(room, { type: 'neighborEdgeAdded', userA: edge.userA, userB: edge.userB });
         }, delay));
@@ -168,7 +169,7 @@ function ThreeNeighbourDriver({ room, rows, cols }: { room: string; rows: number
       cancelAnimationFrame(raf);
       timers.forEach(clearTimeout);
     };
-  }, [room, rows, cols]);
+  }, [room, rows, cols, totalMs]);
   return null;
 }
 
@@ -204,11 +205,13 @@ function EntryDriver({ room }: { room: string }) {
 
 export const TwoNeighbourScan: Story = {
   name: '2-neighbour scan (graph view)',
+  args: { totalMs: 8000 } as any,
   render: (args) => {
     const room = (args as any).room ?? ROOM;
+    const totalMs = (args as any).totalMs ?? 8000;
     return (
       <>
-        <TwoNeighbourDriver room={room} rows={5} cols={6} />
+        <TwoNeighbourDriver room={room} rows={5} cols={6} totalMs={totalMs} />
         <NeighborPanel initialView="graph" />
       </>
     );
@@ -217,11 +220,13 @@ export const TwoNeighbourScan: Story = {
 
 export const ThreeNeighbourScan: Story = {
   name: '3-neighbour scan (graph view)',
+  args: { totalMs: 8000 } as any,
   render: (args) => {
     const room = (args as any).room ?? ROOM;
+    const totalMs = (args as any).totalMs ?? 8000;
     return (
       <>
-        <ThreeNeighbourDriver room={room} rows={5} cols={6} />
+        <ThreeNeighbourDriver room={room} rows={5} cols={6} totalMs={totalMs} />
         <NeighborPanel initialView="graph" />
       </>
     );


### PR DESCRIPTION
## Summary

- Adds a new **NeighborPanel** for building a live social graph of nearby audience members
- **Participant view:** shows the user's own 4-digit code; numeric keypad for entering a neighbour's code; auto-submits at 4 digits; ✕ clears; faint "map" link bottom-right
- **Graph view:** D3 force-directed layout with all room participants as nodes; new edges flash green on arrival; draggable nodes; "Clear all connections" resets

## Server changes

- Assigns each user a unique 4-digit code on connect (stable per session, cleared on disconnect)
- Sends `myNeighborCode` in the `connected` message
- New message handlers: `neighborEdge` (resolve code → userId, store undirected edge, broadcast); `requestNeighborEdges` (snapshot to requester); `clearNeighborEdges` (broadcast clear)
- Error replies for `self`, `not_found`, `duplicate`

## Storybook

Three graph stories with Controls panel knobs for `totalMs`, `neighbors` (float: floor = guaranteed, fraction = probability of one more), and `strategy` (`cardinal` / `all` / `front-right`):
- **CardinalScan** — `neighbors=2, strategy=cardinal`
- **DiagonalScan** — `neighbors=2.5, strategy=all`
- **FrontRightScan** — `neighbors=2, strategy=front-right`

## Test plan

- [ ] `pnpm tsc --noEmit` passes
- [ ] Storybook: EntryView shows code + keypad; graph stories animate edges over 8s
- [ ] Dev: "Neighbor Network" appears in Interfaces tab at `#v4?interface=emcee`
- [ ] Two tabs: entering one tab's code in the other's keypad shows "Got it!" and flashes the edge in graph view
- [ ] "Clear all connections" resets graph on all clients
- [ ] Disconnecting removes the user's code (no stale codes)

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~200 words of PR description from ~150 words of human prompts across this session)