### PR TITLE
feat(ci): deploy Storybook to Chromatic on every push

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ TELEGRAM_CHAT_ID=
 # Set to true to log incoming message rate to the server console (see party/server.ts).
 # Useful for measuring real client send rates before tuning perf thresholds.
 DEBUG=false
+
+# Chromatic project token for Storybook visual testing deploys.
+# Get from your Chromatic project dashboard → Manage → Configure.
+CHROMATIC_PROJECT_TOKEN=

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -24,3 +24,4 @@ jobs:
           # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           autoAcceptChanges: true
+          exitOnceUploaded: true

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -1,0 +1,26 @@
+name: "Storybook"
+
+on: push
+
+jobs:
+  chromatic:
+    name: Run Chromatic
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run Chromatic
+        uses: chromaui/action@latest
+        with:
+          # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          autoAcceptChanges: true

--- a/.github/workflows/storybook.yaml
+++ b/.github/workflows/storybook.yaml
@@ -6,6 +6,8 @@ jobs:
   chromatic:
     name: Run Chromatic
     runs-on: ubuntu-latest
+    permissions:
+      deployments: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -18,10 +20,46 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Create GitHub deployment
+        id: deployment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const branch = context.ref.replace('refs/heads/', '');
+            const { data: deployment } = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: context.sha,
+              environment: `storybook-${branch}`,
+              auto_merge: false,
+              required_contexts: [],
+              description: `Storybook for ${branch}`,
+            });
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: deployment.id,
+              state: 'in_progress',
+            });
+            core.setOutput('deployment_id', deployment.id);
       - name: Run Chromatic
+        id: chromatic
         uses: chromaui/action@latest
         with:
           # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           autoAcceptChanges: true
           exitOnceUploaded: true
+      - name: Update deployment status
+        if: always()
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: ${{ steps.deployment.outputs.deployment_id }},
+              state: '${{ steps.chromatic.outcome }}' === 'success' ? 'success' : 'failure',
+              environment_url: '${{ steps.chromatic.outputs.storybookUrl }}',
+              log_url: `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 29 (2026-06-02)
 
 ### Added
-- **Chromatic Storybook deploy** — GitHub Actions workflow publishes Storybook to Chromatic on every push; visual changes are auto-accepted so CI never blocks on review.
+- **Chromatic Storybook deploy** — GitHub Actions workflow publishes Storybook to Chromatic on every push; visual changes are auto-accepted so CI never blocks on review. ([#137](https://github.com/patcon/polislike-partykit-reaction-canvas/pull/137))
 
 ### Added
 - **Screen Light panel** — new canvas activity mode (`screen-light`) that turns a participant's phone into a full-screen colored light; color and brightness are controlled remotely by an admin running the Light Show panel; screen wake lock is on by default with a subtle toggle in the bottom-right corner.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 29 (2026-06-02)
 
 ### Added
+- **Chromatic Storybook deploy** — GitHub Actions workflow publishes Storybook to Chromatic on every push; visual changes are auto-accepted so CI never blocks on review.
+
+### Added
 - **Screen Light panel** — new canvas activity mode (`screen-light`) that turns a participant's phone into a full-screen colored light; color and brightness are controlled remotely by an admin running the Light Show panel; screen wake lock is on by default with a subtle toggle in the bottom-right corner.
 - **Light Show panel** — new patchable controller panel (`light-show`) for setting the color (via presets + custom picker) and brightness (dimmer slider) of all connected Screen Light phones in real time.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Polislike Reaction Canvas
 
 [![Perf Test](https://github.com/patcon/polislike-partykit-reaction-canvas/actions/workflows/perf-test.yml/badge.svg)](https://github.com/patcon/polislike-partykit-reaction-canvas/actions/workflows/perf-test.yml)
+[![Storybook](https://raw.githubusercontent.com/storybook-eol/storybook-badges/main/packages/badges/src/storybook.svg)](https://main--6a22541e42df9b5a4da5e047.chromatic.com)
 
 A real-time collaborative voting canvas built on [PartyKit](https://partykit.io) (WebSockets) and React. Participants drag or touch their cursor into **Agree / Disagree / Pass** regions of a shared canvas; positions are broadcast live so everyone can see collective reactions in real time.
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "cachebust": "node scripts/build-with-cachebust.js",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
+    "chromatic": "pnpm dlx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "perf": "echo 'Observe at: http://localhost:1999/#perf' && k6 run perf/load-test-k6.js",

--- a/stories/ArrivalCanvasPanel.stories.tsx
+++ b/stories/ArrivalCanvasPanel.stories.tsx
@@ -51,7 +51,7 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('0')).toBeInTheDocument();
-    await expect(canvas.getByText('/ 20')).toBeInTheDocument();
+    await expect(canvas.findByText('/ 20')).resolves.toBeInTheDocument();
   },
 };
 

--- a/stories/GreeterPanel.stories.tsx
+++ b/stories/GreeterPanel.stories.tsx
@@ -37,7 +37,7 @@ export const WithBadUrl: Story = {
   args: { greeterConfig: { eventUrl: 'https://example.com' } },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByText(/Unrecognized URL.*Contact the app admin/)).toBeInTheDocument();
+    await expect(canvas.findByText(/Unrecognized URL.*Contact the app admin/)).resolves.toBeInTheDocument();
   },
 };
 

--- a/stories/MapViewerPanel.stories.tsx
+++ b/stories/MapViewerPanel.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, within } from 'storybook/test';
-import React from 'react';
+import React, { useEffect } from 'react';
 import MapViewerPanel from '../app/components/panels/MapViewerPanel';
 import { PanelContextProvider } from '../app/context/PanelContext';
 import { MapViewerConfigProvider } from '../app/context/PanelConfigs';
@@ -66,11 +66,24 @@ export const NoProjection: Story = {
   },
 };
 
+function ProjectionDriver({ room, projection }: { room: string; projection: MapProjection }) {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      emitToRoom(room, { type: 'connected', mapProjection: projection, connectedUserIds: [], roomAnchors: null });
+    }, 0);
+    return () => clearTimeout(timer);
+  }, [room, projection]);
+  return null;
+}
+
 export const WithGaussianBlob: Story = {
+  render: (args) => (
+    <>
+      <ProjectionDriver room={(args as any).room ?? 'storybook'} projection={GAUSSIAN_PROJECTION} />
+      <MapViewerPanel />
+    </>
+  ),
   play: async ({ canvasElement }) => {
-    // defer emit until after usePartySocket's useEffect has subscribed
-    await new Promise(r => requestAnimationFrame(r));
-    emitToRoom('storybook', { type: 'connected', mapProjection: GAUSSIAN_PROJECTION, connectedUserIds: [], roomAnchors: null });
     const canvas = within(canvasElement);
     await expect(canvas.findByText(/UMAP/)).resolves.toBeInTheDocument();
   },

--- a/stories/MapViewerPanel.stories.tsx
+++ b/stories/MapViewerPanel.stories.tsx
@@ -68,9 +68,10 @@ export const NoProjection: Story = {
 
 export const WithGaussianBlob: Story = {
   play: async ({ canvasElement }) => {
+    // defer emit until after usePartySocket's useEffect has subscribed
+    await new Promise(r => requestAnimationFrame(r));
     emitToRoom('storybook', { type: 'connected', mapProjection: GAUSSIAN_PROJECTION, connectedUserIds: [], roomAnchors: null });
     const canvas = within(canvasElement);
-    // findByText waits for the async state update triggered by emitToRoom to flush
     await expect(canvas.findByText(/UMAP/)).resolves.toBeInTheDocument();
   },
 };


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/storybook.yaml` that runs `chromaui/action@latest` on every push to all branches
- Sets `autoAcceptChanges: true` so visual diffs are never flagged for review (no CI gate on Chromatic)
- Adds a `pnpm run chromatic` script for local Chromatic runs (uses `CHROMATIC_PROJECT_TOKEN` env var)

## Prerequisites

Set `CHROMATIC_PROJECT_TOKEN` as a repository secret in GitHub Settings → Secrets → Actions before this workflow can pass.

## Test plan

- [ ] Set `CHROMATIC_PROJECT_TOKEN` secret in repo settings
- [ ] Merge PR and confirm "Storybook" workflow appears and passes in GitHub Actions
- [ ] Verify Chromatic dashboard shows a published build with all stories
- [ ] Confirm no "pending review" blocks the CI check

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~80 words of PR description from ~50 words of human prompt)