### PR TITLE
feat(screen-light): screen-light and light-show panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 29 (2026-06-02)
 
+### Added
+- **Screen Light panel** — new canvas activity mode (`screen-light`) that turns a participant's phone into a full-screen colored light; color and brightness are controlled remotely by an admin running the Light Show panel; screen wake lock is on by default with a subtle toggle in the bottom-right corner.
+- **Light Show panel** — new patchable controller panel (`light-show`) for setting the color (via presets + custom picker) and brightness (dimmer slider) of all connected Screen Light phones in real time.
+
 ### Changed
 - **NeighborPanel graph view** — nodes are now coloured by live reaction-canvas valence (green/red/yellow) using the same `computeReactionRegion` logic as other projection maps; grey for users with no cursor data yet; no special "you are here" highlight for own node.
 - **NeighborPanel graph view** — new nodes spawn at SVG centre instead of top-left; removed tick-handler coordinate clamping so dragging works correctly when graph is rotated.

--- a/app/components/apps/ReactionCanvasAppV4.tsx
+++ b/app/components/apps/ReactionCanvasAppV4.tsx
@@ -40,6 +40,8 @@ import MapViewerPanel from "../panels/MapViewerPanel";
 import ValenceBeatPadPanel from "../panels/ValenceBeatPadPanel";
 import ArrivalCanvasPanel from "../panels/ArrivalCanvasPanel";
 import NeighborPanel from "../panels/NeighborPanel";
+import ScreenLightPanel from "../panels/ScreenLightPanel";
+import LightShowPanel from "../panels/LightShowPanel";
 import { SMOOTH_CURSOR_ENABLED, SMOOTH_CURSOR_CONFIG } from "../../utils/cursor";
 
 const PANEL_COMPONENTS: Partial<Record<string, PanelDefinition['component']>> = {
@@ -55,6 +57,8 @@ const PANEL_COMPONENTS: Partial<Record<string, PanelDefinition['component']>> = 
   'valence-beat-pad': ValenceBeatPadPanel,
   'arrival-canvas':   ArrivalCanvasPanel,
   'neighbor':         NeighborPanel,
+  'screen-light':     ScreenLightPanel,
+  'light-show':       LightShowPanel,
 };
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;

--- a/app/components/panels/LightShowPanel/index.tsx
+++ b/app/components/panels/LightShowPanel/index.tsx
@@ -1,0 +1,116 @@
+import { useState, useRef } from 'react';
+import usePartySocket from 'partysocket/react';
+import { usePanelContext } from '../../../context/PanelContext';
+import { getPartySocketConfig } from '../../../utils/partyHost';
+
+const PRESETS = [
+  { label: 'Red',     color: '#ff0000' },
+  { label: 'Orange',  color: '#ff8800' },
+  { label: 'Yellow',  color: '#ffee00' },
+  { label: 'Green',   color: '#00cc44' },
+  { label: 'Cyan',    color: '#00ccff' },
+  { label: 'Blue',    color: '#0044ff' },
+  { label: 'Magenta', color: '#cc00ff' },
+  { label: 'White',   color: '#ffffff' },
+  { label: 'Black',   color: '#000000' },
+];
+
+export default function LightShowPanel() {
+  const { room, userId } = usePanelContext();
+  const [color, setColor] = useState('#ffffff');
+  const [brightness, setBrightness] = useState(100);
+  const socketRef = useRef<ReturnType<typeof usePartySocket> | null>(null);
+
+  const sendLight = (nextColor: string, nextBrightness: number) => {
+    socketRef.current?.send(JSON.stringify({ type: 'setLightColor', color: nextColor, brightness: nextBrightness }));
+  };
+
+  const socket = usePartySocket({
+    ...getPartySocketConfig(),
+    room,
+    query: { userId },
+    onMessage(evt) {
+      const msg = JSON.parse(evt.data);
+      if (msg.type === 'connected' && msg.lightColor) {
+        setColor(msg.lightColor.color);
+        setBrightness(msg.lightColor.brightness);
+      }
+    },
+  });
+  socketRef.current = socket;
+
+  const handleColor = (next: string) => {
+    setColor(next);
+    sendLight(next, brightness);
+  };
+
+  const handleBrightness = (next: number) => {
+    setBrightness(next);
+    sendLight(color, next);
+  };
+
+  // Compute preview: actual screen color after brightness dimming
+  const overlayOpacity = 1 - brightness / 100;
+
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', padding: '20px', background: '#0f0f0e', color: '#ccc', fontFamily: 'monospace', gap: '20px', overflow: 'hidden' }}>
+      <div style={{ fontSize: 13, color: '#666', letterSpacing: '0.05em' }}>LIGHT SHOW</div>
+
+      {/* Live preview */}
+      <div style={{ position: 'relative', height: 80, borderRadius: 8, background: color, flexShrink: 0 }}>
+        <div style={{ position: 'absolute', inset: 0, borderRadius: 8, background: `rgba(0,0,0,${overlayOpacity})` }} />
+      </div>
+
+      {/* Color presets */}
+      <div>
+        <div style={{ fontSize: 11, color: '#555', marginBottom: 10, letterSpacing: '0.08em' }}>COLOR</div>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+          {PRESETS.map(p => (
+            <button
+              key={p.color}
+              onClick={() => handleColor(p.color)}
+              aria-label={p.label}
+              style={{
+                width: 36,
+                height: 36,
+                borderRadius: 6,
+                background: p.color,
+                border: color === p.color ? '2px solid #fff' : '2px solid #333',
+                cursor: 'pointer',
+                flexShrink: 0,
+              }}
+            />
+          ))}
+          <label style={{ display: 'flex', alignItems: 'center', gap: 6, fontSize: 12, color: '#888', cursor: 'pointer' }}>
+            <input
+              type="color"
+              value={color}
+              onChange={e => handleColor(e.target.value)}
+              style={{ width: 36, height: 36, borderRadius: 6, border: '2px solid #333', cursor: 'pointer', padding: 2, background: 'none' }}
+            />
+            custom
+          </label>
+        </div>
+      </div>
+
+      {/* Brightness slider */}
+      <div>
+        <div style={{ fontSize: 11, color: '#555', marginBottom: 10, letterSpacing: '0.08em' }}>
+          BRIGHTNESS — {brightness}%
+        </div>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          value={brightness}
+          onChange={e => handleBrightness(Number(e.target.value))}
+          style={{ width: '100%', accentColor: '#4a7acf' }}
+        />
+        <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: '#444', marginTop: 4 }}>
+          <span>dim</span>
+          <span>full</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/components/panels/ScreenLightPanel/index.tsx
+++ b/app/components/panels/ScreenLightPanel/index.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react';
+import usePartySocket from 'partysocket/react';
+import { usePanelContext } from '../../../context/PanelContext';
+import { getPartySocketConfig } from '../../../utils/partyHost';
+import { useWakeLock } from '../../../utils/useWakeLock';
+import WakeLockIndicatorButton from '../../shared/WakeLockIndicatorButton';
+
+export default function ScreenLightPanel() {
+  const { room, userId } = usePanelContext();
+  const [color, setColor] = useState('#000000');
+  const [brightness, setBrightness] = useState(100);
+  const [wakeLockEnabled, setWakeLockEnabled] = useState(true);
+  const { acquired: wakeLockAcquired } = useWakeLock(wakeLockEnabled);
+
+  usePartySocket({
+    ...getPartySocketConfig(),
+    room,
+    query: { userId },
+    onMessage(evt) {
+      const msg = JSON.parse(evt.data);
+      if (msg.type === 'connected' && msg.lightColor) {
+        setColor(msg.lightColor.color);
+        setBrightness(msg.lightColor.brightness);
+      } else if (msg.type === 'lightColor') {
+        setColor(msg.color);
+        setBrightness(msg.brightness);
+      }
+    },
+  });
+
+  // brightness as a dimmer: 0% = pure black overlay, 100% = no overlay
+  const overlayOpacity = 1 - brightness / 100;
+
+  return (
+    <div style={{ flex: 1, position: 'relative', background: color }}>
+      <div style={{ position: 'absolute', inset: 0, background: `rgba(0,0,0,${overlayOpacity})`, pointerEvents: 'none' }} />
+      <div
+        style={{ position: 'absolute', bottom: 16, right: 16, opacity: 0.25, transition: 'opacity 0.2s' }}
+        onPointerEnter={e => (e.currentTarget.style.opacity = '0.75')}
+        onPointerLeave={e => (e.currentTarget.style.opacity = '0.25')}
+      >
+        <WakeLockIndicatorButton
+          enabled={wakeLockEnabled}
+          active={wakeLockAcquired}
+          onToggle={() => setWakeLockEnabled(prev => !prev)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/components/panels/ScreenLightPanel/index.tsx
+++ b/app/components/panels/ScreenLightPanel/index.tsx
@@ -32,19 +32,13 @@ export default function ScreenLightPanel() {
   const overlayOpacity = 1 - brightness / 100;
 
   return (
-    <div style={{ flex: 1, position: 'relative', background: color }}>
+    <div className="screen-light-panel" style={{ flex: 1, position: 'relative', background: color }}>
       <div style={{ position: 'absolute', inset: 0, background: `rgba(0,0,0,${overlayOpacity})`, pointerEvents: 'none' }} />
-      <div
-        style={{ position: 'absolute', bottom: 16, right: 16, opacity: 0.25, transition: 'opacity 0.2s' }}
-        onPointerEnter={e => (e.currentTarget.style.opacity = '0.75')}
-        onPointerLeave={e => (e.currentTarget.style.opacity = '0.25')}
-      >
-        <WakeLockIndicatorButton
-          enabled={wakeLockEnabled}
-          active={wakeLockAcquired}
-          onToggle={() => setWakeLockEnabled(prev => !prev)}
-        />
-      </div>
+      <WakeLockIndicatorButton
+        enabled={wakeLockEnabled}
+        active={wakeLockAcquired}
+        onToggle={() => setWakeLockEnabled(prev => !prev)}
+      />
     </div>
   );
 }

--- a/app/components/shared/WakeLockIndicatorButton.tsx
+++ b/app/components/shared/WakeLockIndicatorButton.tsx
@@ -7,6 +7,7 @@ interface Props {
 }
 
 export default function WakeLockIndicatorButton({ enabled, active, onToggle }: Props) {
+  if (!('wakeLock' in navigator)) return null;
   const classes = [
     'wakelock-indicator-btn',
     !enabled ? 'wakelock-indicator-btn--off' : '',

--- a/app/panelRegistry.ts
+++ b/app/panelRegistry.ts
@@ -28,7 +28,9 @@ export const PANEL_REGISTRY: PanelMeta[] = [
   { id: 'map-viewer',      label: 'Map Viewer',      description: 'View the computed participant map',                     patchable: true,  activityMode: true  },
   { id: 'valence-beat-pad', label: 'Valence Beat Pad', shortLabel: 'Beat Pad', description: 'Interactive musical pad driven by audience valence', patchable: true, activityMode: true },
   { id: 'arrival-canvas', label: 'Arrival Canvas', shortLabel: 'Arrival', description: 'Room-fill visualizer with THX-style audio convergence', patchable: true, activityMode: true },
-  { id: 'neighbor', label: 'Neighbor Network', shortLabel: 'Neighbor', description: 'Social graph of nearby audience members', patchable: true, activityMode: true },
+  { id: 'neighbor',      label: 'Neighbor Network', shortLabel: 'Neighbor', description: 'Social graph of nearby audience members',             patchable: true,  activityMode: true  },
+  { id: 'screen-light', label: 'Screen Light',    shortLabel: 'Light',    description: 'Full-screen colored light controlled remotely',         patchable: false, activityMode: true  },
+  { id: 'light-show',   label: 'Light Show',      shortLabel: 'LShow',   description: 'Control the screen-light color on all connected phones', patchable: true,  activityMode: false },
 ];
 
 export const PATCHABLE_PANELS = PANEL_REGISTRY.filter(p => p.patchable);

--- a/app/styles/panels.css
+++ b/app/styles/panels.css
@@ -134,6 +134,19 @@
   overflow: hidden;
 }
 
+/* Wake lock button — white and anchored bottom-right, low opacity as a subtle hint */
+.screen-light-panel .wakelock-indicator-btn {
+  top: unset;
+  left: unset;
+  bottom: 16px;
+  right: 16px;
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.screen-light-panel .wakelock-indicator-btn--off {
+  color: rgba(255, 255, 255, 0.1);
+}
+
 /* Wake lock button — inverted for dark panel background, anchored left in footer */
 .steno-panel .wakelock-indicator-btn {
   position: absolute;

--- a/app/types.ts
+++ b/app/types.ts
@@ -28,7 +28,7 @@ export interface Statement {
   text: string;
 }
 
-export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social-sharing' | 'mood-tones' | 'treevites' | 'greeter' | 'signature' | 'steno' | 'story-tracer' | 'voice-call' | 'map-maker' | 'map-viewer' | 'valence-beat-pad' | 'arrival-canvas' | 'neighbor';
+export type ActivityMode = 'canvas' | 'soccer' | 'image-canvas' | 'social-sharing' | 'mood-tones' | 'treevites' | 'greeter' | 'signature' | 'steno' | 'story-tracer' | 'voice-call' | 'map-maker' | 'map-viewer' | 'valence-beat-pad' | 'arrival-canvas' | 'neighbor' | 'screen-light' | 'light-show';
 
 export interface MapProjection {
   coords: [string, [number, number]][];

--- a/app/utils/useWakeLock.ts
+++ b/app/utils/useWakeLock.ts
@@ -28,6 +28,7 @@ export function useWakeLock(active: boolean): { acquired: boolean; supported: bo
 
   useEffect(() => {
     if (active) acquire(); else release();
+    return () => { release(); };
   }, [active, acquire, release]);
 
   useEffect(() => {

--- a/app/utils/useWakeLock.ts
+++ b/app/utils/useWakeLock.ts
@@ -2,7 +2,9 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 
 // Manages Screen Wake Lock lifecycle. Pass `active` to drive acquire/release reactively.
 // Automatically re-acquires on visibilitychange (browsers release the lock when tab hides).
-export function useWakeLock(active: boolean): { acquired: boolean } {
+// `supported` is false on non-secure contexts (HTTP LAN) where the API is unavailable.
+export function useWakeLock(active: boolean): { acquired: boolean; supported: boolean } {
+  const supported = 'wakeLock' in navigator;
   const [acquired, setAcquired] = useState(false);
   const sentinelRef = useRef<WakeLockSentinel | null>(null);
 
@@ -36,5 +38,5 @@ export function useWakeLock(active: boolean): { acquired: boolean } {
     return () => document.removeEventListener('visibilitychange', handleVisibility);
   }, [active, acquire]);
 
-  return { acquired };
+  return { acquired, supported };
 }

--- a/party/server.ts
+++ b/party/server.ts
@@ -278,7 +278,9 @@ interface NeighborEdgeEvent      { type: 'neighborEdge';         from: string; t
 interface RequestNeighborEdgesEvent { type: 'requestNeighborEdges' }
 interface ClearNeighborEdgesEvent   { type: 'clearNeighborEdges' }
 
-type ClientEvent =CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | SetGreeterConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent | RegisterCustomAvatarEvent | SetColorCursorsByVoteEvent | SetDefaultCursorColorEvent | SetOwnValenceDisplayEvent | SetValenceInputModeEvent | StrokeSegmentEvent | ClearSignatureEvent | StenoStartRecordingEvent | StenoStopRecordingEvent | StenoAppendTextEvent | StenoSetTextEvent | StoryTracerSetPointsEvent | StoryTracerClearPointsEvent | MapProjectionSetEvent | MapProjectionClearEvent | JoinCallQueueEvent | LeaveCallQueueEvent | WebRTCOfferEvent | WebRTCAnswerEvent | WebRTCIceEvent | HangUpCallEvent | SetCallAlgorithmEvent | SetArrivalCapacityEvent | NeighborEdgeEvent | RequestNeighborEdgesEvent | ClearNeighborEdgesEvent;
+interface SetLightColorEvent { type: 'setLightColor'; color: string; brightness: number }
+
+type ClientEvent =CursorEvent | StatementEvent | QueueStatementEvent | ClearQueueEvent | UpdateStatementsPoolEvent | GhostCursorSettingEvent | SetTimecodeEvent | SetRecordingStateEvent | SetRoomLabelsEvent | SetRoomAnchorsEvent | SetRoomAvatarStyleEvent | SetActivityEvent | SetImageUrlEvent | ResetSoccerScoreEvent | SetUserCapEvent | RequestJoinEvent | PlaybackCursorBroadcastEvent | TriggerActivityEvent | SubmitGithubUsernameEvent | SubmitFeedbackStarsEvent | SetSocialConfigEvent | SetGreeterConfigEvent | PushInterfaceEvent | AcceptInterfaceEvent | ClearPushedInterfacesEvent | PushHapticEvent | SetNowLabelEvent | RecordInvitationsEvent | RegisterCustomAvatarEvent | SetColorCursorsByVoteEvent | SetDefaultCursorColorEvent | SetOwnValenceDisplayEvent | SetValenceInputModeEvent | StrokeSegmentEvent | ClearSignatureEvent | StenoStartRecordingEvent | StenoStopRecordingEvent | StenoAppendTextEvent | StenoSetTextEvent | StoryTracerSetPointsEvent | StoryTracerClearPointsEvent | MapProjectionSetEvent | MapProjectionClearEvent | JoinCallQueueEvent | LeaveCallQueueEvent | WebRTCOfferEvent | WebRTCAnswerEvent | WebRTCIceEvent | HangUpCallEvent | SetCallAlgorithmEvent | SetArrivalCapacityEvent | NeighborEdgeEvent | RequestNeighborEdgesEvent | ClearNeighborEdgesEvent | SetLightColorEvent;
 
 // ===== REACTION REGION HELPER (mirrors app/utils/voteRegion.ts) =====
 const DEFAULT_ANCHORS = {
@@ -364,6 +366,7 @@ export default class Server implements Party.Server {
   private arrivalCapacity: number = 50;
   private neighborCodes = new Map<string, string>(); // userId → 4-digit code
   private neighborEdges = new Set<string>();          // canonical "userA|userB" strings
+  private lightColor: { color: string; brightness: number } = { color: '#000000', brightness: 100 };
 
   // ===== GHOST CURSOR DEMO CODE (can be easily removed) =====
   private ghostCursorsEnabled: boolean = false;
@@ -587,6 +590,7 @@ export default class Server implements Party.Server {
       callAlgorithm: this.callAlgorithm,
       arrivalCapacity: this.arrivalCapacity,
       myNeighborCode: this.neighborCodes.get(userId) ?? null,
+      lightColor: this.lightColor,
     }));
   }
 
@@ -954,6 +958,9 @@ export default class Server implements Party.Server {
       } else if (event.type === 'clearNeighborEdges') {
         this.neighborEdges.clear();
         this.room.broadcast(JSON.stringify({ type: 'neighborEdgesCleared' }));
+      } else if (event.type === 'setLightColor') {
+        this.lightColor = { color: event.color, brightness: event.brightness };
+        this.room.broadcast(JSON.stringify({ type: 'lightColor', color: event.color, brightness: event.brightness }));
       }
     } catch (e) {
       console.error('Failed to parse event:', e);

--- a/stories/LightShowPanel.stories.tsx
+++ b/stories/LightShowPanel.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React, { useEffect } from 'react';
+import LightShowPanel from '../app/components/panels/LightShowPanel';
+import { PanelContextProvider } from '../app/context/PanelContext';
+import { emitToRoom } from '../.storybook/mocks/partysocket-react';
+
+const ROOM = 'storybook-light-show';
+
+const meta = {
+  title: 'Panels/LightShowPanel',
+  component: LightShowPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story, ctx) => (
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <PanelContextProvider value={ctx.args as never}>
+          <Story />
+        </PanelContextProvider>
+      </div>
+    ),
+  ],
+  args: {
+    room: ROOM,
+    userId: 'story-user',
+    inviteEdges: {},
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function DefaultDriver({ room }: { room: string }) {
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      emitToRoom(room, { type: 'connected', lightColor: { color: '#ffffff', brightness: 100 } });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [room]);
+  return null;
+}
+
+export const Default: Story = {
+  name: 'Default (white, full brightness)',
+  render: (args) => {
+    const room = (args as any).room ?? ROOM;
+    return (
+      <>
+        <DefaultDriver room={room} />
+        <LightShowPanel />
+      </>
+    );
+  },
+};

--- a/stories/ScreenLightPanel.stories.tsx
+++ b/stories/ScreenLightPanel.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React, { useEffect } from 'react';
+import ScreenLightPanel from '../app/components/panels/ScreenLightPanel';
+import { PanelContextProvider } from '../app/context/PanelContext';
+import { emitToRoom } from '../.storybook/mocks/partysocket-react';
+
+const ROOM = 'storybook-screen-light';
+
+const meta = {
+  title: 'Panels/ScreenLightPanel',
+  component: ScreenLightPanel,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  decorators: [
+    (Story, ctx) => (
+      <div className="v2-app-container" style={{ height: '100vh' }}>
+        <PanelContextProvider value={ctx.args as never}>
+          <Story />
+        </PanelContextProvider>
+      </div>
+    ),
+  ],
+  args: {
+    room: ROOM,
+    userId: 'story-user',
+    inviteEdges: {},
+  },
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ===== Drivers =====
+
+function IdleDriver({ room }: { room: string }) {
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => {
+      emitToRoom(room, { type: 'connected', lightColor: { color: '#000000', brightness: 100 } });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [room]);
+  return null;
+}
+
+// Converts HSL hue (0–360) to a hex colour string at full saturation and 50% lightness.
+function hueToHex(hue: number): string {
+  const h = hue / 60;
+  const s = 1;
+  const l = 0.5;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) => {
+    const k = (n + h) % 12;
+    const val = l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
+    return Math.round(255 * val).toString(16).padStart(2, '0');
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+}
+
+function OscillatingDriver({ room, periodMs = 4000 }: { room: string; periodMs?: number }) {
+  useEffect(() => {
+    emitToRoom(room, { type: 'connected', lightColor: { color: '#ff0000', brightness: 100 } });
+
+    const start = performance.now();
+    let id: ReturnType<typeof setInterval>;
+
+    id = setInterval(() => {
+      const elapsed = performance.now() - start;
+      // Hue cycles through the full spectrum over periodMs
+      const hue = (elapsed / periodMs * 360) % 360;
+      // Brightness pulses between 40% and 100% at half the period
+      const brightness = Math.round(70 + 30 * Math.sin((elapsed / (periodMs / 2)) * Math.PI));
+      emitToRoom(room, { type: 'lightColor', color: hueToHex(hue), brightness });
+    }, 50);
+
+    return () => clearInterval(id);
+  }, [room, periodMs]);
+  return null;
+}
+
+// ===== Stories =====
+
+export const Idle: Story = {
+  name: 'Idle (black, no incoming messages)',
+  render: (args) => {
+    const room = (args as any).room ?? ROOM;
+    return (
+      <>
+        <IdleDriver room={room} />
+        <ScreenLightPanel />
+      </>
+    );
+  },
+};
+
+export const Oscillating: Story = {
+  name: 'Oscillating colors + brightness',
+  render: (args) => {
+    const room = (args as any).room ?? ROOM;
+    return (
+      <>
+        <OscillatingDriver room={room} periodMs={4000} />
+        <ScreenLightPanel />
+      </>
+    );
+  },
+};

--- a/stories/ScreenLightPanel.stories.tsx
+++ b/stories/ScreenLightPanel.stories.tsx
@@ -56,22 +56,27 @@ function hueToHex(hue: number): string {
   return `#${f(0)}${f(8)}${f(4)}`;
 }
 
-function OscillatingDriver({ room, periodMs = 4000 }: { room: string; periodMs?: number }) {
+function ColorCycleDriver({ room, periodMs = 4000 }: { room: string; periodMs?: number }) {
   useEffect(() => {
     emitToRoom(room, { type: 'connected', lightColor: { color: '#ff0000', brightness: 100 } });
-
     const start = performance.now();
-    let id: ReturnType<typeof setInterval>;
-
-    id = setInterval(() => {
-      const elapsed = performance.now() - start;
-      // Hue cycles through the full spectrum over periodMs
-      const hue = (elapsed / periodMs * 360) % 360;
-      // Brightness pulses between 40% and 100% at half the period
-      const brightness = Math.round(70 + 30 * Math.sin((elapsed / (periodMs / 2)) * Math.PI));
-      emitToRoom(room, { type: 'lightColor', color: hueToHex(hue), brightness });
+    const id = setInterval(() => {
+      const hue = ((performance.now() - start) / periodMs * 360) % 360;
+      emitToRoom(room, { type: 'lightColor', color: hueToHex(hue), brightness: 100 });
     }, 50);
+    return () => clearInterval(id);
+  }, [room, periodMs]);
+  return null;
+}
 
+function BrightnessPulseDriver({ room, periodMs = 3000 }: { room: string; periodMs?: number }) {
+  useEffect(() => {
+    emitToRoom(room, { type: 'connected', lightColor: { color: '#ffffff', brightness: 100 } });
+    const start = performance.now();
+    const id = setInterval(() => {
+      const brightness = Math.round(50 + 50 * Math.sin(((performance.now() - start) / periodMs) * Math.PI * 2));
+      emitToRoom(room, { type: 'lightColor', color: '#ffffff', brightness });
+    }, 50);
     return () => clearInterval(id);
   }, [room, periodMs]);
   return null;
@@ -92,13 +97,26 @@ export const Idle: Story = {
   },
 };
 
-export const Oscillating: Story = {
-  name: 'Oscillating colors + brightness',
+export const ColorCycle: Story = {
+  name: 'Oscillating colors (full brightness)',
   render: (args) => {
     const room = (args as any).room ?? ROOM;
     return (
       <>
-        <OscillatingDriver room={room} periodMs={4000} />
+        <ColorCycleDriver room={room} periodMs={4000} />
+        <ScreenLightPanel />
+      </>
+    );
+  },
+};
+
+export const BrightnessPulse: Story = {
+  name: 'Oscillating brightness (white)',
+  render: (args) => {
+    const room = (args as any).room ?? ROOM;
+    return (
+      <>
+        <BrightnessPulseDriver room={room} periodMs={3000} />
         <ScreenLightPanel />
       </>
     );

--- a/stories/ScreenLightPanel.stories.tsx
+++ b/stories/ScreenLightPanel.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import ScreenLightPanel from '../app/components/panels/ScreenLightPanel';
 import { PanelContextProvider } from '../app/context/PanelContext';
 import { emitToRoom } from '../.storybook/mocks/partysocket-react';
@@ -20,10 +20,16 @@ const meta = {
       </div>
     ),
   ],
+  argTypes: {
+    color:      { control: 'color', description: 'Light color' },
+    brightness: { control: { type: 'range', min: 0, max: 100, step: 1 }, description: 'Brightness (0–100%)' },
+  },
   args: {
     room: ROOM,
     userId: 'story-user',
     inviteEdges: {},
+    color: '#ff0000',
+    brightness: 100,
   },
 } satisfies Meta;
 
@@ -32,13 +38,25 @@ type Story = StoryObj<typeof meta>;
 
 // ===== Drivers =====
 
-function IdleDriver({ room }: { room: string }) {
+function DefaultDriver({ room, color, brightness }: { room: string; color: string; brightness: number }) {
+  const mounted = useRef(false);
+
+  // Defer the connected message until after siblings have subscribed
   useEffect(() => {
     const raf = requestAnimationFrame(() => {
-      emitToRoom(room, { type: 'connected', lightColor: { color: '#000000', brightness: 100 } });
+      emitToRoom(room, { type: 'connected', lightColor: { color, brightness } });
+      mounted.current = true;
     });
     return () => cancelAnimationFrame(raf);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [room]);
+
+  // Push control changes after the initial connected message has been sent
+  useEffect(() => {
+    if (!mounted.current) return;
+    emitToRoom(room, { type: 'lightColor', color, brightness });
+  }, [room, color, brightness]);
+
   return null;
 }
 
@@ -84,13 +102,13 @@ function BrightnessPulseDriver({ room, periodMs = 3000 }: { room: string; period
 
 // ===== Stories =====
 
-export const Idle: Story = {
-  name: 'Idle (black, no incoming messages)',
+export const Default: Story = {
+  name: 'Default (color + brightness controls)',
   render: (args) => {
-    const room = (args as any).room ?? ROOM;
+    const a = args as any;
     return (
       <>
-        <IdleDriver room={room} />
+        <DefaultDriver room={a.room ?? ROOM} color={a.color} brightness={a.brightness} />
         <ScreenLightPanel />
       </>
     );


### PR DESCRIPTION
## Summary

- **`screen-light`** — new canvas activity that turns a participant's phone into a full-screen coloured light. Color and brightness are controlled remotely by an admin running the light-show panel. Wake lock is on by default (with a subtle bottom-right toggle) and is released correctly on unmount.
- **`light-show`** — new patchable controller panel with colour presets, a custom colour picker, and a brightness dimmer slider. Broadcasts changes to all connected phones in real time via a new `setLightColor` WebSocket message.
- **`useWakeLock` fix** — added a missing cleanup function so the wake lock sentinel is released whenever any panel that holds one unmounts (previously affected screen-light, steno, voice-call, and orientation mode).
- **`WakeLockIndicatorButton` fix** — self-hides on HTTP/LAN where the Screen Wake Lock API is unavailable, preventing misleading toggle feedback.
- **Storybook** — three stories for `ScreenLightPanel` (default with live controls, color cycle, brightness pulse) and one for `LightShowPanel`.

## Test plan

- [ ] Navigate to `#v4?interface=emcee`, use InterfacesTab to solo `screen-light` — phone screen should fill with black
- [ ] Add `?addInterface=light-show` on another tab — Light Show chip appears; picking a colour updates the screen-light tab immediately
- [ ] Drag brightness slider — screen dims/brightens without changing hue
- [ ] Switch away from screen-light activity — phone screen should stop being kept awake (wake lock released)
- [ ] On HTTP LAN (`192.168.x.x:1999`) — wake lock button should not appear at all
- [ ] On localhost — wake lock button appears subtly in bottom-right; tapping toggles it
- [ ] Run `pnpm vitest` — no regressions
- [ ] Run Storybook — all three ScreenLightPanel stories and the LightShowPanel story render correctly; Default story reflects control changes live

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~150 words of PR description from ~200 words of human prompts across this session)