### PR TITLE
feat: Whisper Gallery product landing page

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -8,6 +8,7 @@ const config: StorybookConfig = {
   stories: [
     "../stories/**/*.mdx",
     "../stories/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../app/**/*.stories.@(js|jsx|mjs|ts|tsx)",
     "../plugins/**/*.stories.@(js|jsx|mjs|ts|tsx)",
   ],
   addons: [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. Releases cu
 ### Added
 - **Whisper Gallery front page** — new product-style landing page component (`app/components/NewFrontPage.tsx`) with "Whisper Gallery" branding, typewriter room-name suggestions, participant/emcee open buttons, an Experiments section (YouTube Videos → V5, Sync'd YouTube Watch Party → V2) with YouTube URL input and label-preset style selector, and a More Prototypes footer; exposed via Storybook story at `Pages/NewFrontPage` only (does not replace the existing landing page).
 
+### Fixed
+- **V5 silent DB failure** — `#v5` now shows an amber warning banner ("Database unreachable — reactions are not being recorded. Contact admin") when the Supabase connection check fails on mount; previously failed silently with no visible feedback.
+
 ## Week 28 (2026-06-01)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file. Releases cu
 - **Whisper Gallery front page** — new product-style landing page component (`app/components/NewFrontPage.tsx`) with "Whisper Gallery" branding, typewriter room-name suggestions, participant/emcee open buttons, an Experiments section (YouTube Videos → V5, Sync'd YouTube Watch Party → V2) with YouTube URL input and label-preset style selector, and a More Prototypes footer; exposed via Storybook story at `Pages/NewFrontPage` only (does not replace the existing landing page).
 
 ### Fixed
-- **V5 silent DB failure** — `#v5` now shows an amber warning banner ("Database unreachable — reactions are not being recorded. Contact admin") when the Supabase connection check fails on mount; previously failed silently with no visible feedback.
+- **V5 silent DB failure** — `#v5` now shows an amber warning banner ("Database unreachable — reactions are not being recorded. Contact admin") when the Supabase connection check fails on mount; previously failed silently with no visible feedback. Includes a `DatabaseUnreachable` Storybook story that injects a failing connection function to verify the banner renders.
 
 ## Week 28 (2026-06-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file. Releases cu
 
 **Commits:** [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) — e.g. `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`.
 
+## Week 29 (2026-06-08)
+
+### Added
+- **Whisper Gallery front page** — new product-style landing page component (`app/components/NewFrontPage.tsx`) with "Whisper Gallery" branding, typewriter room-name suggestions, participant/emcee open buttons, an Experiments section (YouTube Videos → V5, Sync'd YouTube Watch Party → V2) with YouTube URL input and label-preset style selector, and a More Prototypes footer; exposed via Storybook story at `Pages/NewFrontPage` only (does not replace the existing landing page).
+
 ## Week 28 (2026-06-01)
 
 ### Added

--- a/app/client.tsx
+++ b/app/client.tsx
@@ -37,9 +37,19 @@ function App() {
   const [hash, setHash] = useState(window.location.hash);
 
   useEffect(() => {
-    const handleHashChange = () => setHash(window.location.hash);
-    window.addEventListener('hashchange', handleHashChange);
-    return () => window.removeEventListener('hashchange', handleHashChange);
+    // hashchange: hash-only navigation within the SPA (e.g. #v4 → #old)
+    // popstate: back/forward when history entries differ by more than just hash
+    // pageshow (persisted): bfcache restore — neither of the above fires
+    const update = () => setHash(window.location.hash);
+    const handlePageShow = (e: PageTransitionEvent) => { if (e.persisted) update(); };
+    window.addEventListener('hashchange', update);
+    window.addEventListener('popstate', update);
+    window.addEventListener('pageshow', handlePageShow);
+    return () => {
+      window.removeEventListener('hashchange', update);
+      window.removeEventListener('popstate', update);
+      window.removeEventListener('pageshow', handlePageShow);
+    };
   }, []);
 
   useEffect(() => {

--- a/app/client.tsx
+++ b/app/client.tsx
@@ -10,6 +10,7 @@ import ReactionCanvasAppV5 from "./components/apps/ReactionCanvasAppV5";
 import ValenceViz from "./components/viz/ValenceViz";
 import PerfCanvasApp from "./components/apps/PerfCanvasApp";
 import { OldFrontPage } from "./components/OldFrontPage";
+import { NewFrontPage } from "./components/NewFrontPage";
 
 const TITLES: Record<string, (admin: boolean) => string> = {
   '#v1': (admin) => admin ? 'Statement Admin — Polislike' : 'Statement Voting — Polislike',
@@ -54,7 +55,8 @@ function App() {
   else if (hash === '#v5') page = <ReactionCanvasAppV5 />;
   else if (hash === '#valence-viz') page = <ValenceViz />;
   else if (hash === '#perf') page = <PerfCanvasApp />;
-  else page = <OldFrontPage />;
+  else if (hash === '#old') page = <OldFrontPage />;
+  else page = <NewFrontPage />;
 
   return <>{page}{!PARTYKIT_EVENT_BUILD && <GithubCorner />}</>;
 }

--- a/app/client.tsx
+++ b/app/client.tsx
@@ -4,124 +4,12 @@ declare const APP_TITLE: string;
 import { createRoot } from "react-dom/client";
 import { useState, useEffect } from "react";
 import SimpleReactionCanvasAppV1 from "./components/apps/SimpleReactionCanvasAppV1";
-import QRWithCopy from "./components/shared/QRWithCopy";
 import ReactionCanvasAppV2 from "./components/apps/ReactionCanvasAppV2";
 import ReactionCanvasAppV4 from "./components/apps/ReactionCanvasAppV4";
 import ReactionCanvasAppV5 from "./components/apps/ReactionCanvasAppV5";
 import ValenceViz from "./components/viz/ValenceViz";
 import PerfCanvasApp from "./components/apps/PerfCanvasApp";
-
-function IndexApp() {
-  const pageUrl = window.location.origin + window.location.pathname;
-  return (
-    <div className="index-app">
-      <h1 className="index-title">{APP_TITLE} Apps</h1>
-      <div className="index-qr">
-        <QRWithCopy url={pageUrl} size={120} urlClassName="index-qr-label" qrClassName="index-qr-code" />
-      </div>
-      <div className="app-cards">
-        <a href="?room=irc6creOFGs#v5" className="app-card app-card--youtube">
-          <div className="app-card-content">
-            <h2 className="app-card-title">V5 Participation: YouTube Async</h2>
-            <p className="app-card-description">Async YouTube + reaction canvas with an example video. Past reactions replay as cursors in sync with the video timecode.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="?admin=true#v5" className="app-card">
-          <div className="app-card-content">
-            <h2 className="app-card-title">V5 Admin: Database</h2>
-            <p className="app-card-description">Manage labels, anchors, and participant cap. View and clear Supabase reaction recordings.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="#v4" className="app-card">
-          <div className="app-card-content">
-            <h2 className="app-card-title">V4 Participation: Basic Realtime</h2>
-            <p className="app-card-description">Full-page canvas, no video, no statements. Mobile-only with QR gate on desktop.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="?admin=true#v4" className="app-card">
-          <div className="app-card-content">
-            <h2 className="app-card-title">V4 Admin: No Database</h2>
-            <p className="app-card-description">Record live audience reaction data for offline analysis. Downloads as JSON.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="?room=irc6creOFGs#v2" className="app-card app-card--youtube">
-          <div className="app-card-content">
-            <h2 className="app-card-title">V2 Participation: YouTube Realtime</h2>
-            <p className="app-card-description">YouTube embed + reaction canvas with an example video pre-loaded.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="?room=3ntrtcehas#v1" className="app-card">
-          <div className="app-card-content">
-            <h2 className="app-card-title">V1 Participation: Statements (Polis)</h2>
-            <p className="app-card-description">Collaborative voting canvas with real-time cursor tracking and Polis statement display.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="/mood-sounds.html" className="app-card">
-          <div className="app-card-content">
-            <h2 className="app-card-title">Experience: Mood Sounds</h2>
-            <p className="app-card-description">Facilitator tool: ambient generative sound driven by live audience cursor positions. Open in a separate tab — invisible to participant count.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="#valence-viz" className="app-card">
-          <div className="app-card-content">
-            <h2 className="app-card-title">Experience: Valence Viz</h2>
-            <p className="app-card-description">Facilitator tool: 3D particle/wave visualization of audience sentiment. Synthetic demo by default; Audience Sync drives it live from cursor positions.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="/valence-onboarding-v1.html" className="app-card">
-          <div className="app-card-content">
-            <h2 className="app-card-title">Onboarding: Valence V1</h2>
-            <p className="app-card-description">Interactive onboarding experience for the valence wave visualization.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="/valence-onboarding-v2.html" className="app-card">
-          <div className="app-card-content">
-            <h2 className="app-card-title">Onboarding: Valence V2</h2>
-            <p className="app-card-description">Interactive onboarding experience for the valence wave visualization.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="/valence-onboarding-v3.html" className="app-card">
-          <div className="app-card-content">
-            <h2 className="app-card-title">Onboarding: Valence V3</h2>
-            <p className="app-card-description">Valence wave with particle-life physics mode.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="?ghostCursors=true#v1" className="app-card">
-          <div className="app-card-content">
-            <h2 className="app-card-title">V1 Participation: Fake Users Demo</h2>
-            <p className="app-card-description">Same as above, with 10 simulated ghost cursors moving between voting regions.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="#perf" className="app-card">
-          <div className="app-card-content">
-            <h2 className="app-card-title">Perf Test Canvas</h2>
-            <p className="app-card-description">Minimal cursor-only canvas wired to a stripped-down server. Use with the load test scripts to assess peak broadcast performance.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-        <a href="?room=3ntrtcehas&admin=true#v1" className="app-card">
-          <div className="app-card-content">
-            <h2 className="app-card-title">V1 Admin: Statement Queue</h2>
-            <p className="app-card-description">Queue statements for display and monitor submitted votes.</p>
-          </div>
-          <span className="app-card-arrow">→</span>
-        </a>
-      </div>
-    </div>
-  );
-}
+import { OldFrontPage } from "./components/OldFrontPage";
 
 const TITLES: Record<string, (admin: boolean) => string> = {
   '#v1': (admin) => admin ? 'Statement Admin — Polislike' : 'Statement Voting — Polislike',
@@ -166,7 +54,7 @@ function App() {
   else if (hash === '#v5') page = <ReactionCanvasAppV5 />;
   else if (hash === '#valence-viz') page = <ValenceViz />;
   else if (hash === '#perf') page = <PerfCanvasApp />;
-  else page = <IndexApp />;
+  else page = <OldFrontPage />;
 
   return <>{page}{!PARTYKIT_EVENT_BUILD && <GithubCorner />}</>;
 }

--- a/app/components/NewFrontPage.stories.tsx
+++ b/app/components/NewFrontPage.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { NewFrontPage } from '../app/components/NewFrontPage';
+import { NewFrontPage } from './NewFrontPage';
 
 const meta = {
   title: 'Pages/NewFrontPage',

--- a/app/components/NewFrontPage.tsx
+++ b/app/components/NewFrontPage.tsx
@@ -1,0 +1,284 @@
+import { useState, useEffect, useRef } from 'react';
+import { REACTION_LABEL_PRESETS } from '../voteLabels';
+
+const ROOM_SUGGESTIONS = [
+  'amber-dolphin',
+  'brave-forest',
+  'quiet-river',
+  'silver-hawk',
+  'gentle-tide',
+  'swift-canyon',
+  'golden-heron',
+  'misty-pine',
+  'coral-breeze',
+  'indigo-sparrow',
+  'verdant-cove',
+  'azure-meadow',
+];
+
+function useTypewriter(words: string[]) {
+  const [display, setDisplay] = useState('');
+  const indexRef = useRef(0);
+  const charRef = useRef(0);
+  const deletingRef = useRef(false);
+
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>;
+
+    function tick() {
+      const word = words[indexRef.current];
+
+      if (!deletingRef.current) {
+        if (charRef.current < word.length) {
+          charRef.current++;
+          setDisplay(word.slice(0, charRef.current));
+          timeout = setTimeout(tick, 80);
+        } else {
+          deletingRef.current = true;
+          timeout = setTimeout(tick, 1500);
+        }
+      } else {
+        if (charRef.current > 0) {
+          charRef.current--;
+          setDisplay(word.slice(0, charRef.current));
+          timeout = setTimeout(tick, 40);
+        } else {
+          deletingRef.current = false;
+          indexRef.current = (indexRef.current + 1) % words.length;
+          timeout = setTimeout(tick, 300);
+        }
+      }
+    }
+
+    timeout = setTimeout(tick, 800);
+    return () => clearTimeout(timeout);
+  }, [words]);
+
+  return display;
+}
+
+function extractYouTubeId(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.hostname === 'youtu.be') return u.pathname.slice(1).split('?')[0];
+    if (u.pathname.includes('/shorts/')) return u.pathname.split('/shorts/')[1].split('?')[0];
+    return u.searchParams.get('v') ?? url;
+  } catch {
+    return url;
+  }
+}
+
+function buildV4Url(room: string, emcee: boolean) {
+  const r = room.trim().replace(/\s+/g, '-') || 'default';
+  return `#v4?room=${encodeURIComponent(r)}${emcee ? '&interface=emcee' : ''}`;
+}
+
+function buildExperimentUrl(type: 'youtube' | 'watch-party', videoInput: string, style: string) {
+  const id = extractYouTubeId(videoInput.trim()) || 'default';
+  const labelParam = style !== 'default' ? `&labels=${encodeURIComponent(style)}` : '';
+  if (type === 'youtube') return `#v5?room=${encodeURIComponent(id)}${labelParam}`;
+  return `#v2?room=${encodeURIComponent(id)}${labelParam}`;
+}
+
+const PRESET_KEYS = Object.keys(REACTION_LABEL_PRESETS);
+
+type ExperimentType = 'youtube' | 'watch-party';
+
+export function NewFrontPage() {
+  const [room, setRoom] = useState('');
+  const typewriterText = useTypewriter(ROOM_SUGGESTIONS);
+
+  const [experimentType, setExperimentType] = useState<ExperimentType>('youtube');
+  const [youtubeUrl, setYoutubeUrl] = useState('');
+  const [watchPartyUrl, setWatchPartyUrl] = useState('');
+  const [style, setStyle] = useState('default');
+
+  const activeVideoUrl = experimentType === 'youtube' ? youtubeUrl : watchPartyUrl;
+  const setActiveVideoUrl = experimentType === 'youtube' ? setYoutubeUrl : setWatchPartyUrl;
+
+  function handleOpen(emcee: boolean) {
+    window.location.href = buildV4Url(room, emcee);
+  }
+
+  function handleOpenExperiment() {
+    window.location.href = buildExperimentUrl(experimentType, activeVideoUrl, style);
+  }
+
+  function handleOpenV5Admin() {
+    window.location.href = '#v5?admin=true';
+  }
+
+  return (
+    <div className="nfp-page">
+      <div className="nfp-content">
+        {/* Hero */}
+        <div className="nfp-hero">
+          <div className="nfp-icon" aria-hidden="true">〰️</div>
+          <h1 className="nfp-title">Whisper Gallery</h1>
+          <p className="nfp-tagline">see live reactions from the audience</p>
+
+          <div className="nfp-room-field">
+            <label className="nfp-room-label" htmlFor="nfp-room-input">Room name</label>
+            <input
+              id="nfp-room-input"
+              className="nfp-room-input"
+              type="text"
+              value={room}
+              onChange={e => setRoom(e.target.value)}
+              placeholder={typewriterText}
+              autoComplete="off"
+              spellCheck={false}
+            />
+          </div>
+
+          <div className="nfp-actions">
+            <span className="nfp-open-label">Open:</span>
+            <button
+              className="nfp-btn nfp-btn-primary"
+              onClick={() => handleOpen(false)}
+            >
+              Participant View
+            </button>
+            <button
+              className="nfp-btn nfp-btn-secondary"
+              onClick={() => handleOpen(true)}
+            >
+              Emcee View
+            </button>
+          </div>
+        </div>
+
+        {/* Experiments */}
+        <section className="nfp-section">
+          <h2 className="nfp-section-title">Experiments</h2>
+          <p className="nfp-section-desc">Potential variants of the UI in prototype form.</p>
+
+          <div className="nfp-experiment-card-group">
+            {/* YouTube Videos option */}
+            <div
+              className={`nfp-experiment-card ${experimentType === 'youtube' ? 'nfp-experiment-card--active' : ''}`}
+              onClick={() => setExperimentType('youtube')}
+            >
+              <div className="nfp-experiment-row">
+                <label className="nfp-experiment-label">
+                  <input
+                    type="radio"
+                    name="experiment"
+                    value="youtube"
+                    checked={experimentType === 'youtube'}
+                    onChange={() => setExperimentType('youtube')}
+                    onClick={e => e.stopPropagation()}
+                  />
+                  YouTube Videos
+                </label>
+                <input
+                  className="nfp-experiment-url-input"
+                  type="url"
+                  placeholder="YouTube URL"
+                  value={youtubeUrl}
+                  onChange={e => setYoutubeUrl(e.target.value)}
+                  onClick={e => e.stopPropagation()}
+                />
+              </div>
+              {experimentType === 'youtube' && (
+                <div className="nfp-experiment-controls">
+                  <label className="nfp-style-label">
+                    Style:
+                    <select
+                      className="nfp-style-select"
+                      value={style}
+                      onChange={e => setStyle(e.target.value)}
+                    >
+                      {PRESET_KEYS.map(key => (
+                        <option key={key} value={key}>{key}</option>
+                      ))}
+                    </select>
+                  </label>
+                  <button
+                    className="nfp-admin-link"
+                    onClick={e => { e.stopPropagation(); handleOpenV5Admin(); }}
+                  >
+                    Admin
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {/* Sync'd YouTube Watch Party option */}
+            <div
+              className={`nfp-experiment-card ${experimentType === 'watch-party' ? 'nfp-experiment-card--active' : ''}`}
+              onClick={() => setExperimentType('watch-party')}
+            >
+              <div className="nfp-experiment-row">
+                <label className="nfp-experiment-label">
+                  <input
+                    type="radio"
+                    name="experiment"
+                    value="watch-party"
+                    checked={experimentType === 'watch-party'}
+                    onChange={() => setExperimentType('watch-party')}
+                    onClick={e => e.stopPropagation()}
+                  />
+                  Sync'd YouTube Watch Party
+                </label>
+                <input
+                  className="nfp-experiment-url-input"
+                  type="url"
+                  placeholder="YouTube URL"
+                  value={watchPartyUrl}
+                  onChange={e => setWatchPartyUrl(e.target.value)}
+                  onClick={e => e.stopPropagation()}
+                />
+              </div>
+              {experimentType === 'watch-party' && (
+                <div className="nfp-experiment-controls">
+                  <label className="nfp-style-label">
+                    Style:
+                    <select
+                      className="nfp-style-select"
+                      value={style}
+                      onChange={e => setStyle(e.target.value)}
+                    >
+                      {PRESET_KEYS.map(key => (
+                        <option key={key} value={key}>{key}</option>
+                      ))}
+                    </select>
+                  </label>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <button
+            className="nfp-btn nfp-btn-primary nfp-experiment-open"
+            onClick={handleOpenExperiment}
+          >
+            Open Experiment
+          </button>
+        </section>
+
+        {/* More Prototypes */}
+        <section className="nfp-section nfp-section--prototypes">
+          <h2 className="nfp-section-title">More Prototypes</h2>
+          <ul className="nfp-proto-list">
+            <li>
+              <a className="nfp-proto-link" href="/valence-onboarding-v2.html">
+                Valence Visualizer V2
+              </a>
+            </li>
+            <li>
+              <a className="nfp-proto-link" href="#valence-viz">
+                Valence Visualizer V1
+              </a>
+            </li>
+            <li>
+              <a className="nfp-proto-link" href="/mood-sounds.html">
+                Valence Tones
+              </a>
+            </li>
+          </ul>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/components/NewFrontPage.tsx
+++ b/app/components/NewFrontPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from 'react';
-import { REACTION_LABEL_PRESETS } from '../voteLabels';
 
 const ROOM_SUGGESTIONS = [
   'amber-dolphin',
@@ -73,16 +72,44 @@ function buildV4Url(room: string, emcee: boolean) {
   return `#v4?room=${encodeURIComponent(r)}${emcee ? '&interface=emcee' : ''}`;
 }
 
-function buildExperimentUrl(type: 'youtube' | 'watch-party', videoInput: string, style: string) {
+function buildExperimentUrl(type: 'youtube' | 'watch-party', videoInput: string) {
   const id = extractYouTubeId(videoInput.trim()) || 'default';
-  const labelParam = style !== 'default' ? `&labels=${encodeURIComponent(style)}` : '';
-  if (type === 'youtube') return `#v5?room=${encodeURIComponent(id)}${labelParam}`;
-  return `#v2?room=${encodeURIComponent(id)}${labelParam}`;
+  if (type === 'youtube') return `#v5?room=${encodeURIComponent(id)}`;
+  return `#v2?room=${encodeURIComponent(id)}`;
 }
 
-const PRESET_KEYS = Object.keys(REACTION_LABEL_PRESETS);
-
 type ExperimentType = 'youtube' | 'watch-party';
+
+const EXPERIMENTS: { value: ExperimentType; label: string; desc: string }[] = [
+  {
+    value: 'youtube',
+    label: 'YouTube Videos',
+    desc: 'React to pre-recorded videos. Past reactions replay in sync with the video timecode.',
+  },
+  {
+    value: 'watch-party',
+    label: "Sync'd YouTube Watch Party",
+    desc: 'Watch together in real time. Reactions appear live as cursors overlaid on the video.',
+  },
+];
+
+const PROTOTYPES: { label: string; href: string; desc: string }[] = [
+  {
+    label: 'Valence Visualizer V2',
+    href: '/valence-onboarding-v2.html',
+    desc: 'Guided onboarding into a wave-form visualization of live audience sentiment.',
+  },
+  {
+    label: 'Valence Visualizer V1',
+    href: '#valence-viz',
+    desc: '3D particle visualization of audience sentiment. Synthetic demo by default.',
+  },
+  {
+    label: 'Valence Tones',
+    href: '/mood-sounds.html',
+    desc: 'Ambient generative sound driven by live cursor positions across the canvas.',
+  },
+];
 
 export function NewFrontPage() {
   const [room, setRoom] = useState('');
@@ -90,18 +117,13 @@ export function NewFrontPage() {
 
   const [experimentType, setExperimentType] = useState<ExperimentType>('youtube');
   const [youtubeUrl, setYoutubeUrl] = useState('');
-  const [watchPartyUrl, setWatchPartyUrl] = useState('');
-  const [style, setStyle] = useState('default');
-
-  const activeVideoUrl = experimentType === 'youtube' ? youtubeUrl : watchPartyUrl;
-  const setActiveVideoUrl = experimentType === 'youtube' ? setYoutubeUrl : setWatchPartyUrl;
 
   function handleOpen(emcee: boolean) {
     window.location.href = buildV4Url(room, emcee);
   }
 
   function handleOpenExperiment() {
-    window.location.href = buildExperimentUrl(experimentType, activeVideoUrl, style);
+    window.location.href = buildExperimentUrl(experimentType, youtubeUrl);
   }
 
   function handleOpenV5Admin() {
@@ -133,16 +155,10 @@ export function NewFrontPage() {
 
           <div className="nfp-actions">
             <span className="nfp-open-label">Open:</span>
-            <button
-              className="nfp-btn nfp-btn-primary"
-              onClick={() => handleOpen(false)}
-            >
+            <button className="nfp-btn nfp-btn-primary" onClick={() => handleOpen(false)}>
               Participant View
             </button>
-            <button
-              className="nfp-btn nfp-btn-secondary"
-              onClick={() => handleOpen(true)}
-            >
+            <button className="nfp-btn nfp-btn-secondary" onClick={() => handleOpen(true)}>
               Emcee View
             </button>
           </div>
@@ -153,129 +169,63 @@ export function NewFrontPage() {
           <h2 className="nfp-section-title">Experiments</h2>
           <p className="nfp-section-desc">Potential variants of the UI in prototype form.</p>
 
-          <div className="nfp-experiment-card-group">
-            {/* YouTube Videos option */}
-            <div
-              className={`nfp-experiment-card ${experimentType === 'youtube' ? 'nfp-experiment-card--active' : ''}`}
-              onClick={() => setExperimentType('youtube')}
-            >
-              <div className="nfp-experiment-row">
-                <label className="nfp-experiment-label">
-                  <input
-                    type="radio"
-                    name="experiment"
-                    value="youtube"
-                    checked={experimentType === 'youtube'}
-                    onChange={() => setExperimentType('youtube')}
-                    onClick={e => e.stopPropagation()}
-                  />
-                  YouTube Videos
-                </label>
-                <input
-                  className="nfp-experiment-url-input"
-                  type="url"
-                  placeholder="YouTube URL"
-                  value={youtubeUrl}
-                  onChange={e => setYoutubeUrl(e.target.value)}
-                  onClick={e => e.stopPropagation()}
-                />
-              </div>
-              {experimentType === 'youtube' && (
-                <div className="nfp-experiment-controls">
-                  <label className="nfp-style-label">
-                    Style:
-                    <select
-                      className="nfp-style-select"
-                      value={style}
-                      onChange={e => setStyle(e.target.value)}
-                    >
-                      {PRESET_KEYS.map(key => (
-                        <option key={key} value={key}>{key}</option>
-                      ))}
-                    </select>
-                  </label>
-                  <button
-                    className="nfp-admin-link"
-                    onClick={e => { e.stopPropagation(); handleOpenV5Admin(); }}
-                  >
-                    Admin
-                  </button>
-                </div>
-              )}
+          <div className="nfp-experiment-card">
+            <div className="nfp-experiment-url-row">
+              <label className="nfp-room-label" htmlFor="nfp-yt-url">YouTube URL</label>
+              <input
+                id="nfp-yt-url"
+                className="nfp-experiment-url-input"
+                type="url"
+                placeholder="https://youtube.com/watch?v=..."
+                value={youtubeUrl}
+                onChange={e => setYoutubeUrl(e.target.value)}
+              />
             </div>
 
-            {/* Sync'd YouTube Watch Party option */}
-            <div
-              className={`nfp-experiment-card ${experimentType === 'watch-party' ? 'nfp-experiment-card--active' : ''}`}
-              onClick={() => setExperimentType('watch-party')}
-            >
-              <div className="nfp-experiment-row">
-                <label className="nfp-experiment-label">
+            <div className="nfp-experiment-options">
+              {EXPERIMENTS.map(exp => (
+                <label
+                  key={exp.value}
+                  className={`nfp-experiment-option ${experimentType === exp.value ? 'nfp-experiment-option--active' : ''}`}
+                >
                   <input
                     type="radio"
                     name="experiment"
-                    value="watch-party"
-                    checked={experimentType === 'watch-party'}
-                    onChange={() => setExperimentType('watch-party')}
-                    onClick={e => e.stopPropagation()}
+                    value={exp.value}
+                    checked={experimentType === exp.value}
+                    onChange={() => setExperimentType(exp.value)}
                   />
-                  Sync'd YouTube Watch Party
+                  <div className="nfp-experiment-option-text">
+                    <span className="nfp-experiment-option-label">{exp.label}</span>
+                    <span className="nfp-experiment-option-desc">{exp.desc}</span>
+                  </div>
                 </label>
-                <input
-                  className="nfp-experiment-url-input"
-                  type="url"
-                  placeholder="YouTube URL"
-                  value={watchPartyUrl}
-                  onChange={e => setWatchPartyUrl(e.target.value)}
-                  onClick={e => e.stopPropagation()}
-                />
-              </div>
-              {experimentType === 'watch-party' && (
-                <div className="nfp-experiment-controls">
-                  <label className="nfp-style-label">
-                    Style:
-                    <select
-                      className="nfp-style-select"
-                      value={style}
-                      onChange={e => setStyle(e.target.value)}
-                    >
-                      {PRESET_KEYS.map(key => (
-                        <option key={key} value={key}>{key}</option>
-                      ))}
-                    </select>
-                  </label>
-                </div>
+              ))}
+            </div>
+
+            <div className="nfp-experiment-footer">
+              <button className="nfp-btn nfp-btn-primary" onClick={handleOpenExperiment}>
+                Open Experiment
+              </button>
+              {experimentType === 'youtube' && (
+                <button className="nfp-admin-link" onClick={handleOpenV5Admin}>
+                  Admin
+                </button>
               )}
             </div>
           </div>
-
-          <button
-            className="nfp-btn nfp-btn-primary nfp-experiment-open"
-            onClick={handleOpenExperiment}
-          >
-            Open Experiment
-          </button>
         </section>
 
         {/* More Prototypes */}
         <section className="nfp-section nfp-section--prototypes">
           <h2 className="nfp-section-title">More Prototypes</h2>
           <ul className="nfp-proto-list">
-            <li>
-              <a className="nfp-proto-link" href="/valence-onboarding-v2.html">
-                Valence Visualizer V2
-              </a>
-            </li>
-            <li>
-              <a className="nfp-proto-link" href="#valence-viz">
-                Valence Visualizer V1
-              </a>
-            </li>
-            <li>
-              <a className="nfp-proto-link" href="/mood-sounds.html">
-                Valence Tones
-              </a>
-            </li>
+            {PROTOTYPES.map(p => (
+              <li key={p.href}>
+                <a className="nfp-proto-link" href={p.href}>{p.label}</a>
+                <p className="nfp-proto-desc">{p.desc}</p>
+              </li>
+            ))}
           </ul>
         </section>
       </div>

--- a/app/components/NewFrontPage.tsx
+++ b/app/components/NewFrontPage.tsx
@@ -69,13 +69,13 @@ function extractYouTubeId(url: string): string {
 
 function buildV4Url(room: string, emcee: boolean) {
   const r = room.trim().replace(/\s+/g, '-') || 'default';
-  return `#v4?room=${encodeURIComponent(r)}${emcee ? '&interface=emcee' : ''}`;
+  return `?room=${encodeURIComponent(r)}${emcee ? '&interface=emcee' : ''}#v4`;
 }
 
 function buildExperimentUrl(type: 'youtube' | 'watch-party', videoId: string) {
   const id = videoId || 'default';
-  if (type === 'youtube') return `#v5?room=${encodeURIComponent(id)}`;
-  return `#v2?room=${encodeURIComponent(id)}`;
+  if (type === 'youtube') return `?room=${encodeURIComponent(id)}#v5`;
+  return `?room=${encodeURIComponent(id)}#v2`;
 }
 
 type ExperimentType = 'youtube' | 'watch-party';
@@ -148,7 +148,7 @@ export function NewFrontPage() {
   }
 
   function handleOpenV5Admin() {
-    window.location.href = '#v5?admin=true';
+    window.location.href = '?admin=true#v5';
   }
 
   return (

--- a/app/components/NewFrontPage.tsx
+++ b/app/components/NewFrontPage.tsx
@@ -158,7 +158,7 @@ export function NewFrontPage() {
         <div className="nfp-hero">
           <div className="nfp-icon" aria-hidden="true">〰️</div>
           <h1 className="nfp-title">Whisper Gallery</h1>
-          <p className="nfp-tagline">see live reactions from the audience</p>
+          <p className="nfp-tagline">see realtime audience reactions at live events</p>
 
           <div className="nfp-room-field">
             <label className="nfp-room-label" htmlFor="nfp-room-input">Room name</label>

--- a/app/components/NewFrontPage.tsx
+++ b/app/components/NewFrontPage.tsx
@@ -72,13 +72,19 @@ function buildV4Url(room: string, emcee: boolean) {
   return `#v4?room=${encodeURIComponent(r)}${emcee ? '&interface=emcee' : ''}`;
 }
 
-function buildExperimentUrl(type: 'youtube' | 'watch-party', videoInput: string) {
-  const id = extractYouTubeId(videoInput.trim()) || 'default';
+function buildExperimentUrl(type: 'youtube' | 'watch-party', videoId: string) {
+  const id = videoId || 'default';
   if (type === 'youtube') return `#v5?room=${encodeURIComponent(id)}`;
   return `#v2?room=${encodeURIComponent(id)}`;
 }
 
 type ExperimentType = 'youtube' | 'watch-party';
+
+const VIDEO_PRESETS = [
+  { id: 'irc6creOFGs' },
+  { id: 'dQw4w9WgXcQ' },
+  { id: 'jNQXAC9IVRw' },
+];
 
 const EXPERIMENTS: { value: ExperimentType; label: string; desc: string }[] = [
   {
@@ -89,7 +95,7 @@ const EXPERIMENTS: { value: ExperimentType; label: string; desc: string }[] = [
   {
     value: 'watch-party',
     label: "Sync'd YouTube Watch Party",
-    desc: 'Watch together in real time. Reactions appear live as cursors overlaid on the video.',
+    desc: 'Video only plays when everyone is touching the screen.',
   },
 ];
 
@@ -117,13 +123,28 @@ export function NewFrontPage() {
 
   const [experimentType, setExperimentType] = useState<ExperimentType>('youtube');
   const [youtubeUrl, setYoutubeUrl] = useState('');
+  const [activePreset, setActivePreset] = useState<number | null>(0);
+
+  const effectiveVideoId = activePreset !== null
+    ? VIDEO_PRESETS[activePreset].id
+    : extractYouTubeId(youtubeUrl.trim());
+
+  function handlePresetClick(i: number) {
+    setActivePreset(i);
+    setYoutubeUrl('');
+  }
+
+  function handleUrlChange(e: React.ChangeEvent<HTMLInputElement>) {
+    setYoutubeUrl(e.target.value);
+    setActivePreset(null);
+  }
 
   function handleOpen(emcee: boolean) {
     window.location.href = buildV4Url(room, emcee);
   }
 
   function handleOpenExperiment() {
-    window.location.href = buildExperimentUrl(experimentType, youtubeUrl);
+    window.location.href = buildExperimentUrl(experimentType, effectiveVideoId);
   }
 
   function handleOpenV5Admin() {
@@ -176,10 +197,27 @@ export function NewFrontPage() {
                 id="nfp-yt-url"
                 className="nfp-experiment-url-input"
                 type="url"
-                placeholder="https://youtube.com/watch?v=..."
+                placeholder={activePreset !== null
+                  ? `https://youtube.com/watch?v=${VIDEO_PRESETS[activePreset].id}`
+                  : 'https://youtube.com/watch?v=...'}
                 value={youtubeUrl}
-                onChange={e => setYoutubeUrl(e.target.value)}
+                onChange={handleUrlChange}
               />
+              <div className="nfp-video-presets">
+                {VIDEO_PRESETS.map((preset, i) => (
+                  <button
+                    key={preset.id}
+                    className={`nfp-video-preset ${activePreset === i ? 'nfp-video-preset--active' : ''}`}
+                    onClick={() => handlePresetClick(i)}
+                    type="button"
+                  >
+                    <img
+                      src={`https://img.youtube.com/vi/${preset.id}/mqdefault.jpg`}
+                      alt={`Video preset ${i + 1}`}
+                    />
+                  </button>
+                ))}
+              </div>
             </div>
 
             <div className="nfp-experiment-options">

--- a/app/components/OldFrontPage.stories.tsx
+++ b/app/components/OldFrontPage.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { OldFrontPage } from './OldFrontPage';
+
+const meta = {
+  title: 'Pages/OldFrontPage',
+  component: OldFrontPage,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof OldFrontPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/app/components/OldFrontPage.tsx
+++ b/app/components/OldFrontPage.tsx
@@ -4,7 +4,7 @@ declare const APP_TITLE: string;
 const DEFAULT_TITLE = typeof APP_TITLE !== 'undefined' ? APP_TITLE : 'Whispering Gallery';
 
 export function OldFrontPage({ title = DEFAULT_TITLE }: { title?: string }) {
-  const pageUrl = window.location.origin + window.location.pathname;
+  const pageUrl = window.location.origin + window.location.pathname + window.location.hash;
   return (
     <div className="index-app">
       <h1 className="index-title">{title} Apps</h1>

--- a/app/components/OldFrontPage.tsx
+++ b/app/components/OldFrontPage.tsx
@@ -1,0 +1,116 @@
+import QRWithCopy from './shared/QRWithCopy';
+
+declare const APP_TITLE: string;
+const DEFAULT_TITLE = typeof APP_TITLE !== 'undefined' ? APP_TITLE : 'Whispering Gallery';
+
+export function OldFrontPage({ title = DEFAULT_TITLE }: { title?: string }) {
+  const pageUrl = window.location.origin + window.location.pathname;
+  return (
+    <div className="index-app">
+      <h1 className="index-title">{title} Apps</h1>
+      <div className="index-qr">
+        <QRWithCopy url={pageUrl} size={120} urlClassName="index-qr-label" qrClassName="index-qr-code" />
+      </div>
+      <div className="app-cards">
+        <a href="?room=irc6creOFGs#v5" className="app-card app-card--youtube">
+          <div className="app-card-content">
+            <h2 className="app-card-title">V5 Participation: YouTube Async</h2>
+            <p className="app-card-description">Async YouTube + reaction canvas with an example video. Past reactions replay as cursors in sync with the video timecode.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="?admin=true#v5" className="app-card">
+          <div className="app-card-content">
+            <h2 className="app-card-title">V5 Admin: Database</h2>
+            <p className="app-card-description">Manage labels, anchors, and participant cap. View and clear Supabase reaction recordings.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="#v4" className="app-card">
+          <div className="app-card-content">
+            <h2 className="app-card-title">V4 Participation: Basic Realtime</h2>
+            <p className="app-card-description">Full-page canvas, no video, no statements. Mobile-only with QR gate on desktop.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="?admin=true#v4" className="app-card">
+          <div className="app-card-content">
+            <h2 className="app-card-title">V4 Admin: No Database</h2>
+            <p className="app-card-description">Record live audience reaction data for offline analysis. Downloads as JSON.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="?room=irc6creOFGs#v2" className="app-card app-card--youtube">
+          <div className="app-card-content">
+            <h2 className="app-card-title">V2 Participation: YouTube Realtime</h2>
+            <p className="app-card-description">YouTube embed + reaction canvas with an example video pre-loaded.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="?room=3ntrtcehas#v1" className="app-card">
+          <div className="app-card-content">
+            <h2 className="app-card-title">V1 Participation: Statements (Polis)</h2>
+            <p className="app-card-description">Collaborative voting canvas with real-time cursor tracking and Polis statement display.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="/mood-sounds.html" className="app-card">
+          <div className="app-card-content">
+            <h2 className="app-card-title">Experience: Mood Sounds</h2>
+            <p className="app-card-description">Facilitator tool: ambient generative sound driven by live audience cursor positions. Open in a separate tab — invisible to participant count.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="#valence-viz" className="app-card">
+          <div className="app-card-content">
+            <h2 className="app-card-title">Experience: Valence Viz</h2>
+            <p className="app-card-description">Facilitator tool: 3D particle/wave visualization of audience sentiment. Synthetic demo by default; Audience Sync drives it live from cursor positions.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="/valence-onboarding-v1.html" className="app-card">
+          <div className="app-card-content">
+            <h2 className="app-card-title">Onboarding: Valence V1</h2>
+            <p className="app-card-description">Interactive onboarding experience for the valence wave visualization.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="/valence-onboarding-v2.html" className="app-card">
+          <div className="app-card-content">
+            <h2 className="app-card-title">Onboarding: Valence V2</h2>
+            <p className="app-card-description">Interactive onboarding experience for the valence wave visualization.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="/valence-onboarding-v3.html" className="app-card">
+          <div className="app-card-content">
+            <h2 className="app-card-title">Onboarding: Valence V3</h2>
+            <p className="app-card-description">Valence wave with particle-life physics mode.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="?ghostCursors=true#v1" className="app-card">
+          <div className="app-card-content">
+            <h2 className="app-card-title">V1 Participation: Fake Users Demo</h2>
+            <p className="app-card-description">Same as above, with 10 simulated ghost cursors moving between voting regions.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="#perf" className="app-card">
+          <div className="app-card-content">
+            <h2 className="app-card-title">Perf Test Canvas</h2>
+            <p className="app-card-description">Minimal cursor-only canvas wired to a stripped-down server. Use with the load test scripts to assess peak broadcast performance.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+        <a href="?room=3ntrtcehas&admin=true#v1" className="app-card">
+          <div className="app-card-content">
+            <h2 className="app-card-title">V1 Admin: Statement Queue</h2>
+            <p className="app-card-description">Queue statements for display and monitor submitted votes.</p>
+          </div>
+          <span className="app-card-arrow">→</span>
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/app/components/apps/ReactionCanvasAppV5.tsx
+++ b/app/components/apps/ReactionCanvasAppV5.tsx
@@ -91,6 +91,7 @@ export default function ReactionCanvasAppV5() {
   const [debug, setDebug] = useState(() => new URLSearchParams(window.location.search).get('debug') === '1');
   const [recordedEvents, setRecordedEvents] = useState<ReactionEvent[]>([]);
   const [currentTimecode, setCurrentTimecode] = useState(0);
+  const [dbConnected, setDbConnected] = useState<boolean | null>(null);
   const currentTimecodeRef = useRef(0);
   const playerRef = useRef<YTPlayer | null>(null);
   const lastInsertRef = useRef(0);
@@ -177,7 +178,7 @@ export default function ReactionCanvasAppV5() {
   }, [touchPos]);
 
   // Test Supabase connection on mount
-  useEffect(() => { testConnection(); }, []);
+  useEffect(() => { testConnection().then(setDbConnected); }, []);
 
   // Fetch recorded events on mount
   useEffect(() => {
@@ -229,6 +230,12 @@ export default function ReactionCanvasAppV5() {
         )}
       </div>
       <div className="v5-vote-canvas-container">
+        {dbConnected === false && (
+          <div className="v5-db-warning">
+            ⚠ Database unreachable — reactions are not being recorded.{' '}
+            <a href="https://github.com/patcon" target="_blank" rel="noreferrer">Contact admin</a>
+          </div>
+        )}
         {labels && <div className="reaction-label reaction-label-positive" style={reactionLabelStyle(anchors.positive)}>{labels.positive}</div>}
         {labels && <div className="reaction-label reaction-label-negative" style={reactionLabelStyle(anchors.negative)}>{labels.negative}</div>}
         {labels && <div className="reaction-label reaction-label-neutral" style={reactionLabelStyle(anchors.neutral)}>{labels.neutral}</div>}

--- a/app/components/apps/ReactionCanvasAppV5.tsx
+++ b/app/components/apps/ReactionCanvasAppV5.tsx
@@ -128,7 +128,7 @@ export default function ReactionCanvasAppV5({ testConnectionFn = testConnection 
   useEffect(() => {
     if (!videoId) return;
 
-    window.onYouTubeIframeAPIReady = () => {
+    const createPlayer = () => {
       playerRef.current = new window.YT.Player('v5-youtube-player', {
         videoId,
         playerVars: { controls: debug ? 1 : 0, modestbranding: 1, rel: 0, iv_load_policy: 3, cc_load_policy: 0 },
@@ -138,15 +138,20 @@ export default function ReactionCanvasAppV5({ testConnectionFn = testConnection 
       });
     };
 
-    const script = document.createElement('script');
-    script.src = 'https://www.youtube.com/iframe_api';
-    document.head.appendChild(script);
+    if (window.YT?.Player) {
+      // API already loaded (e.g. remount after navigation) — create player immediately.
+      createPlayer();
+    } else {
+      window.onYouTubeIframeAPIReady = createPlayer;
+      const script = document.createElement('script');
+      script.src = 'https://www.youtube.com/iframe_api';
+      document.head.appendChild(script);
+    }
 
     return () => {
-      // Cleanup: remove the script tag and the global callback
-      if (script.parentNode) script.parentNode.removeChild(script);
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       window.onYouTubeIframeAPIReady = () => {};
+      playerRef.current = null;
     };
   }, [videoId]);
 

--- a/app/components/apps/ReactionCanvasAppV5.tsx
+++ b/app/components/apps/ReactionCanvasAppV5.tsx
@@ -81,7 +81,11 @@ function MobileOnlyGate() {
   );
 }
 
-export default function ReactionCanvasAppV5() {
+interface Props {
+  testConnectionFn?: () => Promise<boolean>;
+}
+
+export default function ReactionCanvasAppV5({ testConnectionFn = testConnection }: Props) {
   const [sessionId] = useState(() => getPersistentUserId());
   const [userId] = useState(() => getPersistentUserId());
   const [canvasBackgroundReactionState, setCanvasBackgroundReactionState] = useState<ReactionState>(null);
@@ -178,7 +182,7 @@ export default function ReactionCanvasAppV5() {
   }, [touchPos]);
 
   // Test Supabase connection on mount
-  useEffect(() => { testConnection().then(setDbConnected); }, []);
+  useEffect(() => { testConnectionFn().then(setDbConnected); }, []);
 
   // Fetch recorded events on mount
   useEffect(() => {

--- a/app/styles/canvas-v2.css
+++ b/app/styles/canvas-v2.css
@@ -552,6 +552,40 @@
   gap: 6px;
 }
 
+.nfp-video-presets {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.nfp-video-preset {
+  flex: 1;
+  padding: 0;
+  border: 2px solid #dee2e6;
+  border-radius: 6px;
+  background: none;
+  cursor: pointer;
+  overflow: hidden;
+  transition: border-color 0.15s;
+  line-height: 0;
+}
+
+.nfp-video-preset:hover {
+  border-color: #a5b4fc;
+}
+
+.nfp-video-preset--active {
+  border-color: #4f6ef7;
+  box-shadow: 0 0 0 2px rgba(79, 110, 247, 0.2);
+}
+
+.nfp-video-preset img {
+  width: 100%;
+  height: 56px;
+  object-fit: cover;
+  display: block;
+}
+
 .nfp-experiment-url-input {
   font-size: 14px;
   padding: 9px 12px;

--- a/app/styles/canvas-v2.css
+++ b/app/styles/canvas-v2.css
@@ -372,3 +372,349 @@
   }
 }
 
+/* ── NewFrontPage (Whisper Gallery) ─────────────────────────── */
+
+.nfp-page {
+  min-height: 100vh;
+  background: #ffffff;
+  display: flex;
+  justify-content: center;
+  padding: 0 16px 64px;
+  box-sizing: border-box;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.nfp-content {
+  width: 100%;
+  max-width: 600px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.nfp-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 56px 0 40px;
+}
+
+.nfp-icon {
+  font-size: 40px;
+  margin-bottom: 12px;
+  line-height: 1;
+}
+
+.nfp-title {
+  font-size: 36px;
+  font-weight: 700;
+  color: #111;
+  margin: 0 0 8px;
+  letter-spacing: -0.5px;
+}
+
+.nfp-tagline {
+  font-size: 17px;
+  color: #6c757d;
+  margin: 0 0 32px;
+}
+
+.nfp-room-field {
+  width: 100%;
+  margin-bottom: 20px;
+  text-align: left;
+}
+
+.nfp-room-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: #6c757d;
+  margin-bottom: 6px;
+}
+
+.nfp-room-input {
+  width: 100%;
+  font-size: 20px;
+  padding: 12px 14px;
+  border: 2px solid #dee2e6;
+  border-radius: 10px;
+  outline: none;
+  color: #111;
+  background: #fff;
+  box-sizing: border-box;
+  transition: border-color 0.15s;
+}
+
+.nfp-room-input:focus {
+  border-color: #4f6ef7;
+}
+
+.nfp-room-input::placeholder {
+  color: #adb5bd;
+}
+
+.nfp-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.nfp-open-label {
+  font-size: 14px;
+  color: #6c757d;
+  font-weight: 500;
+}
+
+.nfp-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 11px 22px;
+  border-radius: 9px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 2px solid transparent;
+  transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.nfp-btn-primary {
+  background: #4f6ef7;
+  color: #fff;
+  border-color: #4f6ef7;
+}
+
+.nfp-btn-primary:hover {
+  background: #3b5be3;
+  border-color: #3b5be3;
+  box-shadow: 0 2px 8px rgba(79, 110, 247, 0.35);
+}
+
+.nfp-btn-secondary {
+  background: #fff;
+  color: #4f6ef7;
+  border-color: #4f6ef7;
+}
+
+.nfp-btn-secondary:hover {
+  background: #f0f3ff;
+}
+
+.nfp-section {
+  border: 1.5px solid #e9ecef;
+  border-radius: 14px;
+  padding: 24px;
+  margin-top: 28px;
+  background: #fafafa;
+}
+
+.nfp-section--prototypes {
+  background: #fff;
+}
+
+.nfp-section-title {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #adb5bd;
+  margin: 0 0 4px;
+}
+
+.nfp-section-desc {
+  font-size: 13px;
+  color: #868e96;
+  margin: 0 0 18px;
+}
+
+.nfp-experiment-card-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.nfp-experiment-card {
+  border: 1.5px solid #dee2e6;
+  border-radius: 10px;
+  padding: 14px 16px;
+  background: #fff;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.nfp-experiment-card:hover {
+  border-color: #a5b4fc;
+  background: #f8f9ff;
+}
+
+.nfp-experiment-card--active {
+  border-color: #4f6ef7;
+  background: #f0f3ff;
+}
+
+.nfp-experiment-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.nfp-experiment-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  color: #343a40;
+  cursor: pointer;
+  flex-shrink: 0;
+  min-width: 160px;
+}
+
+.nfp-experiment-label input[type="radio"] {
+  accent-color: #4f6ef7;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.nfp-experiment-url-input {
+  flex: 1;
+  min-width: 140px;
+  font-size: 13px;
+  padding: 7px 10px;
+  border: 1.5px solid #dee2e6;
+  border-radius: 7px;
+  outline: none;
+  color: #343a40;
+  background: #fff;
+  transition: border-color 0.15s;
+  box-sizing: border-box;
+}
+
+.nfp-experiment-url-input:focus {
+  border-color: #4f6ef7;
+}
+
+.nfp-experiment-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid #e9ecef;
+  flex-wrap: wrap;
+}
+
+.nfp-style-label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #6c757d;
+}
+
+.nfp-style-select {
+  font-size: 13px;
+  padding: 5px 8px;
+  border: 1.5px solid #dee2e6;
+  border-radius: 6px;
+  background: #fff;
+  color: #343a40;
+  outline: none;
+  cursor: pointer;
+}
+
+.nfp-admin-link {
+  font-size: 12px;
+  color: #868e96;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  margin-left: auto;
+}
+
+.nfp-admin-link:hover {
+  color: #495057;
+}
+
+.nfp-experiment-open {
+  margin-top: 4px;
+}
+
+.nfp-proto-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.nfp-proto-link {
+  font-size: 14px;
+  color: #6c757d;
+  text-decoration: none;
+  padding: 4px 0;
+  display: inline-block;
+  border-bottom: 1px solid transparent;
+  transition: color 0.12s, border-color 0.12s;
+}
+
+.nfp-proto-link:hover {
+  color: #343a40;
+  border-color: #dee2e6;
+}
+
+@media (max-width: 640px) {
+  .nfp-hero {
+    padding: 36px 0 28px;
+  }
+
+  .nfp-title {
+    font-size: 28px;
+  }
+
+  .nfp-room-input {
+    font-size: 17px;
+  }
+
+  .nfp-actions {
+    gap: 8px;
+  }
+
+  .nfp-btn {
+    padding: 10px 16px;
+    font-size: 14px;
+  }
+
+  .nfp-section {
+    padding: 18px 16px;
+  }
+
+  .nfp-experiment-row {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .nfp-experiment-url-input {
+    width: 100%;
+  }
+
+  .nfp-experiment-label {
+    min-width: unset;
+  }
+}
+

--- a/app/styles/canvas-v2.css
+++ b/app/styles/canvas-v2.css
@@ -561,22 +561,24 @@
 .nfp-video-preset {
   flex: 1;
   padding: 0;
-  border: 2px solid #dee2e6;
+  border: 2px solid transparent;
   border-radius: 6px;
   background: none;
   cursor: pointer;
   overflow: hidden;
-  transition: border-color 0.15s;
+  transition: border-color 0.15s, opacity 0.15s;
   line-height: 0;
+  opacity: 0.35;
 }
 
 .nfp-video-preset:hover {
-  border-color: #a5b4fc;
+  opacity: 0.7;
 }
 
 .nfp-video-preset--active {
   border-color: #4f6ef7;
-  box-shadow: 0 0 0 2px rgba(79, 110, 247, 0.2);
+  box-shadow: 0 0 0 2px rgba(79, 110, 247, 0.3);
+  opacity: 1;
 }
 
 .nfp-video-preset img {

--- a/app/styles/canvas-v2.css
+++ b/app/styles/canvas-v2.css
@@ -375,7 +375,8 @@
 /* ── NewFrontPage (Whisper Gallery) ─────────────────────────── */
 
 .nfp-page {
-  min-height: 100vh;
+  height: 100vh;
+  overflow-y: auto;
   background: #ffffff;
   display: flex;
   justify-content: center;
@@ -535,103 +536,97 @@
   margin: 0 0 18px;
 }
 
-.nfp-experiment-card-group {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  margin-bottom: 16px;
-}
-
 .nfp-experiment-card {
   border: 1.5px solid #dee2e6;
   border-radius: 10px;
-  padding: 14px 16px;
+  padding: 16px;
   background: #fff;
-  cursor: pointer;
-  transition: border-color 0.15s, background 0.15s;
-}
-
-.nfp-experiment-card:hover {
-  border-color: #a5b4fc;
-  background: #f8f9ff;
-}
-
-.nfp-experiment-card--active {
-  border-color: #4f6ef7;
-  background: #f0f3ff;
-}
-
-.nfp-experiment-row {
   display: flex;
-  align-items: center;
-  gap: 12px;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 14px;
 }
 
-.nfp-experiment-label {
+.nfp-experiment-url-row {
   display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  font-weight: 600;
-  color: #343a40;
-  cursor: pointer;
-  flex-shrink: 0;
-  min-width: 160px;
-}
-
-.nfp-experiment-label input[type="radio"] {
-  accent-color: #4f6ef7;
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .nfp-experiment-url-input {
-  flex: 1;
-  min-width: 140px;
-  font-size: 13px;
-  padding: 7px 10px;
+  font-size: 14px;
+  padding: 9px 12px;
   border: 1.5px solid #dee2e6;
-  border-radius: 7px;
+  border-radius: 8px;
   outline: none;
   color: #343a40;
   background: #fff;
   transition: border-color 0.15s;
   box-sizing: border-box;
+  width: 100%;
 }
 
 .nfp-experiment-url-input:focus {
   border-color: #4f6ef7;
 }
 
-.nfp-experiment-controls {
+.nfp-experiment-options {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nfp-experiment-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1.5px solid #e9ecef;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.nfp-experiment-option:hover {
+  border-color: #a5b4fc;
+  background: #f8f9ff;
+}
+
+.nfp-experiment-option--active {
+  border-color: #4f6ef7;
+  background: #f0f3ff;
+}
+
+.nfp-experiment-option input[type="radio"] {
+  accent-color: #4f6ef7;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.nfp-experiment-option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.nfp-experiment-option-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #343a40;
+}
+
+.nfp-experiment-option-desc {
+  font-size: 12px;
+  color: #868e96;
+  line-height: 1.4;
+}
+
+.nfp-experiment-footer {
   display: flex;
   align-items: center;
   gap: 16px;
-  margin-top: 12px;
-  padding-top: 10px;
-  border-top: 1px solid #e9ecef;
-  flex-wrap: wrap;
-}
-
-.nfp-style-label {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  color: #6c757d;
-}
-
-.nfp-style-select {
-  font-size: 13px;
-  padding: 5px 8px;
-  border: 1.5px solid #dee2e6;
-  border-radius: 6px;
-  background: #fff;
-  color: #343a40;
-  outline: none;
-  cursor: pointer;
+  padding-top: 4px;
 }
 
 .nfp-admin-link {
@@ -643,15 +638,10 @@
   cursor: pointer;
   text-decoration: underline;
   text-underline-offset: 2px;
-  margin-left: auto;
 }
 
 .nfp-admin-link:hover {
   color: #495057;
-}
-
-.nfp-experiment-open {
-  margin-top: 4px;
 }
 
 .nfp-proto-list {
@@ -660,14 +650,14 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 14px;
 }
 
 .nfp-proto-link {
   font-size: 14px;
-  color: #6c757d;
+  font-weight: 600;
+  color: #495057;
   text-decoration: none;
-  padding: 4px 0;
   display: inline-block;
   border-bottom: 1px solid transparent;
   transition: color 0.12s, border-color 0.12s;
@@ -676,6 +666,13 @@
 .nfp-proto-link:hover {
   color: #343a40;
   border-color: #dee2e6;
+}
+
+.nfp-proto-desc {
+  font-size: 12px;
+  color: #868e96;
+  margin: 3px 0 0;
+  line-height: 1.4;
 }
 
 @media (max-width: 640px) {
@@ -702,19 +699,6 @@
 
   .nfp-section {
     padding: 18px 16px;
-  }
-
-  .nfp-experiment-row {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .nfp-experiment-url-input {
-    width: 100%;
-  }
-
-  .nfp-experiment-label {
-    min-width: unset;
   }
 }
 

--- a/app/styles/v4-v5.css
+++ b/app/styles/v4-v5.css
@@ -229,6 +229,27 @@
   min-height: 0;
 }
 
+.v5-db-warning {
+  position: absolute;
+  bottom: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(200, 120, 0, 0.9);
+  color: #fff;
+  font-size: 13px;
+  padding: 8px 14px;
+  border-radius: 6px;
+  z-index: 20;
+  text-align: center;
+  pointer-events: auto;
+  max-width: 90%;
+}
+
+.v5-db-warning a {
+  color: #fff;
+  text-decoration: underline;
+}
+
 .v5-touch-indicator {
   position: absolute;
   width: 80px;

--- a/app/styles/v4-v5.css
+++ b/app/styles/v4-v5.css
@@ -21,7 +21,7 @@
 .v3-rec-badge--left {
   right: unset;
   left: 8px;
-  top: 100px;
+  top: 8px;
 }
 
 /* V3: Admin panel container */

--- a/stories/NewFrontPage.stories.tsx
+++ b/stories/NewFrontPage.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { NewFrontPage } from '../app/components/NewFrontPage';
+
+const meta = {
+  title: 'Pages/NewFrontPage',
+  component: NewFrontPage,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+} satisfies Meta<typeof NewFrontPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/stories/ReactionCanvasAppV2.stories.ts
+++ b/stories/ReactionCanvasAppV2.stories.ts
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { createElement } from 'react';
 import ReactionCanvasAppV2 from '../app/components/apps/ReactionCanvasAppV2';
 
 const meta = {
@@ -6,6 +7,9 @@ const meta = {
   component: ReactionCanvasAppV2,
   parameters: { layout: 'fullscreen' },
   tags: ['autodocs'],
+  decorators: [
+    (Story) => createElement('div', { style: { height: '100vh', width: '100vw', overflow: 'hidden' } }, createElement(Story)),
+  ],
 } satisfies Meta<typeof ReactionCanvasAppV2>;
 
 export default meta;

--- a/stories/ReactionCanvasAppV5.stories.tsx
+++ b/stories/ReactionCanvasAppV5.stories.tsx
@@ -1,19 +1,25 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import ReactionCanvasAppV5 from '../app/components/apps/ReactionCanvasAppV5';
 
+const EXAMPLE_VIDEO_ID = 'irc6creOFGs';
+
 const meta = {
   title: 'App/ReactionCanvasAppV5',
   component: ReactionCanvasAppV5,
   parameters: { layout: 'fullscreen' },
   tags: ['autodocs'],
+  args: {
+    testConnectionFn: () => Promise.resolve(true),
+  },
   beforeEach: () => {
-    // Bypass mobile-only gate so canvas renders in Storybook on desktop.
     const url = new URL(window.location.href);
     url.searchParams.set('forceView', 'mobile');
+    url.searchParams.set('room', EXAMPLE_VIDEO_ID);
     window.history.replaceState({}, '', url.toString());
     return () => {
       const reset = new URL(window.location.href);
       reset.searchParams.delete('forceView');
+      reset.searchParams.delete('room');
       window.history.replaceState({}, '', reset.toString());
     };
   },
@@ -22,9 +28,13 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {
-  args: {
-    testConnectionFn: () => Promise.resolve(true),
+export const Default: Story = {};
+
+export const NoVideo: Story = {
+  beforeEach: () => {
+    const url = new URL(window.location.href);
+    url.searchParams.delete('room');
+    window.history.replaceState({}, '', url.toString());
   },
 };
 

--- a/stories/ReactionCanvasAppV5.stories.tsx
+++ b/stories/ReactionCanvasAppV5.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import ReactionCanvasAppV5 from '../app/components/apps/ReactionCanvasAppV5';
+
+const meta = {
+  title: 'App/ReactionCanvasAppV5',
+  component: ReactionCanvasAppV5,
+  parameters: { layout: 'fullscreen' },
+  tags: ['autodocs'],
+  beforeEach: () => {
+    // Bypass mobile-only gate so canvas renders in Storybook on desktop.
+    const url = new URL(window.location.href);
+    url.searchParams.set('forceView', 'mobile');
+    window.history.replaceState({}, '', url.toString());
+    return () => {
+      const reset = new URL(window.location.href);
+      reset.searchParams.delete('forceView');
+      window.history.replaceState({}, '', reset.toString());
+    };
+  },
+} satisfies Meta<typeof ReactionCanvasAppV5>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    testConnectionFn: () => Promise.resolve(true),
+  },
+};
+
+export const DatabaseUnreachable: Story = {
+  args: {
+    testConnectionFn: () => Promise.resolve(false),
+  },
+};

--- a/stories/ReactionCanvasAppV5.stories.tsx
+++ b/stories/ReactionCanvasAppV5.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import ReactionCanvasAppV5 from '../app/components/apps/ReactionCanvasAppV5';
+import React from 'react';
 
 const EXAMPLE_VIDEO_ID = 'irc6creOFGs';
 
@@ -8,6 +9,9 @@ const meta = {
   component: ReactionCanvasAppV5,
   parameters: { layout: 'fullscreen' },
   tags: ['autodocs'],
+  decorators: [
+    (Story) => React.createElement('div', { style: { height: '100vh', width: '100vw', overflow: 'hidden' } }, React.createElement(Story)),
+  ],
   args: {
     testConnectionFn: () => Promise.resolve(true),
   },


### PR DESCRIPTION
## Summary

- Adds a new product-style front page (`NewFrontPage`) branded as **Whisper Gallery** with a typewriter room-name input, participant/emcee open buttons, an Experiments section (YouTube Videos → V5, Sync'd Watch Party → V2) with YouTube thumbnail presets, and a More Prototypes footer
- Extracts the existing landing page to `OldFrontPage` (accessible at `#old`); `NewFrontPage` is now the default route
- Co-locates story files beside their components; adds `app/**` glob to `.storybook/main.ts`
- Fixes long-standing back-button regression: router now listens to `hashchange`, `popstate`, and `pageshow` (bfcache) so navigating back from any hash route reliably restores the front page

## Test plan

- [ ] Load root URL — Whisper Gallery page renders with typewriter effect cycling through room name suggestions
- [ ] "Participant View" and "Emcee View" buttons produce correct `?room=...#v4` URLs (query string before hash)
- [ ] Selecting a video thumbnail preset populates the URL placeholder; typing in the field deselects all presets
- [ ] "Open Experiment" navigates to V5 (YouTube Videos) or V2 (Watch Party) with correct URL
- [ ] "Admin" link appears only when YouTube Videos is selected
- [ ] Navigate to `#old` — old card-grid front page renders with QR code pointing to `.../#old`
- [ ] Back button from any `#hash` app returns to the correct front page without a manual refresh
- [ ] Storybook: `Pages/NewFrontPage` and `Pages/OldFrontPage` stories render correctly and scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~150 words of PR description from ~400 words of human prompts across this session)