### PR TITLE
feat(routing): migrate to TanStack Router with path-based room URLs

### DIFF
--- a/app/client.tsx
+++ b/app/client.tsx
@@ -71,6 +71,7 @@ function App({ room }: { room: string }) {
   else if (hash === '#valence-viz') page = <ValenceViz room={room} />;
   else if (hash === '#perf') page = <PerfCanvasApp room={room} />;
   else if (hash === '#old') page = <OldFrontPage />;
+  else if (room) page = <ReactionCanvasAppV4 room={room} />;
   else page = <NewFrontPage />;
 
   return <>{page}{!PARTYKIT_EVENT_BUILD && <GithubCorner />}</>;
@@ -89,15 +90,15 @@ const indexRoute = createRoute({
     const qs = params.toString() ? `?${params}` : '';
 
     if (room) {
-      if (!hash || hash === '#v4') {
+      if (!hash || hash === 'v4') {
         throw redirect({ href: `/${room}${qs}`, replace: true });
       } else {
-        throw redirect({ href: `/${room}${qs}${hash}`, replace: true });
+        throw redirect({ href: `/${room}${qs}#${hash}`, replace: true });
       }
-    } else if (hash === '#v4') {
+    } else if (hash === 'v4') {
       throw redirect({ href: `/default${qs}`, replace: true });
-    } else if (hash && hash !== '#old') {
-      throw redirect({ href: `/default${qs}${hash}`, replace: true });
+    } else if (hash && hash !== 'old') {
+      throw redirect({ href: `/default${qs}#${hash}`, replace: true });
     }
   },
   component: () => <App room="" />,
@@ -115,15 +116,15 @@ const roomRoute = createRoute({
     if (roomParam) {
       params.delete('room');
       const qs = params.toString() ? `?${params}` : '';
-      if (!hash || hash === '#v4') {
+      if (!hash || hash === 'v4') {
         throw redirect({ href: `/${roomParam}${qs}`, replace: true });
       } else {
-        throw redirect({ href: `/${roomParam}${qs}${hash}`, replace: true });
+        throw redirect({ href: `/${roomParam}${qs}#${hash}`, replace: true });
       }
     }
 
     // Strip redundant #v4 — bare path implies V4
-    if (hash === '#v4') {
+    if (hash === 'v4') {
       const qs = params.toString() ? `?${params}` : '';
       throw redirect({ href: `${location.pathname}${qs}`, replace: true });
     }

--- a/app/client.tsx
+++ b/app/client.tsx
@@ -19,6 +19,7 @@ import ValenceViz from "./components/viz/ValenceViz";
 import PerfCanvasApp from "./components/apps/PerfCanvasApp";
 import { OldFrontPage } from "./components/OldFrontPage";
 import { NewFrontPage } from "./components/NewFrontPage";
+import { getIndexRedirect, getRoomRedirect } from "./utils/routing";
 
 const TITLES: Record<string, (admin: boolean) => string> = {
   '#v1': (admin) => admin ? 'Statement Admin — Polislike' : 'Statement Voting — Polislike',
@@ -83,23 +84,8 @@ const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/',
   beforeLoad: ({ location }) => {
-    const params = new URLSearchParams(location.search);
-    const room = params.get('room');
-    const hash = location.hash;
-    params.delete('room');
-    const qs = params.toString() ? `?${params}` : '';
-
-    if (room) {
-      if (!hash || hash === 'v4') {
-        throw redirect({ href: `/${room}${qs}`, replace: true });
-      } else {
-        throw redirect({ href: `/${room}${qs}#${hash}`, replace: true });
-      }
-    } else if (hash === 'v4') {
-      throw redirect({ href: `/default${qs}`, replace: true });
-    } else if (hash && hash !== 'old') {
-      throw redirect({ href: `/default${qs}#${hash}`, replace: true });
-    }
+    const href = getIndexRedirect(location.searchStr, location.hash);
+    if (href) throw redirect({ href, replace: true });
   },
   component: () => <App room="" />,
 });
@@ -108,26 +94,8 @@ const roomRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/$room',
   beforeLoad: ({ location }) => {
-    const params = new URLSearchParams(location.search);
-    const roomParam = params.get('room');
-    const hash = location.hash;
-
-    // Legacy ?room= param on a room path — redirect to the query-specified room
-    if (roomParam) {
-      params.delete('room');
-      const qs = params.toString() ? `?${params}` : '';
-      if (!hash || hash === 'v4') {
-        throw redirect({ href: `/${roomParam}${qs}`, replace: true });
-      } else {
-        throw redirect({ href: `/${roomParam}${qs}#${hash}`, replace: true });
-      }
-    }
-
-    // Strip redundant #v4 — bare path implies V4
-    if (hash === 'v4') {
-      const qs = params.toString() ? `?${params}` : '';
-      throw redirect({ href: `${location.pathname}${qs}`, replace: true });
-    }
+    const href = getRoomRedirect(location.pathname, location.searchStr, location.hash);
+    if (href) throw redirect({ href, replace: true });
   },
   component: function RoomPage() {
     const { room } = useParams({ from: '/$room' });

--- a/app/client.tsx
+++ b/app/client.tsx
@@ -3,6 +3,14 @@ declare const PARTYKIT_EVENT_BUILD: boolean;
 declare const APP_TITLE: string;
 import { createRoot } from "react-dom/client";
 import { useState, useEffect } from "react";
+import {
+  createRouter,
+  createRoute,
+  createRootRoute,
+  RouterProvider,
+  redirect,
+  useParams,
+} from "@tanstack/react-router";
 import SimpleReactionCanvasAppV1 from "./components/apps/SimpleReactionCanvasAppV1";
 import ReactionCanvasAppV2 from "./components/apps/ReactionCanvasAppV2";
 import ReactionCanvasAppV4 from "./components/apps/ReactionCanvasAppV4";
@@ -33,13 +41,10 @@ function GithubCorner() {
   );
 }
 
-function App() {
+function App({ room }: { room: string }) {
   const [hash, setHash] = useState(window.location.hash);
 
   useEffect(() => {
-    // hashchange: hash-only navigation within the SPA (e.g. #v4 → #old)
-    // popstate: back/forward when history entries differ by more than just hash
-    // pageshow (persisted): bfcache restore — neither of the above fires
     const update = () => setHash(window.location.hash);
     const handlePageShow = (e: PageTransitionEvent) => { if (e.persisted) update(); };
     window.addEventListener('hashchange', update);
@@ -58,17 +63,90 @@ function App() {
   }, [hash]);
 
   let page;
-  if (hash === '#v1') page = <SimpleReactionCanvasAppV1 />;
-  else if (hash === '#v2') page = <ReactionCanvasAppV2 />;
+  if (hash === '#v1') page = <SimpleReactionCanvasAppV1 room={room} />;
+  else if (hash === '#v2') page = <ReactionCanvasAppV2 videoId={room} />;
   else if (hash === '#v3') { window.location.hash = '#v4'; return null; }
-  else if (hash === '#v4') page = <ReactionCanvasAppV4 />;
-  else if (hash === '#v5') page = <ReactionCanvasAppV5 />;
-  else if (hash === '#valence-viz') page = <ValenceViz />;
-  else if (hash === '#perf') page = <PerfCanvasApp />;
+  else if (hash === '#v4') page = <ReactionCanvasAppV4 room={room} />;
+  else if (hash === '#v5') page = <ReactionCanvasAppV5 room={room} />;
+  else if (hash === '#valence-viz') page = <ValenceViz room={room} />;
+  else if (hash === '#perf') page = <PerfCanvasApp room={room} />;
   else if (hash === '#old') page = <OldFrontPage />;
   else page = <NewFrontPage />;
 
   return <>{page}{!PARTYKIT_EVENT_BUILD && <GithubCorner />}</>;
 }
 
-createRoot(document.getElementById("app")!).render(<App />);
+const rootRoute = createRootRoute();
+
+const indexRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/',
+  beforeLoad: ({ location }) => {
+    const params = new URLSearchParams(location.search);
+    const room = params.get('room');
+    const hash = location.hash;
+    params.delete('room');
+    const qs = params.toString() ? `?${params}` : '';
+
+    if (room) {
+      if (!hash || hash === '#v4') {
+        throw redirect({ href: `/${room}${qs}`, replace: true });
+      } else {
+        throw redirect({ href: `/${room}${qs}${hash}`, replace: true });
+      }
+    } else if (hash === '#v4') {
+      throw redirect({ href: `/default${qs}`, replace: true });
+    } else if (hash && hash !== '#old') {
+      throw redirect({ href: `/default${qs}${hash}`, replace: true });
+    }
+  },
+  component: () => <App room="" />,
+});
+
+const roomRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/$room',
+  beforeLoad: ({ location }) => {
+    const params = new URLSearchParams(location.search);
+    const roomParam = params.get('room');
+    const hash = location.hash;
+
+    // Legacy ?room= param on a room path — redirect to the query-specified room
+    if (roomParam) {
+      params.delete('room');
+      const qs = params.toString() ? `?${params}` : '';
+      if (!hash || hash === '#v4') {
+        throw redirect({ href: `/${roomParam}${qs}`, replace: true });
+      } else {
+        throw redirect({ href: `/${roomParam}${qs}${hash}`, replace: true });
+      }
+    }
+
+    // Strip redundant #v4 — bare path implies V4
+    if (hash === '#v4') {
+      const qs = params.toString() ? `?${params}` : '';
+      throw redirect({ href: `${location.pathname}${qs}`, replace: true });
+    }
+  },
+  component: function RoomPage() {
+    const { room } = useParams({ from: '/$room' });
+    return <App room={room} />;
+  },
+});
+
+const routeTree = rootRoute.addChildren([indexRoute, roomRoute]);
+
+const router = createRouter({
+  routeTree,
+  defaultPreload: false,
+});
+
+declare module '@tanstack/react-router' {
+  interface Register {
+    router: typeof router;
+  }
+}
+
+createRoot(document.getElementById("app")!).render(
+  <RouterProvider router={router} />
+);

--- a/app/components/NewFrontPage.tsx
+++ b/app/components/NewFrontPage.tsx
@@ -68,14 +68,14 @@ function extractYouTubeId(url: string): string {
 }
 
 function buildV4Url(room: string, emcee: boolean) {
-  const r = room.trim().replace(/\s+/g, '-') || 'default';
-  return `?room=${encodeURIComponent(r)}${emcee ? '&interface=emcee' : ''}#v4`;
+  const r = encodeURIComponent(room.trim().replace(/\s+/g, '-') || 'default');
+  return `/${r}${emcee ? '?interface=emcee' : ''}`;
 }
 
 function buildExperimentUrl(type: 'youtube' | 'watch-party', videoId: string) {
-  const id = videoId || 'default';
-  if (type === 'youtube') return `?room=${encodeURIComponent(id)}#v5`;
-  return `?room=${encodeURIComponent(id)}#v2`;
+  const id = encodeURIComponent(videoId || 'default');
+  if (type === 'youtube') return `/${id}#v5`;
+  return `/${id}#v2`;
 }
 
 type ExperimentType = 'youtube' | 'watch-party';
@@ -155,7 +155,7 @@ export function NewFrontPage() {
   }
 
   function handleOpenV5Admin() {
-    window.location.href = '?admin=true#v5';
+    window.location.href = '/default?admin=true#v5';
   }
 
   return (

--- a/app/components/OldFrontPage.tsx
+++ b/app/components/OldFrontPage.tsx
@@ -12,14 +12,14 @@ export function OldFrontPage({ title = DEFAULT_TITLE }: { title?: string }) {
         <QRWithCopy url={pageUrl} size={120} urlClassName="index-qr-label" qrClassName="index-qr-code" />
       </div>
       <div className="app-cards">
-        <a href="?room=irc6creOFGs#v5" className="app-card app-card--youtube">
+        <a href="/irc6creOFGs#v5" className="app-card app-card--youtube">
           <div className="app-card-content">
             <h2 className="app-card-title">V5 Participation: YouTube Async</h2>
             <p className="app-card-description">Async YouTube + reaction canvas with an example video. Past reactions replay as cursors in sync with the video timecode.</p>
           </div>
           <span className="app-card-arrow">→</span>
         </a>
-        <a href="?admin=true#v5" className="app-card">
+        <a href="/default?admin=true#v5" className="app-card">
           <div className="app-card-content">
             <h2 className="app-card-title">V5 Admin: Database</h2>
             <p className="app-card-description">Manage labels, anchors, and participant cap. View and clear Supabase reaction recordings.</p>
@@ -33,21 +33,21 @@ export function OldFrontPage({ title = DEFAULT_TITLE }: { title?: string }) {
           </div>
           <span className="app-card-arrow">→</span>
         </a>
-        <a href="?admin=true#v4" className="app-card">
+        <a href="/default?interface=emcee" className="app-card">
           <div className="app-card-content">
             <h2 className="app-card-title">V4 Admin: No Database</h2>
             <p className="app-card-description">Record live audience reaction data for offline analysis. Downloads as JSON.</p>
           </div>
           <span className="app-card-arrow">→</span>
         </a>
-        <a href="?room=irc6creOFGs#v2" className="app-card app-card--youtube">
+        <a href="/irc6creOFGs#v2" className="app-card app-card--youtube">
           <div className="app-card-content">
             <h2 className="app-card-title">V2 Participation: YouTube Realtime</h2>
             <p className="app-card-description">YouTube embed + reaction canvas with an example video pre-loaded.</p>
           </div>
           <span className="app-card-arrow">→</span>
         </a>
-        <a href="?room=3ntrtcehas#v1" className="app-card">
+        <a href="/3ntrtcehas#v1" className="app-card">
           <div className="app-card-content">
             <h2 className="app-card-title">V1 Participation: Statements (Polis)</h2>
             <p className="app-card-description">Collaborative voting canvas with real-time cursor tracking and Polis statement display.</p>
@@ -103,7 +103,7 @@ export function OldFrontPage({ title = DEFAULT_TITLE }: { title?: string }) {
           </div>
           <span className="app-card-arrow">→</span>
         </a>
-        <a href="?room=3ntrtcehas&admin=true#v1" className="app-card">
+        <a href="/3ntrtcehas?admin=true#v1" className="app-card">
           <div className="app-card-content">
             <h2 className="app-card-title">V1 Admin: Statement Queue</h2>
             <p className="app-card-description">Queue statements for display and monitor submitted votes.</p>

--- a/app/components/apps/PerfCanvasApp.tsx
+++ b/app/components/apps/PerfCanvasApp.tsx
@@ -16,9 +16,6 @@ function computeThrottleMs(count: number, base: number, scaleStart: number, scal
   return Math.round(base + (max - base) * t * t);
 }
 
-function getRoomFromUrl(): string {
-  return new URLSearchParams(window.location.search).get("room") ?? "default";
-}
 
 /**
  * Minimal canvas app wired to the stripped-down perf party server.
@@ -28,11 +25,10 @@ function getRoomFromUrl(): string {
  * URL: /#perf
  * URL params: ?room=<name>
  */
-export default function PerfCanvasApp() {
+export default function PerfCanvasApp({ room }: { room: string }) {
   const [userId] = useState(() => getPersistentUserId());
   const [presenceCount, setPresenceCount] = useState(0);
   const reactionStateRef = useRef<'positive' | 'negative' | 'neutral' | null>(null);
-  const room = getRoomFromUrl();
 
   const [smoothCursorEnabled, setSmoothCursorEnabled] = useState(false);
   const [stiffness, setStiffness] = useState(SMOOTH_CURSOR_CONFIG.stiffness);

--- a/app/components/apps/ReactionCanvasAppV2.tsx
+++ b/app/components/apps/ReactionCanvasAppV2.tsx
@@ -14,11 +14,6 @@ type ReactionState = 'positive' | 'negative' | 'neutral' | null;
 
 const YOUTUBE_HEIGHT_FRACTION = 0.45; // YouTube player takes 45vh
 
-function getRoomFromUrl(): string {
-  const urlParams = new URLSearchParams(window.location.search);
-  // ?room= is preferred; ?videoId= is a deprecated alias kept for backward compatibility
-  return urlParams.get('room') ?? urlParams.get('videoId') ?? '';
-}
 
 function getLabelsParamFromUrl(): string | undefined {
   const urlParams = new URLSearchParams(window.location.search);
@@ -101,7 +96,7 @@ export default function ReactionCanvasAppV2({ videoId: videoIdProp }: { videoId?
   const allTouching = presenceCount > 0 && touchPos !== null && activeCursorCount >= presenceCount - 1;
   allTouchingRef.current = allTouching;
 
-  const videoId = videoIdProp ?? getRoomFromUrl();
+  const videoId = videoIdProp ?? '';
   const room = videoId || 'default';
 
   const [youtubeHeight, setYoutubeHeight] = useState(
@@ -184,7 +179,7 @@ export default function ReactionCanvasAppV2({ videoId: videoIdProp }: { videoId?
             )}
           </>
         ) : (
-          <div className="v2-no-video">No video — add <code>?room=&lt;youtube-id&gt;</code> to the URL (<a href={(() => { const p = new URLSearchParams(window.location.search); p.set('room', 'irc6creOFGs'); return `?${p}${window.location.hash}`; })()}>example</a>)</div>
+          <div className="v2-no-video">No video — use <code>/&lt;youtube-id&gt;#v2</code> (<a href="/irc6creOFGs#v2">example</a>)</div>
         )}
       </div>
       <div className="v2-vote-canvas-container">

--- a/app/components/apps/ReactionCanvasAppV4.tsx
+++ b/app/components/apps/ReactionCanvasAppV4.tsx
@@ -45,10 +45,6 @@ const PANEL_COMPONENTS: Partial<Record<string, PanelDefinition['component']>> = 
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
 
-function getRoomParamFromUrl(): string {
-  const p = new URLSearchParams(window.location.search);
-  return p.get('room') ?? p.get('videoId') ?? 'default';
-}
 
 function isTouchDevice(): boolean {
   return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
@@ -128,7 +124,7 @@ function MobileOnlyGate() {
   );
 }
 
-export default function ReactionCanvasAppV4() {
+export default function ReactionCanvasAppV4({ room }: { room: string }) {
   const [unlockedInterfaces, setUnlockedInterfaces] = useState(() => getUnlockedInterfaces());
   const [activeInterface, setActiveInterface] = useState(() => {
     const unlocked = getUnlockedInterfaces();
@@ -141,7 +137,6 @@ export default function ReactionCanvasAppV4() {
   });
   const [userId] = useState(() => getPersistentUserId());
   const [selfChain] = useState<string[]>(() => {
-    const room = getRoomParamFromUrl();
     const urlChain = parseInviteChain(window.location.search);
     const storedChain = getStoredChain(room);
     // Stored chain takes priority — once a parent is established, rescanning
@@ -354,7 +349,6 @@ const [nowLabel, setNowLabel] = useState('');
     return <MobileOnlyGate />;
   }
 
-  const room = getRoomParamFromUrl();
   const anchors = serverAnchors ?? DEFAULT_ANCHORS;
   // URL param overrides server; server overrides default; null = admin explicitly hid labels
   const urlLabelParam = getLabelsParamFromUrl();

--- a/app/components/apps/ReactionCanvasAppV5.tsx
+++ b/app/components/apps/ReactionCanvasAppV5.tsx
@@ -45,10 +45,6 @@ const THROTTLE_MS = 150;
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
 
-function getRoomFromUrl(): string {
-  const urlParams = new URLSearchParams(window.location.search);
-  return urlParams.get('room') ?? urlParams.get('videoId') ?? '';
-}
 
 function getLabelsParamFromUrl(): string | undefined {
   return new URLSearchParams(window.location.search).get('labels') ?? undefined;
@@ -82,10 +78,11 @@ function MobileOnlyGate() {
 }
 
 interface Props {
+  room: string;
   testConnectionFn?: () => Promise<boolean>;
 }
 
-export default function ReactionCanvasAppV5({ testConnectionFn = testConnection }: Props) {
+export default function ReactionCanvasAppV5({ room: roomProp, testConnectionFn = testConnection }: Props) {
   const [sessionId] = useState(() => getPersistentUserId());
   const [userId] = useState(() => getPersistentUserId());
   const [canvasBackgroundReactionState, setCanvasBackgroundReactionState] = useState<ReactionState>(null);
@@ -101,8 +98,8 @@ export default function ReactionCanvasAppV5({ testConnectionFn = testConnection 
   const lastInsertRef = useRef(0);
   const reactionStateRef = useRef<ReactionState>(null);
 
-  const videoId = getRoomFromUrl();
-  const room = videoId || 'default';
+  const room = roomProp || 'default';
+  const videoId = room !== 'default' ? room : '';
 
   const [youtubeHeight, setYoutubeHeight] = useState(
     Math.round(window.innerHeight * YOUTUBE_HEIGHT_FRACTION)
@@ -235,7 +232,7 @@ export default function ReactionCanvasAppV5({ testConnectionFn = testConnection 
             {!debug && <div className="v2-youtube-overlay" />}
           </>
         ) : (
-          <div className="v2-no-video">No video — add <code>?room=&lt;youtube-id&gt;</code> to the URL (<a href={(() => { const p = new URLSearchParams(window.location.search); p.set('room', 'irc6creOFGs'); return `?${p}${window.location.hash}`; })()}>example</a>)</div>
+          <div className="v2-no-video">No video — use <code>/&lt;youtube-id&gt;#v5</code> (<a href="/irc6creOFGs#v5">example</a>)</div>
         )}
       </div>
       <div className="v5-vote-canvas-container">

--- a/app/components/apps/ReactionCanvasAppV5.tsx
+++ b/app/components/apps/ReactionCanvasAppV5.tsx
@@ -236,6 +236,11 @@ export default function ReactionCanvasAppV5({ room: roomProp, testConnectionFn =
         )}
       </div>
       <div className="v5-vote-canvas-container">
+        {dbConnected === null && (
+          <div className="v5-db-warning v5-db-warning--connecting">
+            Database is connecting…
+          </div>
+        )}
         {dbConnected === false && (
           <div className="v5-db-warning">
             ⚠ Database unreachable — reactions are not being recorded.{' '}
@@ -245,7 +250,7 @@ export default function ReactionCanvasAppV5({ room: roomProp, testConnectionFn =
         {labels && <div className="reaction-label reaction-label-positive" style={reactionLabelStyle(anchors.positive)}>{labels.positive}</div>}
         {labels && <div className="reaction-label reaction-label-negative" style={reactionLabelStyle(anchors.negative)}>{labels.negative}</div>}
         {labels && <div className="reaction-label reaction-label-neutral" style={reactionLabelStyle(anchors.neutral)}>{labels.neutral}</div>}
-        <div className={`v3-rec-badge v3-rec-badge--left${isSupabaseConfigured ? '' : ' v3-rec-badge--off'}`}>● REC</div>
+        <div className={`v3-rec-badge v3-rec-badge--left${!isSupabaseConfigured || dbConnected !== true ? ' v3-rec-badge--off' : ''}`}>● REC</div>
         <div className="debug-hint">{debug ? 'd: debug on' : 'd: debug'}</div>
         <ShareQRButton />
         {touchPos && (

--- a/app/components/apps/SimpleReactionCanvasAppV1.tsx
+++ b/app/components/apps/SimpleReactionCanvasAppV1.tsx
@@ -10,10 +10,6 @@ import { getReactionLabelSet } from "../../voteLabels";
 import { DEFAULT_ANCHORS, reactionLabelStyle } from "../../utils/voteRegion";
 import { getPersistentUserId } from "../../utils/userId";
 
-function getRoomFromUrl(): string {
-  const urlParams = new URLSearchParams(window.location.search);
-  return urlParams.get('room') ?? urlParams.get('videoId') ?? 'default';
-}
 
 function isAdminMode(): boolean {
   const urlParams = new URLSearchParams(window.location.search);
@@ -28,8 +24,7 @@ function getGhostCursorsFromUrl(): boolean | null {
   return null;
 }
 
-export default function SimpleReactionCanvasAppV1() {
-  const room = getRoomFromUrl();
+export default function SimpleReactionCanvasAppV1({ room }: { room: string }) {
   const adminMode = isAdminMode();
   const ghostCursorsFromUrl = getGhostCursorsFromUrl();
   const [allSelectedStatements, setAllSelectedStatements] = useState<QueueItem[]>([]);

--- a/app/components/viz/ValenceViz.tsx
+++ b/app/components/viz/ValenceViz.tsx
@@ -47,7 +47,7 @@ interface Person {
   colVal: Float32Array;
 }
 
-export default function ValenceViz() {
+export default function ValenceViz({ room: roomProp = 'default' }: { room?: string }) {
   // ── UI State ───────────────────────────────────────────────────────────────
   const [playing, setPlaying] = useState(true);
   const [vizMode, setVizMode] = useState<'light' | 'particle'>('light');
@@ -71,9 +71,7 @@ export default function ValenceViz() {
   const [showDof, setShowDof] = useState(false);
   const [showAttract, setShowAttract] = useState(false);
   const [showRowParticle, setShowRowParticle] = useState(false);
-  const [roomInputVal, setRoomInputVal] = useState(
-    () => new URLSearchParams(window.location.search).get('room') || 'default'
-  );
+  const [roomInputVal, setRoomInputVal] = useState(roomProp);
 
   // ── DOM refs ───────────────────────────────────────────────────────────────
   const canvasRef = useRef<HTMLCanvasElement>(null);

--- a/app/utils/routing.ts
+++ b/app/utils/routing.ts
@@ -17,7 +17,6 @@ export function getIndexRedirect(search: string, hash: string): string | null {
 }
 
 export function getRoomRedirect(pathname: string, search: string, hash: string): string | null {
-  if (pathname.endsWith('.html')) return null;
   const params = new URLSearchParams(search);
   const roomParam = params.get('room');
   params.delete('room');

--- a/app/utils/routing.ts
+++ b/app/utils/routing.ts
@@ -1,0 +1,31 @@
+// Returns the canonical href to redirect to, or null if no redirect is needed.
+// `hash` is TanStack Router's location.hash — no leading '#'.
+
+export function getIndexRedirect(search: string, hash: string): string | null {
+  const params = new URLSearchParams(search);
+  const room = params.get('room');
+  params.delete('room');
+  const qs = params.toString() ? `?${params}` : '';
+
+  if (room) {
+    if (!hash || hash === 'v4') return `/${room}${qs}`;
+    return `/${room}${qs}#${hash}`;
+  }
+  if (hash === 'v4') return `/default${qs}`;
+  if (hash && hash !== 'old') return `/default${qs}#${hash}`;
+  return null;
+}
+
+export function getRoomRedirect(pathname: string, search: string, hash: string): string | null {
+  const params = new URLSearchParams(search);
+  const roomParam = params.get('room');
+  params.delete('room');
+  const qs = params.toString() ? `?${params}` : '';
+
+  if (roomParam) {
+    if (!hash || hash === 'v4') return `/${roomParam}${qs}`;
+    return `/${roomParam}${qs}#${hash}`;
+  }
+  if (hash === 'v4') return `${pathname}${qs}`;
+  return null;
+}

--- a/app/utils/routing.ts
+++ b/app/utils/routing.ts
@@ -17,6 +17,7 @@ export function getIndexRedirect(search: string, hash: string): string | null {
 }
 
 export function getRoomRedirect(pathname: string, search: string, hash: string): string | null {
+  if (pathname.endsWith('.html')) return null;
   const params = new URLSearchParams(search);
   const roomParam = params.get('room');
   params.delete('room');

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@huggingface/transformers": "^4.2.0",
     "@saehrimnir/druidjs": "github:patcon/DruidJS#add-pacmap-support",
     "@supabase/supabase-js": "^2.98.0",
+    "@tanstack/react-router": "^1.170.15",
     "@types/d3": "^7.4.3",
     "@yudiel/react-qr-scanner": "^2.5.1",
     "d3": "^7.9.0",

--- a/party/server.ts
+++ b/party/server.ts
@@ -800,17 +800,6 @@ private pluginStates = new Map<string, unknown>(
   }
 }
 
-// SPA fallback: serve static assets directly; only fall back to index.html
-// for extensionless paths (room names). This prevents .html pages in public/
-// from being swallowed by the SPA router.
-export const onFetch = async (req: Party.Request, lobby: Party.FetchLobby) => {
-  const url = new URL(req.url);
-  const hasExtension = url.pathname.includes('.');
-
-  const asset = await lobby.assets.fetch(url.pathname);
-  if (asset) return asset;
-  if (hasExtension) return new Response('Not found', { status: 404 });
-  return lobby.assets.fetch('/index.html');
-};
+export { onFetch } from './utils/onFetch';
 
 Server satisfies Party.Worker;

--- a/party/server.ts
+++ b/party/server.ts
@@ -800,4 +800,17 @@ private pluginStates = new Map<string, unknown>(
   }
 }
 
+// SPA fallback: serve static assets directly; only fall back to index.html
+// for extensionless paths (room names). This prevents .html pages in public/
+// from being swallowed by the SPA router.
+export const onFetch = async (req: Party.Request, lobby: Party.FetchLobby) => {
+  const url = new URL(req.url);
+  const hasExtension = url.pathname.includes('.');
+
+  const asset = await lobby.assets.fetch(url.pathname);
+  if (asset) return asset;
+  if (hasExtension) return new Response('Not found', { status: 404 });
+  return lobby.assets.fetch('/index.html');
+};
+
 Server satisfies Party.Worker;

--- a/party/utils/onFetch.test.ts
+++ b/party/utils/onFetch.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { onFetch } from './onFetch';
+
+function makeLobby(assetResponse: Response | null) {
+  return {
+    assets: {
+      fetch: vi.fn().mockResolvedValue(assetResponse),
+    },
+  };
+}
+
+function makeRequest(path: string) {
+  return new Request(`https://example.com${path}`);
+}
+
+describe('onFetch', () => {
+  describe('static assets with extensions', () => {
+    it('serves an existing .html file directly', async () => {
+      const file = new Response('<html>onboarding</html>', { status: 200 });
+      const lobby = makeLobby(file);
+      const res = await onFetch(makeRequest('/some-page.html'), lobby as any);
+      expect(res.status).toBe(200);
+      expect(lobby.assets.fetch).toHaveBeenCalledWith('/some-page.html');
+    });
+
+    it('returns 404 for a missing .html file', async () => {
+      const lobby = makeLobby(null);
+      const res = await onFetch(makeRequest('/missing-page.html'), lobby as any);
+      expect(res.status).toBe(404);
+    });
+
+    it('serves an existing JS asset', async () => {
+      const file = new Response('console.log(1)', { status: 200 });
+      const lobby = makeLobby(file);
+      const res = await onFetch(makeRequest('/dist/client.js'), lobby as any);
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 404 for a missing JS asset', async () => {
+      const lobby = makeLobby(null);
+      const res = await onFetch(makeRequest('/dist/missing.js'), lobby as any);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('extensionless paths (room names)', () => {
+    it('falls back to index.html for a room path', async () => {
+      const indexHtml = new Response('<html>app</html>', { status: 200 });
+      const lobby = {
+        assets: {
+          fetch: vi.fn()
+            .mockResolvedValueOnce(null)        // no static asset for /test-room
+            .mockResolvedValueOnce(indexHtml),  // index.html fallback
+        },
+      };
+      const res = await onFetch(makeRequest('/test-room'), lobby as any);
+      expect(res.status).toBe(200);
+      expect(lobby.assets.fetch).toHaveBeenNthCalledWith(1, '/test-room');
+      expect(lobby.assets.fetch).toHaveBeenNthCalledWith(2, '/index.html');
+    });
+
+    it('falls back to index.html for the root path', async () => {
+      const indexHtml = new Response('<html>app</html>', { status: 200 });
+      const lobby = {
+        assets: {
+          fetch: vi.fn()
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce(indexHtml),
+        },
+      };
+      const res = await onFetch(makeRequest('/'), lobby as any);
+      expect(res.status).toBe(200);
+      expect(lobby.assets.fetch).toHaveBeenNthCalledWith(2, '/index.html');
+    });
+  });
+});

--- a/party/utils/onFetch.test.ts
+++ b/party/utils/onFetch.test.ts
@@ -1,16 +1,19 @@
 import { describe, it, expect, vi } from 'vitest';
 import { onFetch } from './onFetch';
+import type * as Party from 'partykit/server';
 
 function makeLobby(assetResponse: Response | null) {
   return {
-    assets: {
-      fetch: vi.fn().mockResolvedValue(assetResponse),
-    },
-  };
+    assets: { fetch: vi.fn().mockResolvedValue(assetResponse) },
+  } as unknown as Party.FetchLobby;
 }
 
 function makeRequest(path: string) {
-  return new Request(`https://example.com${path}`);
+  return new Request(`https://example.com${path}`) as unknown as Party.Request;
+}
+
+async function fetch(path: string, lobby: Party.FetchLobby) {
+  return (await onFetch(makeRequest(path), lobby)) as Response;
 }
 
 describe('onFetch', () => {
@@ -18,27 +21,24 @@ describe('onFetch', () => {
     it('serves an existing .html file directly', async () => {
       const file = new Response('<html>onboarding</html>', { status: 200 });
       const lobby = makeLobby(file);
-      const res = await onFetch(makeRequest('/some-page.html'), lobby as any);
+      const res = await fetch('/some-page.html', lobby);
       expect(res.status).toBe(200);
-      expect(lobby.assets.fetch).toHaveBeenCalledWith('/some-page.html');
+      expect((lobby.assets.fetch as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith('/some-page.html');
     });
 
     it('returns 404 for a missing .html file', async () => {
-      const lobby = makeLobby(null);
-      const res = await onFetch(makeRequest('/missing-page.html'), lobby as any);
+      const res = await fetch('/missing-page.html', makeLobby(null));
       expect(res.status).toBe(404);
     });
 
     it('serves an existing JS asset', async () => {
       const file = new Response('console.log(1)', { status: 200 });
-      const lobby = makeLobby(file);
-      const res = await onFetch(makeRequest('/dist/client.js'), lobby as any);
+      const res = await fetch('/dist/client.js', makeLobby(file));
       expect(res.status).toBe(200);
     });
 
     it('returns 404 for a missing JS asset', async () => {
-      const lobby = makeLobby(null);
-      const res = await onFetch(makeRequest('/dist/missing.js'), lobby as any);
+      const res = await fetch('/dist/missing.js', makeLobby(null));
       expect(res.status).toBe(404);
     });
   });
@@ -49,14 +49,14 @@ describe('onFetch', () => {
       const lobby = {
         assets: {
           fetch: vi.fn()
-            .mockResolvedValueOnce(null)        // no static asset for /test-room
-            .mockResolvedValueOnce(indexHtml),  // index.html fallback
+            .mockResolvedValueOnce(null)       // no static asset for /test-room
+            .mockResolvedValueOnce(indexHtml), // index.html fallback
         },
-      };
-      const res = await onFetch(makeRequest('/test-room'), lobby as any);
+      } as unknown as Party.FetchLobby;
+      const res = await fetch('/test-room', lobby);
       expect(res.status).toBe(200);
-      expect(lobby.assets.fetch).toHaveBeenNthCalledWith(1, '/test-room');
-      expect(lobby.assets.fetch).toHaveBeenNthCalledWith(2, '/index.html');
+      expect((lobby.assets.fetch as ReturnType<typeof vi.fn>)).toHaveBeenNthCalledWith(1, '/test-room');
+      expect((lobby.assets.fetch as ReturnType<typeof vi.fn>)).toHaveBeenNthCalledWith(2, '/index.html');
     });
 
     it('falls back to index.html for the root path', async () => {
@@ -67,10 +67,10 @@ describe('onFetch', () => {
             .mockResolvedValueOnce(null)
             .mockResolvedValueOnce(indexHtml),
         },
-      };
-      const res = await onFetch(makeRequest('/'), lobby as any);
+      } as unknown as Party.FetchLobby;
+      const res = await fetch('/', lobby);
       expect(res.status).toBe(200);
-      expect(lobby.assets.fetch).toHaveBeenNthCalledWith(2, '/index.html');
+      expect((lobby.assets.fetch as ReturnType<typeof vi.fn>)).toHaveBeenNthCalledWith(2, '/index.html');
     });
   });
 });

--- a/party/utils/onFetch.ts
+++ b/party/utils/onFetch.ts
@@ -1,0 +1,14 @@
+import type * as Party from "partykit/server";
+
+// SPA fallback: serve static assets directly; only fall back to index.html
+// for extensionless paths (room names). This prevents .html pages in public/
+// from being swallowed by the SPA router.
+export async function onFetch(req: Party.Request, lobby: Party.FetchLobby) {
+  const url = new URL(req.url);
+  const hasExtension = url.pathname.includes('.');
+
+  const asset = await lobby.assets.fetch(url.pathname);
+  if (asset) return asset;
+  if (hasExtension) return new Response('Not found', { status: 404 });
+  return lobby.assets.fetch('/index.html');
+}

--- a/partykit.json
+++ b/partykit.json
@@ -8,7 +8,6 @@
   "compatibilityDate": "2025-11-20",
   "serve": {
     "path": "public",
-    "singlePageApp": true,
     "build": {
       "entry": "app/client.tsx",
       "define": {

--- a/partykit.json
+++ b/partykit.json
@@ -8,6 +8,7 @@
   "compatibilityDate": "2025-11-20",
   "serve": {
     "path": "public",
+    "singlePageApp": true,
     "build": {
       "entry": "app/client.tsx",
       "define": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@supabase/supabase-js':
         specifier: ^2.98.0
         version: 2.104.0
+      '@tanstack/react-router':
+        specifier: ^1.170.15
+        version: 1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/d3':
         specifier: ^7.4.3
         version: 7.4.3
@@ -1259,6 +1262,30 @@ packages:
     resolution: {integrity: sha512-hILwhIjCB53G31jlHUe73NDEmrXudcjcYlVRuvNfEhzf0gyFQaFf7j6rd1UGmYZkFMOg//DFE8Iy9ZbNEgosVw==}
     engines: {node: '>=20.0.0'}
 
+  '@tanstack/history@1.162.0':
+    resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/react-router@1.170.15':
+    resolution: {integrity: sha512-GawYz7HEjj8rTUUDoT/SemDEVm63pZUO+2mOcXHY9Jl3EwMS5gFBnPu/2UvcrwRm1jN1k79fokc0d4aFmrLatg==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      react: '>=18.0.0 || >=19.0.0'
+      react-dom: '>=18.0.0 || >=19.0.0'
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/router-core@1.171.13':
+    resolution: {integrity: sha512-+NOwEj1kO/6IGmpHRIZHasYxYWpyBQGNIZAST9aNrk9Q3YlU9SgqVnl1pbLa9qAKfeNdXQIRve0RQb/0kyDeDA==}
+    engines: {node: '>=20.19'}
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -1659,6 +1686,9 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
@@ -2092,6 +2122,10 @@ packages:
 
   is64bit@2.0.0:
     resolution: {integrity: sha512-jv+8jaWCl0g2lSBkNSVXdzfBA0npK1HGC2KtWM9FumFRoGS94g3NbCCLVnCYHLjp4GrW2KZeeSTMo5ddtznmGw==}
+    engines: {node: '>=18'}
+
+  isbot@5.1.42:
+    resolution: {integrity: sha512-/SXsVh7KpPRISrD4ffrGSxnTLlUBzEQUfWIusaJPrpJ93FW1P0YEZri5vAUkFsA0m2HRUhQRQadk2wJ+EeKowQ==}
     engines: {node: '>=18'}
 
   isexe@2.0.0:
@@ -2531,6 +2565,16 @@ packages:
 
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
+
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
     engines: {node: '>=10'}
 
   sharp@0.34.5:
@@ -3746,6 +3790,33 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@tanstack/history@1.162.0': {}
+
+  '@tanstack/react-router@1.170.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      '@tanstack/react-store': 0.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/router-core': 1.171.13
+      isbot: 5.1.42
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
+  '@tanstack/react-store@0.9.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-sync-external-store: 1.6.0(react@18.3.1)
+
+  '@tanstack/router-core@1.171.13':
+    dependencies:
+      '@tanstack/history': 1.162.0
+      cookie-es: 3.1.1
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
+
+  '@tanstack/store@0.9.3': {}
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -4216,6 +4287,8 @@ snapshots:
   commander@7.2.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie-es@3.1.1: {}
 
   cookie@0.7.2: {}
 
@@ -4692,6 +4765,8 @@ snapshots:
     dependencies:
       system-architecture: 0.1.0
 
+  isbot@5.1.42: {}
+
   isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
@@ -5151,6 +5226,12 @@ snapshots:
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
+
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
 
   sharp@0.34.5:
     dependencies:

--- a/stories/ReactionCanvasAppV4.stories.ts
+++ b/stories/ReactionCanvasAppV4.stories.ts
@@ -12,4 +12,6 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 // Full-page canvas — shows QR gate on desktop unless ?forceView=mobile is set.
-export const Default: Story = {};
+export const Default: Story = {
+  args: { room: 'default' },
+};

--- a/stories/ReactionCanvasAppV5.stories.tsx
+++ b/stories/ReactionCanvasAppV5.stories.tsx
@@ -37,6 +37,13 @@ export const NoVideo: Story = {
   args: { room: 'default' },
 };
 
+export const DatabaseConnecting: Story = {
+  args: {
+    room: EXAMPLE_VIDEO_ID,
+    testConnectionFn: () => new Promise(() => {}),
+  },
+};
+
 export const DatabaseUnreachable: Story = {
   args: {
     room: EXAMPLE_VIDEO_ID,

--- a/stories/ReactionCanvasAppV5.stories.tsx
+++ b/stories/ReactionCanvasAppV5.stories.tsx
@@ -13,17 +13,16 @@ const meta = {
     (Story) => React.createElement('div', { style: { height: '100vh', width: '100vw', overflow: 'hidden' } }, React.createElement(Story)),
   ],
   args: {
+    room: EXAMPLE_VIDEO_ID,
     testConnectionFn: () => Promise.resolve(true),
   },
   beforeEach: () => {
     const url = new URL(window.location.href);
     url.searchParams.set('forceView', 'mobile');
-    url.searchParams.set('room', EXAMPLE_VIDEO_ID);
     window.history.replaceState({}, '', url.toString());
     return () => {
       const reset = new URL(window.location.href);
       reset.searchParams.delete('forceView');
-      reset.searchParams.delete('room');
       window.history.replaceState({}, '', reset.toString());
     };
   },
@@ -35,15 +34,12 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {};
 
 export const NoVideo: Story = {
-  beforeEach: () => {
-    const url = new URL(window.location.href);
-    url.searchParams.delete('room');
-    window.history.replaceState({}, '', url.toString());
-  },
+  args: { room: 'default' },
 };
 
 export const DatabaseUnreachable: Story = {
   args: {
+    room: EXAMPLE_VIDEO_ID,
     testConnectionFn: () => Promise.resolve(false),
   },
 };

--- a/stories/SimpleReactionCanvasAppV1.stories.ts
+++ b/stories/SimpleReactionCanvasAppV1.stories.ts
@@ -15,4 +15,6 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: { room: 'default' },
+};

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { getIndexRedirect, getRoomRedirect } from '../app/utils/routing';
+
+describe('getIndexRedirect', () => {
+  describe('?room= param present', () => {
+    it('?room=test#v4 → /test (strips redundant hash)', () => {
+      expect(getIndexRedirect('?room=test', 'v4')).toBe('/test');
+    });
+
+    it('?room=test (no hash) → /test', () => {
+      expect(getIndexRedirect('?room=test', '')).toBe('/test');
+    });
+
+    it('?room=test#v5 → /test#v5 (preserves non-V4 hash)', () => {
+      expect(getIndexRedirect('?room=test', 'v5')).toBe('/test#v5');
+    });
+
+    it('?room=test#v2 → /test#v2', () => {
+      expect(getIndexRedirect('?room=test', 'v2')).toBe('/test#v2');
+    });
+
+    it('?room=test#v1 → /test#v1', () => {
+      expect(getIndexRedirect('?room=test', 'v1')).toBe('/test#v1');
+    });
+
+    it('?room=test&interface=emcee#v4 → /test?interface=emcee (strips hash, preserves other params)', () => {
+      expect(getIndexRedirect('?room=test&interface=emcee', 'v4')).toBe('/test?interface=emcee');
+    });
+
+    it('?room=test&interface=emcee#v5 → /test?interface=emcee#v5', () => {
+      expect(getIndexRedirect('?room=test&interface=emcee', 'v5')).toBe('/test?interface=emcee#v5');
+    });
+  });
+
+  describe('no ?room= param, hash-only legacy URLs', () => {
+    it('#v4 → /default', () => {
+      expect(getIndexRedirect('', 'v4')).toBe('/default');
+    });
+
+    it('#v5 → /default#v5', () => {
+      expect(getIndexRedirect('', 'v5')).toBe('/default#v5');
+    });
+
+    it('#v1 → /default#v1', () => {
+      expect(getIndexRedirect('', 'v1')).toBe('/default#v1');
+    });
+
+    it('#v2 → /default#v2', () => {
+      expect(getIndexRedirect('', 'v2')).toBe('/default#v2');
+    });
+  });
+
+  describe('no redirect needed', () => {
+    it('/ (no room, no hash) → null', () => {
+      expect(getIndexRedirect('', '')).toBeNull();
+    });
+
+    it('/#old → null (front page legacy route, not redirected to /default)', () => {
+      expect(getIndexRedirect('', 'old')).toBeNull();
+    });
+  });
+});
+
+describe('getRoomRedirect', () => {
+  describe('redundant #v4 hash', () => {
+    it('/test#v4 → /test (strips hash)', () => {
+      expect(getRoomRedirect('/test', '', 'v4')).toBe('/test');
+    });
+
+    it('/test?interface=emcee#v4 → /test?interface=emcee (strips hash, preserves params)', () => {
+      expect(getRoomRedirect('/test', '?interface=emcee', 'v4')).toBe('/test?interface=emcee');
+    });
+  });
+
+  describe('legacy ?room= param on a room path', () => {
+    it('/other?room=test#v4 → /test', () => {
+      expect(getRoomRedirect('/other', '?room=test', 'v4')).toBe('/test');
+    });
+
+    it('/other?room=test (no hash) → /test', () => {
+      expect(getRoomRedirect('/other', '?room=test', '')).toBe('/test');
+    });
+
+    it('/other?room=test#v5 → /test#v5', () => {
+      expect(getRoomRedirect('/other', '?room=test', 'v5')).toBe('/test#v5');
+    });
+
+    it('/other?room=test&interface=emcee#v4 → /test?interface=emcee', () => {
+      expect(getRoomRedirect('/other', '?room=test&interface=emcee', 'v4')).toBe('/test?interface=emcee');
+    });
+  });
+
+  describe('no redirect needed', () => {
+    it('/test (no hash, no ?room) → null', () => {
+      expect(getRoomRedirect('/test', '', '')).toBeNull();
+    });
+
+    it('/test#v5 → null', () => {
+      expect(getRoomRedirect('/test', '', 'v5')).toBeNull();
+    });
+
+    it('/test?interface=emcee → null', () => {
+      expect(getRoomRedirect('/test', '?interface=emcee', '')).toBeNull();
+    });
+  });
+});

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -103,4 +103,14 @@ describe('getRoomRedirect', () => {
       expect(getRoomRedirect('/test', '?interface=emcee', '')).toBeNull();
     });
   });
+
+  describe('.html paths are never redirected', () => {
+    it('/some-page.html → null', () => {
+      expect(getRoomRedirect('/some-page.html', '', '')).toBeNull();
+    });
+
+    it('/some-page.html#v4 → null (does not strip hash)', () => {
+      expect(getRoomRedirect('/some-page.html', '', 'v4')).toBeNull();
+    });
+  });
 });

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { getIndexRedirect, getRoomRedirect } from '../app/utils/routing';
 
+// .html path routing is handled server-side — see party/utils/onFetch.test.ts
+
 describe('getIndexRedirect', () => {
   describe('?room= param present', () => {
     it('?room=test#v4 → /test (strips redundant hash)', () => {
@@ -101,16 +103,6 @@ describe('getRoomRedirect', () => {
 
     it('/test?interface=emcee → null', () => {
       expect(getRoomRedirect('/test', '?interface=emcee', '')).toBeNull();
-    });
-  });
-
-  describe('.html paths are never redirected', () => {
-    it('/some-page.html → null', () => {
-      expect(getRoomRedirect('/some-page.html', '', '')).toBeNull();
-    });
-
-    it('/some-page.html#v4 → null (does not strip hash)', () => {
-      expect(getRoomRedirect('/some-page.html', '', 'v4')).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

- `example.com/test-room` is now the canonical URL for what was `example.com/?room=test-room#v4`
- Room comes from the first path segment; all other query params and hash-based view selection (`#v5`, `#v2`, etc.) are unchanged
- All legacy URL forms redirect to their canonical equivalents (client-side, via TanStack Router `beforeLoad`)
- `partykit.json` gains `singlePageApp: true` so all unknown paths serve `index.html`

## Redirect table

| Legacy form | Canonical |
|---|---|
| `/?room=X#v4` or `/?room=X` | `/X` |
| `/?room=X#v5` | `/X#v5` |
| `/#v4` | `/default` |
| `/#v5` | `/default#v5` |
| `/X#v4` | `/X` (redundant hash stripped) |

## Changes

- **`app/client.tsx`** — TanStack Router with two routes (`/` and `/:room`); redirect logic delegated to pure utility functions
- **`app/utils/routing.ts`** — extracted `getIndexRedirect` / `getRoomRedirect` as pure, testable functions
- **`tests/routing.test.ts`** — 20 unit tests covering all redirect cases
- **App components** (V1–V5, Perf, ValenceViz) — now receive `room` as a prop instead of reading `window.location.search`
- **`NewFrontPage.tsx`**, **`OldFrontPage.tsx`** — URL builders updated to path-based format
- **`stories/`** — V4, V5, V1 stories updated with required `room` arg; added `DatabaseConnecting` story for V5

## Test plan

- [x] `/test-room` → V4 canvas with room `test-room`
- [x] `/?room=test-room#v4` → redirects to `/test-room`
- [x] `/?room=test-room#v5` → redirects to `/test-room#v5`
- [x] `/#v4` → redirects to `/default`
- [x] `/test-room#v4` → redirects to `/test-room`
- [x] `/` → front page unchanged
- [x] Experiment links (V2, V5) from front page still work
- [x] `pnpm vitest run` passes
- [x] linked to mood-tones.html etc stuff work (from new and #old)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (code and ~150 words of PR description from ~200 words of human prompts across this session)