### PR TITLE
ci(deploy): also push to legacy polislike-partykit-reaction-canvas URL on main deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,3 +46,7 @@ jobs:
         env:
           PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
           PARTYKIT_LOGIN: patcon
+      - run: pnpm exec partykit deploy --name polislike-partykit-reaction-canvas
+        env:
+          PARTYKIT_TOKEN: ${{ secrets.PARTYKIT_TOKEN }}
+          PARTYKIT_LOGIN: patcon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 28 (2026-06-01)
 
 ### Added
+- **CI: deploy to legacy URL** — production deploy now also pushes to `polislike-partykit-reaction-canvas.patcon.partykit.dev` (old app name) so previously-shared links continue to work after the rename to `whispering-gallery`.
 - **Perf test CI workflow** — `deploy:perf` npm script and `.github/workflows/perf-test.yml` deploy to a persistent `perf` PartyKit preview and run the k6 load test suite (200 VUs, 30s) against `wss://perf.whispering-gallery.patcon.partykit.dev/parties/perf/perf-default`; triggered manually or on a daily schedule (skipped if no commits in 24h).
 - **k6 load test improvements** — adds `cursor_delivery_ms` end-to-end latency metric (sender timestamp echoed back via `cursorBatch`), `connection_success` rate metric replacing the meaningless `ws_sessions` threshold, fixes `cursors_received` to count only cursor events (not `presenceCount` messages), staggered 18–22s VU close timer to avoid reconnect storms, and a `handleSummary` fanout ratio display.
 - **ArrivalCanvas panel** — new patchable panel that turns arrivals into an audio-visual moment: the screen transitions black → white and a THX deep note synthesizes and converges to a D major chord as participants join. Emcee sets room capacity via a gear-icon config modal; count and capacity are displayed on screen. Includes a `SimulatingArrivals` Storybook story with a mock driver that steps through arrivals over 10 seconds.


### PR DESCRIPTION
Adds a second partykit deploy step using --name to keep the old URL
alive after the rename to whispering-gallery, preserving shared links.

https://claude.ai/code/session_0155vioBfDnLWLEFZ3VTnmuC