### PR TITLE
perf(server): batch cursor broadcasts to reduce message rate

### DIFF
--- a/app/components/panels/AdminPanelNoDB/index.tsx
+++ b/app/components/panels/AdminPanelNoDB/index.tsx
@@ -103,8 +103,15 @@ export default function AdminPanelNoDB({ room, userId, selfChain }: AdminPanelNo
     onMessage(evt) {
       try {
         const data = JSON.parse(evt.data);
-        dispatchRef.current(data);
-        busRef.current.notify(data);
+        if (data.type === 'cursorBatch' && Array.isArray(data.cursors)) {
+          for (const cursorEvent of data.cursors) {
+            dispatchRef.current(cursorEvent);
+            busRef.current.notify(cursorEvent);
+          }
+        } else {
+          dispatchRef.current(data);
+          busRef.current.notify(data);
+        }
       } catch (e) {
         console.error('AdminPanelV4: failed to parse message', e);
       }

--- a/app/components/viz/ValenceViz.tsx
+++ b/app/components/viz/ValenceViz.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { generateUUID } from "../../utils/userId";
+import { expandCursorEvents } from "../../utils/cursor";
 
 const CAM_MODES = ['static', 'lerp', 'exp', 'spring', 'quat'];
 
@@ -818,8 +819,9 @@ export default function ValenceViz() {
           assignLiveSlot(data.userId);
         } else if (data.type==='userLeft') {
           cursors.delete(data.userId); freeLiveSlot(data.userId);
-        } else if (data.type==='cursorBatch') {
-          for (const e of (data.cursors??[])) {
+        } else {
+          const events = expandCursorEvents(data);
+          for (const e of events) {
             if (e.type==='move'||e.type==='touch') {
               const {userId,x,y}=e.position;
               cursors.set(userId,{x,y}); assignLiveSlot(userId);
@@ -828,14 +830,7 @@ export default function ValenceViz() {
               if (userId.startsWith('replay_')) freeLiveSlot(userId);
             }
           }
-          setAudienceN(cursors.size);
-        } else if (data.type==='move'||data.type==='touch') {
-          const {userId,x,y}=data.position;
-          cursors.set(userId,{x,y}); assignLiveSlot(userId); setAudienceN(cursors.size);
-        } else if (data.type==='remove') {
-          const {userId}=data.position; cursors.delete(userId);
-          if (userId.startsWith('replay_')) freeLiveSlot(userId);
-          setAudienceN(cursors.size);
+          if (events.length > 0) setAudienceN(cursors.size);
         }
       };
       ws.onerror=()=>{ setWsStatusText('connection error'); setWsStatusCls('warn'); };

--- a/app/components/viz/ValenceViz.tsx
+++ b/app/components/viz/ValenceViz.tsx
@@ -818,6 +818,17 @@ export default function ValenceViz() {
           assignLiveSlot(data.userId);
         } else if (data.type==='userLeft') {
           cursors.delete(data.userId); freeLiveSlot(data.userId);
+        } else if (data.type==='cursorBatch') {
+          for (const e of (data.cursors??[])) {
+            if (e.type==='move'||e.type==='touch') {
+              const {userId,x,y}=e.position;
+              cursors.set(userId,{x,y}); assignLiveSlot(userId);
+            } else if (e.type==='remove') {
+              const {userId}=e.position; cursors.delete(userId);
+              if (userId.startsWith('replay_')) freeLiveSlot(userId);
+            }
+          }
+          setAudienceN(cursors.size);
         } else if (data.type==='move'||data.type==='touch') {
           const {userId,x,y}=data.position;
           cursors.set(userId,{x,y}); assignLiveSlot(userId); setAudienceN(cursors.size);

--- a/app/utils/cursor.ts
+++ b/app/utils/cursor.ts
@@ -9,6 +9,27 @@ export const CURSOR_THROTTLE_MS = 33;
 // and broadcast each event immediately (useful for perf comparison).
 export const SERVER_CURSOR_BATCH_MS = 50;
 
+/** Minimal cursor event shape shared by all consumers. */
+export type CursorEventMsg = {
+  type: string;
+  position: { userId: string; x: number; y: number };
+};
+
+/**
+ * Normalizes an incoming WebSocket message into a flat array of cursor events.
+ * Handles both individual `move`/`touch`/`remove` messages and the batched
+ * `cursorBatch` format emitted by the server when SERVER_CURSOR_BATCH_MS > 0.
+ * Returns [] for any non-cursor message, so callers can always just `for...of`.
+ */
+export function expandCursorEvents(
+  data: { type: string; position?: CursorEventMsg['position']; cursors?: CursorEventMsg[] },
+): CursorEventMsg[] {
+  if (data.type === 'cursorBatch') return data.cursors ?? [];
+  if (data.type === 'move' || data.type === 'touch' || data.type === 'remove')
+    return [data as CursorEventMsg];
+  return [];
+}
+
 // Smooth cursor config — applied in the main app and perf app.
 // Tune these values in PerfCanvasApp's debug UI, then update here.
 export const SMOOTH_CURSOR_ENABLED = true;

--- a/app/utils/cursor.ts
+++ b/app/utils/cursor.ts
@@ -4,6 +4,11 @@
 // reflect real client behaviour.
 export const CURSOR_THROTTLE_MS = 33;
 
+// Server-side batching window in ms. The server coalesces cursor events within
+// this window into a single cursorBatch broadcast. Set to 0 to disable batching
+// and broadcast each event immediately (useful for perf comparison).
+export const SERVER_CURSOR_BATCH_MS = 50;
+
 // Smooth cursor config — applied in the main app and perf app.
 // Tune these values in PerfCanvasApp's debug UI, then update here.
 export const SMOOTH_CURSOR_ENABLED = true;

--- a/party/server.ts
+++ b/party/server.ts
@@ -5,6 +5,7 @@ import type { ReactionAnchors } from './lib/reactionRegion';
 import { getCurrentActiveStatementId, computeNextDisplayTimestamp, computeClearedQueue } from './lib/queueLogic';
 import type { QueueItem } from './lib/queueLogic';
 import { GhostCursorManager } from './lib/ghostCursors';
+import { SERVER_CURSOR_BATCH_MS } from '../app/utils/cursor';
 import { PLUGIN_MAP } from '../plugins/index';
 import type { PluginContext, PluginConnection } from '../plugins/types';
 import { getSoccerBallState, getSoccerScore } from '../plugins/soccer/server';
@@ -42,6 +43,8 @@ export default class Server implements Party.Server {
   private msgRateInterval?: NodeJS.Timeout;
   private githubSubmissions: { username: string; displayName: string | null; avatarUrl: string | null; timestamp: number }[] = [];
   private cursorPositions = new Map<string, { x: number; y: number }>();
+  private pendingCursorUpdates = new Map<string, CursorEvent>();
+  private batchTimer: ReturnType<typeof setTimeout> | null = null;
   private inviteEdges = new Map<string, string>(); // inviteeId -> inviterId
   private customAvatars = new Map<string, string>(); // userId -> photoUrl
   private colorCursorsByVote: boolean = false;
@@ -360,6 +363,14 @@ private pluginStates = new Map<string, unknown>(
 
   // --- Cursor handlers ---
 
+  private flushCursorBatch(): void {
+    if (this.pendingCursorUpdates.size === 0) return;
+    const cursors = [...this.pendingCursorUpdates.values()];
+    this.pendingCursorUpdates.clear();
+    this.batchTimer = null;
+    this.room.broadcast(JSON.stringify({ type: 'cursorBatch', cursors }));
+  }
+
   private handlePlaybackCursorBroadcast(event: PlaybackCursorBroadcastEvent): void {
     // Admin replaying recorded events — broadcast to ALL clients (including sender)
     // so the admin's own "Peek Canvas" tab also sees playback cursors
@@ -378,7 +389,14 @@ private pluginStates = new Map<string, unknown>(
     } else if (event.type === 'remove') {
       this.cursorPositions.delete(event.position.userId);
     }
-    this.room.broadcast(message, [sender.id]);
+    if (SERVER_CURSOR_BATCH_MS > 0) {
+      this.pendingCursorUpdates.set(event.position.userId, event);
+      if (!this.batchTimer) {
+        this.batchTimer = setTimeout(() => this.flushCursorBatch(), SERVER_CURSOR_BATCH_MS);
+      }
+    } else {
+      this.room.broadcast(message, [sender.id]);
+    }
   }
 
   // --- Statement / queue handlers ---

--- a/party/tests/pluginDispatch.test.ts
+++ b/party/tests/pluginDispatch.test.ts
@@ -52,6 +52,10 @@ vi.mock('../../plugins/soccer/server', () => ({
   getSoccerScore:     () => ({ left: 0, right: 0 }),
 }));
 
+// Disable cursor batching so dispatch tests get immediate broadcasts
+// without needing fake timers. Batching behaviour is tested in server.test.ts.
+vi.mock('../../app/utils/cursor', () => ({ SERVER_CURSOR_BATCH_MS: 0 }));
+
 import Server from '../server';
 import { createMockRoom, createMockConnection, makeConnectCtx } from './helpers/mockParty';
 

--- a/party/tests/server.test.ts
+++ b/party/tests/server.test.ts
@@ -3,6 +3,10 @@ import type * as Party from 'partykit/server';
 import Server from '../server';
 import { createMockRoom, createMockConnection, makeConnectCtx } from './helpers/mockParty';
 
+// Mutable mock so individual describe blocks can test both batching modes.
+const cursorMock = vi.hoisted(() => ({ SERVER_CURSOR_BATCH_MS: 50 }));
+vi.mock('../../app/utils/cursor', () => cursorMock);
+
 // Helper: JSON-encode a client event for onMessage
 function msg(event: object): string {
   return JSON.stringify(event);
@@ -51,28 +55,90 @@ describe('Server onMessage handlers', () => {
   // -----------------------------------------------------------------------
 
   describe('cursor: move / touch / remove', () => {
-    it('move: tracks position and broadcasts to others', () => {
-      const { conn } = connectUser('alice');
-      server.onMessage(msg({ type: 'move', position: { userId: 'alice', x: 0.5, y: 0.3, timestamp: 1 } }), conn);
-      expect(broadcast).toHaveBeenCalledOnce();
-      expect(broadcast.mock.calls[0][1]).toEqual([conn.id]); // excludes sender
+    describe('batching disabled (SERVER_CURSOR_BATCH_MS = 0)', () => {
+      beforeEach(() => { cursorMock.SERVER_CURSOR_BATCH_MS = 0; });
+      afterEach(() => { cursorMock.SERVER_CURSOR_BATCH_MS = 50; });
+
+      it('move: tracks position and broadcasts immediately to others', () => {
+        const { conn } = connectUser('alice');
+        server.onMessage(msg({ type: 'move', position: { userId: 'alice', x: 0.5, y: 0.3, timestamp: 1 } }), conn);
+        expect(broadcast).toHaveBeenCalledOnce();
+        expect(broadcast.mock.calls[0][1]).toEqual([conn.id]); // excludes sender
+        const payload = JSON.parse(broadcast.mock.calls[0][0] as string);
+        expect(payload.type).toBe('move');
+      });
+
+      it('touch: tracks position and broadcasts immediately to others', () => {
+        const { conn } = connectUser('alice');
+        server.onMessage(msg({ type: 'touch', position: { userId: 'alice', x: 0.2, y: 0.8, timestamp: 1 } }), conn);
+        expect(broadcast).toHaveBeenCalledOnce();
+        expect(broadcast.mock.calls[0][1]).toEqual([conn.id]);
+        const payload = JSON.parse(broadcast.mock.calls[0][0] as string);
+        expect(payload.type).toBe('touch');
+      });
+
+      it('remove: removes tracked position and broadcasts immediately to others', () => {
+        const { conn } = connectUser('alice');
+        server.onMessage(msg({ type: 'move', position: { userId: 'alice', x: 0.5, y: 0.5, timestamp: 1 } }), conn);
+        broadcast.mockClear();
+        server.onMessage(msg({ type: 'remove', position: { userId: 'alice', x: 0, y: 0, timestamp: 2 } }), conn);
+        expect(broadcast).toHaveBeenCalledOnce();
+        expect(broadcast.mock.calls[0][1]).toEqual([conn.id]);
+        const payload = JSON.parse(broadcast.mock.calls[0][0] as string);
+        expect(payload.type).toBe('remove');
+      });
     });
 
-    it('touch: tracks position and broadcasts to others', () => {
-      const { conn } = connectUser('alice');
-      server.onMessage(msg({ type: 'touch', position: { userId: 'alice', x: 0.2, y: 0.8, timestamp: 1 } }), conn);
-      expect(broadcast).toHaveBeenCalledOnce();
-      expect(broadcast.mock.calls[0][1]).toEqual([conn.id]);
-    });
+    describe('batching enabled (SERVER_CURSOR_BATCH_MS = 50)', () => {
+      beforeEach(() => { cursorMock.SERVER_CURSOR_BATCH_MS = 50; vi.useFakeTimers(); });
+      afterEach(() => { vi.useRealTimers(); });
 
-    it('remove: removes tracked position and broadcasts to others', () => {
-      const { conn } = connectUser('alice');
-      // First establish a position
-      server.onMessage(msg({ type: 'move', position: { userId: 'alice', x: 0.5, y: 0.5, timestamp: 1 } }), conn);
-      broadcast.mockClear();
-      server.onMessage(msg({ type: 'remove', position: { userId: 'alice', x: 0, y: 0, timestamp: 2 } }), conn);
-      expect(broadcast).toHaveBeenCalledOnce();
-      expect(broadcast.mock.calls[0][1]).toEqual([conn.id]);
+      it('move: not broadcast until timer fires, then cursorBatch to all', () => {
+        const { conn } = connectUser('alice');
+        server.onMessage(msg({ type: 'move', position: { userId: 'alice', x: 0.5, y: 0.3, timestamp: 1 } }), conn);
+        expect(broadcast).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(50);
+        expect(broadcast).toHaveBeenCalledOnce();
+        const payload = JSON.parse(broadcast.mock.calls[0][0] as string);
+        expect(payload.type).toBe('cursorBatch');
+        expect(payload.cursors[0]).toMatchObject({ type: 'move', position: { userId: 'alice' } });
+      });
+
+      it('touch: not broadcast until timer fires, then cursorBatch to all', () => {
+        const { conn } = connectUser('alice');
+        server.onMessage(msg({ type: 'touch', position: { userId: 'alice', x: 0.2, y: 0.8, timestamp: 1 } }), conn);
+        expect(broadcast).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(50);
+        expect(broadcast).toHaveBeenCalledOnce();
+        const payload = JSON.parse(broadcast.mock.calls[0][0] as string);
+        expect(payload.type).toBe('cursorBatch');
+        expect(payload.cursors[0]).toMatchObject({ type: 'touch', position: { userId: 'alice' } });
+      });
+
+      it('remove: not broadcast until timer fires, then cursorBatch to all', () => {
+        const { conn } = connectUser('alice');
+        server.onMessage(msg({ type: 'move', position: { userId: 'alice', x: 0.5, y: 0.5, timestamp: 1 } }), conn);
+        vi.advanceTimersByTime(50);
+        broadcast.mockClear();
+        server.onMessage(msg({ type: 'remove', position: { userId: 'alice', x: 0, y: 0, timestamp: 2 } }), conn);
+        expect(broadcast).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(50);
+        expect(broadcast).toHaveBeenCalledOnce();
+        const payload = JSON.parse(broadcast.mock.calls[0][0] as string);
+        expect(payload.type).toBe('cursorBatch');
+        expect(payload.cursors[0]).toMatchObject({ type: 'remove', position: { userId: 'alice' } });
+      });
+
+      it('coalesces rapid moves from the same user into one cursor entry', () => {
+        const { conn } = connectUser('alice');
+        server.onMessage(msg({ type: 'move', position: { userId: 'alice', x: 0.1, y: 0.1, timestamp: 1 } }), conn);
+        server.onMessage(msg({ type: 'move', position: { userId: 'alice', x: 0.9, y: 0.9, timestamp: 2 } }), conn);
+        vi.advanceTimersByTime(50);
+        expect(broadcast).toHaveBeenCalledOnce();
+        const payload = JSON.parse(broadcast.mock.calls[0][0] as string);
+        expect(payload.cursors).toHaveLength(1); // coalesced
+        expect(payload.cursors[0].position).toMatchObject({ x: 0.9, y: 0.9 }); // latest wins
+      });
     });
   });
 

--- a/plugins/map/mapViewer.tsx
+++ b/plugins/map/mapViewer.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import usePartySocket from 'partysocket/react';
 import * as d3 from 'd3';
 import { getPartySocketConfig } from '../../app/utils/partyHost';
+import { expandCursorEvents } from '../../app/utils/cursor';
 import { usePanelContext } from '../../app/context/PanelContext';
 import { useMapViewerConfig } from './useMapViewerConfig';
 import { idbGet } from '../../app/utils/idbStorage';
@@ -295,9 +296,9 @@ export default function MapViewerPanel() {
         setLiveCursors(prev => { const next = new Map(prev); next.delete(data.userId); return next; });
         return;
       }
-      const applyOneCursor = (e: { type: string; position?: { userId: string; x: number; y: number } }) => {
+      for (const e of expandCursorEvents(data)) {
         if (e.type === 'move' || e.type === 'touch') {
-          const { userId: uid, x, y } = e.position!;
+          const { userId: uid, x, y } = e.position;
           setLiveCursors(prev => new Map(prev).set(uid, { x, y }));
           const existing = cursorTimers.current.get(uid);
           if (existing) clearTimeout(existing);
@@ -306,21 +307,11 @@ export default function MapViewerPanel() {
             cursorTimers.current.delete(uid);
           }, 3000));
         } else if (e.type === 'remove') {
-          const uid = e.position?.userId;
-          if (uid) {
-            setLiveCursors(prev => { const next = new Map(prev); next.delete(uid); return next; });
-            const t = cursorTimers.current.get(uid);
-            if (t) { clearTimeout(t); cursorTimers.current.delete(uid); }
-          }
+          const { userId: uid } = e.position;
+          setLiveCursors(prev => { const next = new Map(prev); next.delete(uid); return next; });
+          const t = cursorTimers.current.get(uid);
+          if (t) { clearTimeout(t); cursorTimers.current.delete(uid); }
         }
-      };
-      if (data.type === 'cursorBatch') {
-        for (const e of (data.cursors ?? [])) applyOneCursor(e);
-        return;
-      }
-      if (data.type === 'move' || data.type === 'touch' || data.type === 'remove') {
-        applyOneCursor(data);
-        return;
       }
     },
   });

--- a/plugins/map/mapViewer.tsx
+++ b/plugins/map/mapViewer.tsx
@@ -295,24 +295,32 @@ export default function MapViewerPanel() {
         setLiveCursors(prev => { const next = new Map(prev); next.delete(data.userId); return next; });
         return;
       }
-      if (data.type === 'move' || data.type === 'touch') {
-        const { userId: uid, x, y } = data.position;
-        setLiveCursors(prev => new Map(prev).set(uid, { x, y }));
-        const existing = cursorTimers.current.get(uid);
-        if (existing) clearTimeout(existing);
-        cursorTimers.current.set(uid, setTimeout(() => {
-          setLiveCursors(prev => { const next = new Map(prev); next.delete(uid); return next; });
-          cursorTimers.current.delete(uid);
-        }, 3000));
+      const applyOneCursor = (e: { type: string; position?: { userId: string; x: number; y: number } }) => {
+        if (e.type === 'move' || e.type === 'touch') {
+          const { userId: uid, x, y } = e.position!;
+          setLiveCursors(prev => new Map(prev).set(uid, { x, y }));
+          const existing = cursorTimers.current.get(uid);
+          if (existing) clearTimeout(existing);
+          cursorTimers.current.set(uid, setTimeout(() => {
+            setLiveCursors(prev => { const next = new Map(prev); next.delete(uid); return next; });
+            cursorTimers.current.delete(uid);
+          }, 3000));
+        } else if (e.type === 'remove') {
+          const uid = e.position?.userId;
+          if (uid) {
+            setLiveCursors(prev => { const next = new Map(prev); next.delete(uid); return next; });
+            const t = cursorTimers.current.get(uid);
+            if (t) { clearTimeout(t); cursorTimers.current.delete(uid); }
+          }
+        }
+      };
+      if (data.type === 'cursorBatch') {
+        for (const e of (data.cursors ?? [])) applyOneCursor(e);
         return;
       }
-      if (data.type === 'remove') {
-        const uid = data.position?.userId;
-        if (uid) {
-          setLiveCursors(prev => { const next = new Map(prev); next.delete(uid); return next; });
-          const t = cursorTimers.current.get(uid);
-          if (t) { clearTimeout(t); cursorTimers.current.delete(uid); }
-        }
+      if (data.type === 'move' || data.type === 'touch' || data.type === 'remove') {
+        applyOneCursor(data);
+        return;
       }
     },
   });

--- a/plugins/moodTones/component.tsx
+++ b/plugins/moodTones/component.tsx
@@ -278,24 +278,31 @@ export default function MoodTonesPanel() {
     onClose: () => setWsStatus('disconnected'),
     onError: () => setWsStatus('disconnected'),
     onMessage(evt) {
-      let data: { type: string; count?: number; position?: { userId: string; x: number; y: number } };
+      let data: { type: string; count?: number; position?: { userId: string; x: number; y: number }; cursors?: Array<{ type: string; position: { userId: string; x: number; y: number } }> };
       try { data = JSON.parse(evt.data as string); } catch { return; }
-      if (data.type === 'presenceCount') {
-        setAudienceCount(data.count ?? 0);
-      } else if (data.type === 'move' || data.type === 'touch') {
-        const { userId, x, y } = data.position!;
-        const region = computeReactionRegion(x, y) ?? 'neutral';
-        const prevRegion = cursorRegionsRef.current.get(userId);
-        cursorsRef.current.set(userId, { x, y, region });
-        if (valenceModeRef.current === 'continuous' || region !== prevRegion) {
-          cursorRegionsRef.current.set(userId, region);
+      const applyOneCursor = (e: { type: string; position: { userId: string; x: number; y: number } }) => {
+        if (e.type === 'move' || e.type === 'touch') {
+          const { userId, x, y } = e.position;
+          const region = computeReactionRegion(x, y) ?? 'neutral';
+          const prevRegion = cursorRegionsRef.current.get(userId);
+          cursorsRef.current.set(userId, { x, y, region });
+          if (valenceModeRef.current === 'continuous' || region !== prevRegion) {
+            cursorRegionsRef.current.set(userId, region);
+            applyAudienceMood();
+          }
+        } else if (e.type === 'remove') {
+          const { userId } = e.position;
+          cursorsRef.current.delete(userId);
+          cursorRegionsRef.current.delete(userId);
           applyAudienceMood();
         }
-      } else if (data.type === 'remove') {
-        const { userId } = data.position!;
-        cursorsRef.current.delete(userId);
-        cursorRegionsRef.current.delete(userId);
-        applyAudienceMood();
+      };
+      if (data.type === 'presenceCount') {
+        setAudienceCount(data.count ?? 0);
+      } else if (data.type === 'cursorBatch') {
+        (data.cursors ?? []).forEach(applyOneCursor);
+      } else if (data.type === 'move' || data.type === 'touch' || data.type === 'remove') {
+        applyOneCursor(data as { type: string; position: { userId: string; x: number; y: number } });
       }
     },
   });

--- a/plugins/moodTones/component.tsx
+++ b/plugins/moodTones/component.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import usePartySocket from 'partysocket/react';
 import { usePanelContext } from "../../app/context/PanelContext";
 import { getPartySocketConfig } from '../../app/utils/partyHost';
+import { expandCursorEvents } from '../../app/utils/cursor';
 import { generateUUID } from '../../app/utils/userId';
 import { computeCursorValence, computeReactionRegion } from '../../app/utils/voteRegion';
 
@@ -278,31 +279,28 @@ export default function MoodTonesPanel() {
     onClose: () => setWsStatus('disconnected'),
     onError: () => setWsStatus('disconnected'),
     onMessage(evt) {
-      let data: { type: string; count?: number; position?: { userId: string; x: number; y: number }; cursors?: Array<{ type: string; position: { userId: string; x: number; y: number } }> };
+      let data: { type: string; count?: number; position?: { userId: string; x: number; y: number } };
       try { data = JSON.parse(evt.data as string); } catch { return; }
-      const applyOneCursor = (e: { type: string; position: { userId: string; x: number; y: number } }) => {
-        if (e.type === 'move' || e.type === 'touch') {
-          const { userId, x, y } = e.position;
-          const region = computeReactionRegion(x, y) ?? 'neutral';
-          const prevRegion = cursorRegionsRef.current.get(userId);
-          cursorsRef.current.set(userId, { x, y, region });
-          if (valenceModeRef.current === 'continuous' || region !== prevRegion) {
-            cursorRegionsRef.current.set(userId, region);
-            applyAudienceMood();
-          }
-        } else if (e.type === 'remove') {
-          const { userId } = e.position;
-          cursorsRef.current.delete(userId);
-          cursorRegionsRef.current.delete(userId);
-          applyAudienceMood();
-        }
-      };
       if (data.type === 'presenceCount') {
         setAudienceCount(data.count ?? 0);
-      } else if (data.type === 'cursorBatch') {
-        (data.cursors ?? []).forEach(applyOneCursor);
-      } else if (data.type === 'move' || data.type === 'touch' || data.type === 'remove') {
-        applyOneCursor(data as { type: string; position: { userId: string; x: number; y: number } });
+      } else {
+        for (const e of expandCursorEvents(data)) {
+          if (e.type === 'move' || e.type === 'touch') {
+            const { userId, x, y } = e.position;
+            const region = computeReactionRegion(x, y) ?? 'neutral';
+            const prevRegion = cursorRegionsRef.current.get(userId);
+            cursorsRef.current.set(userId, { x, y, region });
+            if (valenceModeRef.current === 'continuous' || region !== prevRegion) {
+              cursorRegionsRef.current.set(userId, region);
+              applyAudienceMood();
+            }
+          } else if (e.type === 'remove') {
+            const { userId } = e.position;
+            cursorsRef.current.delete(userId);
+            cursorRegionsRef.current.delete(userId);
+            applyAudienceMood();
+          }
+        }
       }
     },
   });

--- a/plugins/neighbor/component.tsx
+++ b/plugins/neighbor/component.tsx
@@ -3,6 +3,7 @@ import usePartySocket from 'partysocket/react';
 import * as d3 from 'd3';
 import { usePanelContext } from '../../app/context/PanelContext';
 import { getPartySocketConfig } from '../../app/utils/partyHost';
+import { expandCursorEvents } from '../../app/utils/cursor';
 import { generateUUID } from '../../app/utils/userId';
 import { computeReactionRegion, DEFAULT_ANCHORS } from '../../app/utils/voteRegion';
 import type { ReactionAnchors } from '../../app/utils/voteRegion';
@@ -171,22 +172,18 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       } else if (msg.type === 'roomAnchorsChanged') {
         anchorsRef.current = msg.anchors ?? DEFAULT_ANCHORS;
         updateNodeColors();
-      } else if (msg.type === 'cursorBatch') {
-        for (const e of (msg.cursors ?? [])) {
+      } else if (msg.type === 'move' || msg.type === 'touch' || msg.type === 'remove' || msg.type === 'cursorBatch') {
+        let changed = false;
+        for (const e of expandCursorEvents(msg)) {
           if (e.type === 'move' || e.type === 'touch') {
             liveCursorsRef.current.set(e.position.userId, { x: e.position.x, y: e.position.y });
+            changed = true;
           } else if (e.type === 'remove') {
             liveCursorsRef.current.delete(e.position.userId);
+            changed = true;
           }
         }
-        updateNodeColors();
-      } else if (msg.type === 'move' || msg.type === 'touch') {
-        const { userId, x, y } = msg.position;
-        liveCursorsRef.current.set(userId, { x, y });
-        updateNodeColors();
-      } else if (msg.type === 'remove') {
-        liveCursorsRef.current.delete(msg.position.userId);
-        updateNodeColors();
+        if (changed) updateNodeColors();
       } else if (msg.type === 'userJoined') {
         const uid: string = msg.userId;
         const existing = nodesRef.current.find(n => n.id === uid);

--- a/plugins/neighbor/component.tsx
+++ b/plugins/neighbor/component.tsx
@@ -171,6 +171,15 @@ export default function NeighborPanel({ initialView = 'entry' as View }: { initi
       } else if (msg.type === 'roomAnchorsChanged') {
         anchorsRef.current = msg.anchors ?? DEFAULT_ANCHORS;
         updateNodeColors();
+      } else if (msg.type === 'cursorBatch') {
+        for (const e of (msg.cursors ?? [])) {
+          if (e.type === 'move' || e.type === 'touch') {
+            liveCursorsRef.current.set(e.position.userId, { x: e.position.x, y: e.position.y });
+          } else if (e.type === 'remove') {
+            liveCursorsRef.current.delete(e.position.userId);
+          }
+        }
+        updateNodeColors();
       } else if (msg.type === 'move' || msg.type === 'touch') {
         const { userId, x, y } = msg.position;
         liveCursorsRef.current.set(userId, { x, y });

--- a/plugins/valenceBeatPad/component.tsx
+++ b/plugins/valenceBeatPad/component.tsx
@@ -333,17 +333,24 @@ export default function ValenceBeatPadPanel() {
     onClose: () => setWsStatus('disconnected'),
     onError: () => setWsStatus('disconnected'),
     onMessage(evt) {
-      let data: { type: string; count?: number; position?: { userId: string; x: number; y: number } };
+      let data: { type: string; count?: number; position?: { userId: string; x: number; y: number }; cursors?: Array<{ type: string; position: { userId: string; x: number; y: number } }> };
       try { data = JSON.parse(evt.data as string); } catch { return; }
+      const applyOneCursor = (e: { type: string; position: { userId: string; x: number; y: number } }) => {
+        if (e.type === 'move' || e.type === 'touch') {
+          const { userId, x, y } = e.position;
+          cursorsRef.current.set(userId, { x, y });
+          applyAudienceMood();
+        } else if (e.type === 'remove') {
+          cursorsRef.current.delete(e.position.userId);
+          applyAudienceMood();
+        }
+      };
       if (data.type === 'presenceCount') {
         setAudienceCount(data.count ?? 0);
-      } else if (data.type === 'move' || data.type === 'touch') {
-        const { userId, x, y } = data.position!;
-        cursorsRef.current.set(userId, { x, y });
-        applyAudienceMood();
-      } else if (data.type === 'remove') {
-        cursorsRef.current.delete(data.position!.userId);
-        applyAudienceMood();
+      } else if (data.type === 'cursorBatch') {
+        (data.cursors ?? []).forEach(applyOneCursor);
+      } else if (data.type === 'move' || data.type === 'touch' || data.type === 'remove') {
+        applyOneCursor(data as { type: string; position: { userId: string; x: number; y: number } });
       }
     },
   });

--- a/plugins/valenceBeatPad/component.tsx
+++ b/plugins/valenceBeatPad/component.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import usePartySocket from 'partysocket/react';
 import { usePanelContext } from "../../app/context/PanelContext";
 import { getPartySocketConfig } from '../../app/utils/partyHost';
+import { expandCursorEvents } from '../../app/utils/cursor';
 import { generateUUID } from '../../app/utils/userId';
 import { computeCursorValence } from '../../app/utils/voteRegion';
 
@@ -333,24 +334,21 @@ export default function ValenceBeatPadPanel() {
     onClose: () => setWsStatus('disconnected'),
     onError: () => setWsStatus('disconnected'),
     onMessage(evt) {
-      let data: { type: string; count?: number; position?: { userId: string; x: number; y: number }; cursors?: Array<{ type: string; position: { userId: string; x: number; y: number } }> };
+      let data: { type: string; count?: number; position?: { userId: string; x: number; y: number } };
       try { data = JSON.parse(evt.data as string); } catch { return; }
-      const applyOneCursor = (e: { type: string; position: { userId: string; x: number; y: number } }) => {
-        if (e.type === 'move' || e.type === 'touch') {
-          const { userId, x, y } = e.position;
-          cursorsRef.current.set(userId, { x, y });
-          applyAudienceMood();
-        } else if (e.type === 'remove') {
-          cursorsRef.current.delete(e.position.userId);
-          applyAudienceMood();
-        }
-      };
       if (data.type === 'presenceCount') {
         setAudienceCount(data.count ?? 0);
-      } else if (data.type === 'cursorBatch') {
-        (data.cursors ?? []).forEach(applyOneCursor);
-      } else if (data.type === 'move' || data.type === 'touch' || data.type === 'remove') {
-        applyOneCursor(data as { type: string; position: { userId: string; x: number; y: number } });
+      } else {
+        for (const e of expandCursorEvents(data)) {
+          if (e.type === 'move' || e.type === 'touch') {
+            const { userId, x, y } = e.position;
+            cursorsRef.current.set(userId, { x, y });
+            applyAudienceMood();
+          } else if (e.type === 'remove') {
+            cursorsRef.current.delete(e.position.userId);
+            applyAudienceMood();
+          }
+        }
       }
     },
   });

--- a/public/mood-sounds.html
+++ b/public/mood-sounds.html
@@ -1042,6 +1042,24 @@ function setConnStatus(text, cls) {
   connStatus.className = 'conn-status' + (cls ? ' ' + cls : '');
 }
 
+function handleCursorEvent(e) {
+  if (e.type === 'move' || e.type === 'touch') {
+    const { userId, x, y } = e.position;
+    const region = computeRegion(x, y);
+    const prevRegion = cursorRegions.get(userId);
+    cursors.set(userId, { x, y, region });
+    if (valenceMode === 'continuous' || region !== prevRegion) {
+      cursorRegions.set(userId, region);
+      applyAudienceMood();
+    }
+  } else if (e.type === 'remove') {
+    const { userId } = e.position;
+    cursors.delete(userId);
+    cursorRegions.delete(userId);
+    applyAudienceMood();
+  }
+}
+
 function connectWs() {
   if (ws) {
     ws.onclose = null;
@@ -1072,22 +1090,11 @@ function connectWs() {
       const n = data.count ?? 0;
       audienceN.textContent = n;
       setConnStatus(`connected · room: ${room} · ${n} participant${n !== 1 ? 's' : ''}`, 'ok');
-    } else if (data.type === 'move' || data.type === 'touch') {
-      const { userId, x, y } = data.position;
-      const region = computeRegion(x, y);
-      const prevRegion = cursorRegions.get(userId);
-      cursors.set(userId, { x, y, region });
-      // Unit mode: only recalculate on zone transition or new cursor
-      if (valenceMode === 'continuous' || region !== prevRegion) {
-        cursorRegions.set(userId, region);
-        applyAudienceMood();
-      }
+    } else if (data.type === 'cursorBatch') {
+      (data.cursors || []).forEach(handleCursorEvent);
       audienceN.textContent = cursors.size;
-    } else if (data.type === 'remove') {
-      const { userId } = data.position;
-      cursors.delete(userId);
-      cursorRegions.delete(userId);
-      applyAudienceMood();
+    } else if (data.type === 'move' || data.type === 'touch' || data.type === 'remove') {
+      handleCursorEvent(data);
       audienceN.textContent = cursors.size;
     }
   };

--- a/public/valence-onboarding-v2.html
+++ b/public/valence-onboarding-v2.html
@@ -621,6 +621,21 @@ function removeLiveChord(userId){
   if(lc&&lc.departT==null)lc.departT=0;
 }
 
+function handleLiveCursorEvent(e){
+  if(e.type==='move'||e.type==='touch'){
+    const pos=e.position;
+    if(pos){
+      if(!liveChords.find(lc=>lc.userId===pos.userId)) addLiveChord(pos.userId);
+      const lc=liveChords.find(lc=>lc.userId===pos.userId);
+      if(lc){lc.value=cursorToValue(pos.x,pos.y);lc.hasTouched=true;lc.lifted=false;}
+    }
+  }else if(e.type==='remove'){
+    const uid=e.userId||(e.position&&e.position.userId);
+    const lc=liveChords.find(lc=>lc.userId===uid);
+    if(lc){lc.lifted=true;lc.value=0;}
+  }
+}
+
 function connectWs(room){
   if(ws){ws.onclose=null;ws.close();}
   if(wsReconnectTimer){clearTimeout(wsReconnectTimer);wsReconnectTimer=null;}
@@ -644,18 +659,10 @@ function connectWs(room){
       addLiveChord(data.userId);
     }else if(data.type==='userLeft'){
       removeLiveChord(data.userId||(data.position&&data.position.userId));
-    }else if(data.type==='move'||data.type==='touch'){
-      const pos=data.position;
-      if(pos){
-        // Auto-add chord if user was already connected when we joined (missed userJoined)
-        if(!liveChords.find(lc=>lc.userId===pos.userId)) addLiveChord(pos.userId);
-        const lc=liveChords.find(lc=>lc.userId===pos.userId);
-        if(lc){lc.value=cursorToValue(pos.x,pos.y);lc.hasTouched=true;lc.lifted=false;}
-      }
-    }else if(data.type==='remove'){
-      const uid=data.userId||(data.position&&data.position.userId);
-      const lc=liveChords.find(lc=>lc.userId===uid);
-      if(lc){lc.lifted=true;lc.value=0;}
+    }else if(data.type==='cursorBatch'){
+      (data.cursors||[]).forEach(e=>handleLiveCursorEvent(e));
+    }else if(data.type==='move'||data.type==='touch'||data.type==='remove'){
+      handleLiveCursorEvent(data);
     }
   };
   ws.onerror=()=>setConnStatus('connection error','warn');

--- a/public/valence-onboarding-v3.html
+++ b/public/valence-onboarding-v3.html
@@ -736,6 +736,21 @@ function removeLiveChord(userId){
   if(lc&&lc.departT==null)lc.departT=0;
 }
 
+function handleLiveCursorEvent(e){
+  if(e.type==='move'||e.type==='touch'){
+    const pos=e.position;
+    if(pos){
+      if(!liveChords.find(lc=>lc.userId===pos.userId)) addLiveChord(pos.userId);
+      const lc=liveChords.find(lc=>lc.userId===pos.userId);
+      if(lc){lc.value=cursorToValue(pos.x,pos.y);lc.hasTouched=true;lc.lifted=false;}
+    }
+  }else if(e.type==='remove'){
+    const uid=e.userId||(e.position&&e.position.userId);
+    const lc=liveChords.find(lc=>lc.userId===uid);
+    if(lc){lc.lifted=true;lc.value=0;}
+  }
+}
+
 function connectWs(room){
   if(ws){ws.onclose=null;ws.close();}
   if(wsReconnectTimer){clearTimeout(wsReconnectTimer);wsReconnectTimer=null;}
@@ -761,18 +776,10 @@ function connectWs(room){
       addLiveChord(data.userId);
     }else if(data.type==='userLeft'){
       removeLiveChord(data.userId||(data.position&&data.position.userId));
-    }else if(data.type==='move'||data.type==='touch'){
-      const pos=data.position;
-      if(pos){
-        // Auto-add chord if user was already connected when we joined (missed userJoined)
-        if(!liveChords.find(lc=>lc.userId===pos.userId)) addLiveChord(pos.userId);
-        const lc=liveChords.find(lc=>lc.userId===pos.userId);
-        if(lc){lc.value=cursorToValue(pos.x,pos.y);lc.hasTouched=true;lc.lifted=false;}
-      }
-    }else if(data.type==='remove'){
-      const uid=data.userId||(data.position&&data.position.userId);
-      const lc=liveChords.find(lc=>lc.userId===uid);
-      if(lc){lc.lifted=true;lc.value=0;}
+    }else if(data.type==='cursorBatch'){
+      (data.cursors||[]).forEach(e=>handleLiveCursorEvent(e));
+    }else if(data.type==='move'||data.type==='touch'||data.type==='remove'){
+      handleLiveCursorEvent(data);
     }
   };
   ws.onerror=()=>setConnStatus('connection error','warn');


### PR DESCRIPTION
## Summary

- Coalesces `move`/`touch`/`remove` cursor events into a single `cursorBatch` broadcast per 50ms window, reducing server-to-client message rate under high cursor load
- Batch window configured via `SERVER_CURSOR_BATCH_MS` in `app/utils/cursor.ts`; set to `0` to disable and revert to immediate per-event broadcasts (useful for perf comparison)
- All cursor consumers updated to handle both formats via a new `expandCursorEvents()` utility

## Changes

**Server**
- `party/server.ts` — batching logic ported from `party/perf-server.ts`; cursor positions still updated synchronously (soccer physics, region targeting unaffected)

**Shared utility**
- `app/utils/cursor.ts` — adds `SERVER_CURSOR_BATCH_MS = 50`, `CursorEventMsg` type, and `expandCursorEvents(data)` which normalises any cursor message (individual or batch) into a flat array

**Client consumers updated**
- `app/components/shared/Canvas.tsx` — already handled `cursorBatch`; no change needed
- `app/components/panels/AdminPanelNoDB/index.tsx` — unwraps `cursorBatch` at dispatch so `useRecording`/`useParticipants` hooks are unchanged
- `plugins/moodTones`, `valenceBeatPad`, `neighbor`, `map/mapViewer` — adopt `expandCursorEvents`
- `app/components/viz/ValenceViz.tsx` — adopts `expandCursorEvents`
- `public/valence-onboarding-v2.html`, `valence-onboarding-v3.html`, `mood-sounds.html` — inline helpers added

**Tests**
- `party/tests/server.test.ts` — two sub-describes for cursor events: batching disabled (`= 0`, immediate individual broadcast) and batching enabled (`= 50`, `cursorBatch` after timer, coalescing verified)
- `party/tests/pluginDispatch.test.ts` — mocks `SERVER_CURSOR_BATCH_MS = 0` to keep dispatch contract tests timer-free

## Test plan

- [ ] `pnpm tsc --noEmit` — no type errors
- [ ] `pnpm test` — all 252 tests pass
- [ ] Two browser tabs on `localhost:1999` — cursors visible and moving in both
- [ ] Set `SERVER_CURSOR_BATCH_MS = 0`, restart — cursors still work via individual broadcasts
- [ ] Admin panel open — participant tracking and recording capture cursor movement correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~200 words of PR description from ~150 words of human prompts across this session)