### PR TITLE
test: cover core pure-logic utilities and server HTTP surface

### DIFF
--- a/party/tests/onRequest.test.ts
+++ b/party/tests/onRequest.test.ts
@@ -1,0 +1,221 @@
+/**
+ * HTTP surface tests for the PartyKit server: the `onRequest` REST endpoints
+ * (vote submission/retrieval, github submissions, debug-state) and the Polis
+ * API proxy reached through the `updateStatementsPool` client message.
+ *
+ * Plugins are mocked out to an empty registry so these tests exercise only the
+ * server's own request handling, not plugin `onRequest` delegation (which is a
+ * separate contract).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type * as Party from 'partykit/server';
+import Server from '../server';
+import { createMockRoom, createMockConnection } from './helpers/mockParty';
+
+vi.mock('../../plugins/index', () => ({ PLUGINS: [], PLUGIN_MAP: {} }));
+// Immediate broadcasts (no cursor batching) keep async assertions simple.
+vi.mock('../../app/utils/cursor', () => ({ SERVER_CURSOR_BATCH_MS: 0 }));
+
+function makeRequest(
+  method: string,
+  path: string,
+  opts: { json?: unknown } = {},
+): Party.Request {
+  return {
+    method,
+    url: `https://test.example.com${path}`,
+    json: async () => {
+      if ('json' in opts) return opts.json;
+      throw new SyntaxError('Unexpected end of JSON input');
+    },
+  } as unknown as Party.Request;
+}
+
+describe('Server.onRequest', () => {
+  let room: Party.Room;
+  let server: Server;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    ({ room } = createMockRoom([]));
+    server = new Server(room);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── POST /vote ────────────────────────────────────────────────────────────
+
+  describe('POST /vote', () => {
+    const validVote = { userId: 'u1', statementId: 3, vote: 1, timestamp: 123 };
+
+    it('stores a valid vote and returns the running count', async () => {
+      const res = await server.onRequest(makeRequest('POST', '/parties/main/room/vote', { json: validVote }));
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ success: true, voteCount: 1 });
+    });
+
+    it('defaults a missing timestamp instead of rejecting', async () => {
+      const { userId, statementId, vote } = validVote;
+      const res = await server.onRequest(makeRequest('POST', '/vote', { json: { userId, statementId, vote } }));
+      expect(res.status).toBe(200);
+      // The stored vote should now be retrievable with a timestamp filled in.
+      const votes = await (await server.onRequest(makeRequest('GET', '/votes'))).json();
+      expect(votes[0].timestamp).toEqual(expect.any(Number));
+    });
+
+    it.each([
+      ['missing userId', { statementId: 1, vote: 1 }],
+      ['non-numeric statementId', { userId: 'u1', statementId: '1', vote: 1 }],
+      ['out-of-range vote', { userId: 'u1', statementId: 1, vote: 2 }],
+    ])('rejects invalid vote data (%s) with 400', async (_label, body) => {
+      const res = await server.onRequest(makeRequest('POST', '/vote', { json: body }));
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 500 when the body is not valid JSON', async () => {
+      const res = await server.onRequest(makeRequest('POST', '/vote')); // json() throws
+      expect(res.status).toBe(500);
+    });
+
+    it.each([-1, 0, 1])('accepts the valid vote value %i', async (vote) => {
+      const res = await server.onRequest(makeRequest('POST', '/vote', { json: { userId: 'u', statementId: 0, vote } }));
+      expect(res.status).toBe(200);
+    });
+  });
+
+  // ── GET / DELETE /votes ─────────────────────────────────────────────────────
+
+  describe('GET /votes and DELETE /votes', () => {
+    it('returns an empty array before any votes are cast', async () => {
+      const res = await server.onRequest(makeRequest('GET', '/votes'));
+      expect(await res.json()).toEqual([]);
+    });
+
+    it('returns stored votes, then clears them on DELETE', async () => {
+      await server.onRequest(makeRequest('POST', '/vote', { json: { userId: 'a', statementId: 1, vote: 1 } }));
+      await server.onRequest(makeRequest('POST', '/vote', { json: { userId: 'b', statementId: 2, vote: -1 } }));
+
+      const before = await (await server.onRequest(makeRequest('GET', '/votes'))).json();
+      expect(before).toHaveLength(2);
+
+      const del = await server.onRequest(makeRequest('DELETE', '/votes'));
+      expect(await del.json()).toEqual({ success: true, message: 'All votes cleared' });
+
+      const after = await (await server.onRequest(makeRequest('GET', '/votes'))).json();
+      expect(after).toEqual([]);
+    });
+  });
+
+  // ── GET / DELETE /github-submissions ────────────────────────────────────────
+
+  describe('github-submissions endpoints', () => {
+    it('returns an empty list and clears on DELETE', async () => {
+      const get = await server.onRequest(makeRequest('GET', '/github-submissions'));
+      expect(await get.json()).toEqual([]);
+
+      const del = await server.onRequest(makeRequest('DELETE', '/github-submissions'));
+      expect(await del.json()).toEqual({ success: true });
+    });
+  });
+
+  // ── debug-state ─────────────────────────────────────────────────────────────
+
+  describe('debug-state endpoints', () => {
+    it('GET reads persisted state from storage', async () => {
+      const res = await server.onRequest(makeRequest('GET', '/debug-state'));
+      const body = await res.json();
+      expect(room.storage.get).toHaveBeenCalledWith('state');
+      expect(body).toHaveProperty('inMemoryPluginStates');
+    });
+
+    it('DELETE removes persisted state from storage', async () => {
+      const res = await server.onRequest(makeRequest('DELETE', '/debug-state'));
+      expect(room.storage.delete).toHaveBeenCalledWith('state');
+      expect(await res.json()).toEqual({ success: true, message: 'Persisted state deleted from storage' });
+    });
+  });
+
+  // ── default response ────────────────────────────────────────────────────────
+
+  describe('unmatched routes', () => {
+    it('returns the default plain-text health response', async () => {
+      const res = await server.onRequest(makeRequest('GET', '/something-else'));
+      expect(res.headers.get('Content-Type')).toBe('text/plain');
+      expect(await res.text()).toBe('Cursor tracking server is running');
+    });
+  });
+});
+
+// ── Polis API proxy (updateStatementsPool) ────────────────────────────────────
+
+describe('Polis statements-pool proxy', () => {
+  let room: Party.Room;
+  let broadcast: ReturnType<typeof vi.fn>;
+  let server: Server;
+  let conn: Party.Connection;
+
+  function lastBroadcast() {
+    const calls = broadcast.mock.calls;
+    return JSON.parse(calls[calls.length - 1][0] as string);
+  }
+
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    ({ room, broadcast } = createMockRoom([]));
+    server = new Server(room);
+    ({ conn } = createMockConnection('conn-1'));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches from the Polis API and broadcasts the loaded pool', async () => {
+    const statements = [{ txt: 'hi', tid: 1, created: '2024', is_seed: false, is_meta: false, lang: 'en', pid: 0 }];
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => statements });
+    vi.stubGlobal('fetch', fetchMock);
+
+    server.onMessage(JSON.stringify({ type: 'updateStatementsPool', conversationId: 'abc123' }), conn);
+
+    await vi.waitFor(() => expect(lastBroadcast().type).toBe('statementsPoolUpdated'));
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('conversation_id=abc123'));
+    expect(lastBroadcast().statementsPool).toEqual(statements);
+  });
+
+  it('honours a custom baseUrl for the Polis fetch', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => [] });
+    vi.stubGlobal('fetch', fetchMock);
+
+    server.onMessage(JSON.stringify({ type: 'updateStatementsPool', conversationId: 'c1', baseUrl: 'https://custom.pol.is' }), conn);
+
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('https://custom.pol.is/api/v3/comments'));
+  });
+
+  it('broadcasts an error when the Polis API responds non-OK', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503, json: async () => ({}) }));
+
+    server.onMessage(JSON.stringify({ type: 'updateStatementsPool', conversationId: 'abc' }), conn);
+
+    await vi.waitFor(() => expect(lastBroadcast().type).toBe('statementsPoolError'));
+    expect(lastBroadcast().error).toContain('503');
+  });
+
+  it('converts inline JSON statements (DefaultStatement → PolisStatement) without fetching', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const json = [{ text: 'Local statement', statementId: 7 }];
+    server.onMessage(JSON.stringify({ type: 'updateStatementsPool', json }), conn);
+
+    await vi.waitFor(() => expect(lastBroadcast().type).toBe('statementsPoolUpdated'));
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(lastBroadcast().statementsPool[0]).toMatchObject({ txt: 'Local statement', tid: 7, lang: 'en' });
+  });
+});

--- a/tests/inviteChain.test.ts
+++ b/tests/inviteChain.test.ts
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  parseInviteChain,
+  appendSelfToChain,
+  chainToEdges,
+  getStoredChain,
+  storeChain,
+  buildInviteChainUrl,
+} from '../app/utils/inviteChain';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('parseInviteChain', () => {
+  it('returns an empty array when the param is absent', () => {
+    expect(parseInviteChain('?room=test')).toEqual([]);
+  });
+
+  it('splits a comma-separated chain', () => {
+    expect(parseInviteChain('?inviteChain=a,b,c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('drops empty segments', () => {
+    expect(parseInviteChain('?inviteChain=a,,b,')).toEqual(['a', 'b']);
+  });
+
+  it('handles a leading "?" or none', () => {
+    expect(parseInviteChain('inviteChain=x')).toEqual(['x']);
+  });
+});
+
+describe('appendSelfToChain', () => {
+  it('appends a new id to the end', () => {
+    expect(appendSelfToChain(['a', 'b'], 'c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('does not append when the id is already present', () => {
+    expect(appendSelfToChain(['a', 'b'], 'b')).toEqual(['a', 'b']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = ['a'];
+    appendSelfToChain(input, 'b');
+    expect(input).toEqual(['a']);
+  });
+});
+
+describe('chainToEdges', () => {
+  it('builds consecutive directed edges', () => {
+    expect(chainToEdges(['a', 'b', 'c'])).toEqual([
+      ['a', 'b'],
+      ['b', 'c'],
+    ]);
+  });
+
+  it('returns no edges for a single-node chain', () => {
+    expect(chainToEdges(['a'])).toEqual([]);
+  });
+
+  it('returns no edges for an empty chain', () => {
+    expect(chainToEdges([])).toEqual([]);
+  });
+});
+
+describe('getStoredChain / storeChain', () => {
+  it('returns an empty array when nothing is stored', () => {
+    expect(getStoredChain('room1')).toEqual([]);
+  });
+
+  it('round-trips a stored chain keyed by room', () => {
+    storeChain('room1', ['a', 'b']);
+    expect(getStoredChain('room1')).toEqual(['a', 'b']);
+    expect(getStoredChain('room2')).toEqual([]);
+  });
+
+  it('returns an empty array for corrupt stored JSON', () => {
+    localStorage.setItem('treevites-chain-room1', '{not json');
+    expect(getStoredChain('room1')).toEqual([]);
+  });
+});
+
+describe('buildInviteChainUrl', () => {
+  it('appends self and serializes the chain into the inviteChain param', () => {
+    const result = buildInviteChainUrl('?room=test', 'me', ['a', 'b']);
+    const params = new URLSearchParams(result);
+    expect(params.get('room')).toBe('test');
+    expect(params.get('inviteChain')).toBe('a,b,me');
+  });
+
+  it('does not duplicate self if already in the chain', () => {
+    const result = buildInviteChainUrl('', 'me', ['me', 'a']);
+    expect(new URLSearchParams(result).get('inviteChain')).toBe('me,a');
+  });
+
+  it('overwrites an existing inviteChain param', () => {
+    const result = buildInviteChainUrl('?inviteChain=old', 'me', ['a']);
+    expect(new URLSearchParams(result).get('inviteChain')).toBe('a,me');
+  });
+});

--- a/tests/partyHost.test.ts
+++ b/tests/partyHost.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { getPartySocketConfig, getPartyHost } from '../app/utils/partyHost';
+
+function mockLocation(loc: { port: string; hostname: string; protocol: string }) {
+  vi.stubGlobal('window', { location: loc });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getPartySocketConfig', () => {
+  it('connects to the local dev server on port 1999 with ws over HTTP', () => {
+    mockLocation({ port: '1999', hostname: '10.0.0.5', protocol: 'http:' });
+    expect(getPartySocketConfig()).toEqual({ host: '10.0.0.5:1999', protocol: 'ws' });
+  });
+
+  it('uses wss on port 1999 when the page is served over HTTPS', () => {
+    mockLocation({ port: '1999', hostname: 'localhost', protocol: 'https:' });
+    expect(getPartySocketConfig()).toEqual({ host: 'localhost:1999', protocol: 'wss' });
+  });
+
+  it('returns the deployed host with wss on any other port', () => {
+    mockLocation({ port: '', hostname: 'app.example.partykit.dev', protocol: 'https:' });
+    expect(getPartySocketConfig()).toEqual({ host: 'app.example.partykit.dev', protocol: 'wss' });
+  });
+});
+
+describe('getPartyHost', () => {
+  it('returns just the host from the socket config', () => {
+    mockLocation({ port: '1999', hostname: '192.168.1.2', protocol: 'http:' });
+    expect(getPartyHost()).toBe('192.168.1.2:1999');
+  });
+});

--- a/tests/polisImport.test.ts
+++ b/tests/polisImport.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parsePolisVotes,
+  parsePolisComments,
+  assemblePolisImport,
+} from '../app/utils/polisImport';
+
+describe('parsePolisVotes', () => {
+  it('parses comment-id, voter-id and vote as numbers', () => {
+    const csv = ['comment-id,voter-id,vote', '0,5,1', '1,5,-1', '2,7,0'].join('\n');
+    expect(parsePolisVotes(csv)).toEqual([
+      { commentId: 0, voterId: 5, vote: 1 },
+      { commentId: 1, voterId: 5, vote: -1 },
+      { commentId: 2, voterId: 7, vote: 0 },
+    ]);
+  });
+});
+
+describe('parsePolisComments', () => {
+  it('parses comment-id, timestamp and body', () => {
+    const csv = [
+      'comment-id,timestamp,comment-body',
+      '0,1000,Hello world',
+      '1,2000,Second comment',
+    ].join('\n');
+    expect(parsePolisComments(csv)).toEqual([
+      { commentId: 0, timestamp: 1000, body: 'Hello world' },
+      { commentId: 1, timestamp: 2000, body: 'Second comment' },
+    ]);
+  });
+});
+
+describe('assemblePolisImport', () => {
+  const comments = [
+    { commentId: 0, timestamp: 1000, body: 'first' },
+    { commentId: 1, timestamp: 2000, body: 'second' },
+  ];
+  const votes = [
+    { commentId: 0, voterId: 10, vote: 1 as const },
+    { commentId: 0, voterId: 20, vote: -1 as const },
+    { commentId: 1, voterId: 10, vote: 0 as const },
+    // voter 10 votes more often, so ranks above voter 20
+    { commentId: 1, voterId: 10, vote: 0 as const },
+  ];
+
+  it('orders moments by timestamp descending', () => {
+    const { moments } = assemblePolisImport(comments, votes, ['u1', 'u2']);
+    expect(moments.map((m) => m.label)).toEqual(['second', 'first']);
+  });
+
+  it('converts comment timestamps from seconds to milliseconds', () => {
+    const { moments } = assemblePolisImport(comments, votes, ['u1', 'u2']);
+    const first = moments.find((m) => m.label === 'first')!;
+    expect(first.timestamp).toBe(1_000_000);
+  });
+
+  it('maps votes to regions (1→positive, -1→negative, 0→neutral)', () => {
+    const { moments } = assemblePolisImport(comments, votes, ['u1', 'u2']);
+    const first = moments.find((m) => m.label === 'first')!;
+    const regionValues = Object.values(first.regions).sort();
+    // comment 0 had a +1 and a -1 vote → one positive, one negative
+    expect(regionValues).toEqual(['negative', 'positive']);
+  });
+
+  it('maps a non-voter on a comment to null', () => {
+    const { moments } = assemblePolisImport(comments, votes, ['u1', 'u2']);
+    const second = moments.find((m) => m.label === 'second')!;
+    // only voter 10 voted on comment 1; voter 20's user has no vote → null
+    const values = Object.values(second.regions);
+    expect(values).toContain('neutral'); // voter 10 voted 0
+    expect(values).toContain(null); // voter 20's user did not vote
+  });
+
+  it('reuses all seen users and creates no synthetic ids when enough are supplied', () => {
+    const { syntheticUserIds } = assemblePolisImport(comments, votes, ['u1', 'u2']);
+    expect(syntheticUserIds).toEqual([]);
+  });
+
+  it('generates synthetic ids for voters beyond the supplied seen users', () => {
+    // two distinct voters but only one seen user → one synthetic id
+    const { syntheticUserIds, moments } = assemblePolisImport(comments, votes, ['u1']);
+    expect(syntheticUserIds).toHaveLength(1);
+    // every moment's regions should reference both the seen user and the synthetic id
+    const userIds = new Set(Object.keys(moments[0].regions));
+    expect(userIds.has('u1')).toBe(true);
+    expect(userIds.has(syntheticUserIds[0])).toBe(true);
+  });
+
+  it('assigns a unique id to every moment', () => {
+    const { moments } = assemblePolisImport(comments, votes, ['u1', 'u2']);
+    const ids = moments.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/tests/routing.test.ts
+++ b/tests/routing.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { getIndexRedirect, getRoomRedirect } from '../app/utils/routing';
 
-// .html path routing is handled server-side — see party/utils/onFetch.test.ts
+// .html / SPA path routing is handled by PartyKit's built-in `serve.singlePageApp`
+// config (partykit.json), not by application code, so there is nothing to unit-test there.
+// Server HTTP endpoints (votes, debug-state, Polis proxy) are covered in party/tests/onRequest.test.ts.
 
 describe('getIndexRedirect', () => {
   describe('?room= param present', () => {

--- a/tests/userId.test.ts
+++ b/tests/userId.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { generateUUID, getPersistentUserId } from '../app/utils/userId';
+
+const UUID_V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+describe('generateUUID', () => {
+  it('returns a v4-formatted UUID', () => {
+    expect(generateUUID()).toMatch(UUID_V4);
+  });
+
+  it('returns unique values across calls', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateUUID()));
+    expect(ids.size).toBe(100);
+  });
+
+  describe('fallback when crypto.randomUUID is unavailable (insecure context)', () => {
+    let original: typeof crypto.randomUUID | undefined;
+
+    beforeEach(() => {
+      original = crypto.randomUUID;
+      // Simulate an HTTP LAN context where randomUUID is missing.
+      (crypto as { randomUUID?: unknown }).randomUUID = undefined;
+    });
+
+    afterEach(() => {
+      (crypto as { randomUUID?: unknown }).randomUUID = original;
+    });
+
+    it('still produces a valid v4 UUID via the Math.random fallback', () => {
+      expect(generateUUID()).toMatch(UUID_V4);
+    });
+  });
+});
+
+describe('getPersistentUserId', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('generates and persists an id on first call', () => {
+    const id = getPersistentUserId();
+    expect(id).toMatch(UUID_V4);
+    expect(localStorage.getItem('polis_user_id')).toBe(id);
+  });
+
+  it('returns the same id on subsequent calls', () => {
+    const first = getPersistentUserId();
+    const second = getPersistentUserId();
+    expect(second).toBe(first);
+  });
+});

--- a/tests/voteLabels.test.ts
+++ b/tests/voteLabels.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  REACTION_LABEL_PRESETS,
+  encodeCustomLabels,
+  decodeCustomLabels,
+  getCustomLabelHistory,
+  saveCustomLabelToHistory,
+  removeCustomLabelFromHistory,
+  getReactionLabelSet,
+} from '../app/voteLabels';
+
+const HISTORY_KEY = 'polis_custom_label_history';
+const SET_KEY = 'polis_label_set';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('encodeCustomLabels / decodeCustomLabels', () => {
+  it('round-trips a label set', () => {
+    const encoded = encodeCustomLabels('Yes', 'No', 'Skip');
+    expect(decodeCustomLabels(encoded)).toEqual({ positive: 'Yes', negative: 'No', neutral: 'Skip' });
+  });
+
+  it('round-trips labels containing the "|" delimiter and other special chars', () => {
+    const encoded = encodeCustomLabels('a|b', 'c d', 'é/ñ');
+    expect(decodeCustomLabels(encoded)).toEqual({ positive: 'a|b', negative: 'c d', neutral: 'é/ñ' });
+  });
+
+  it('returns null for malformed base64', () => {
+    expect(decodeCustomLabels('!!!not base64!!!')).toBeNull();
+  });
+
+  it('returns null when there are not exactly three parts', () => {
+    expect(decodeCustomLabels(btoa('only|two'))).toBeNull();
+  });
+
+  it('returns null when any part is empty', () => {
+    expect(decodeCustomLabels(btoa(['a', '', 'c'].join('|')))).toBeNull();
+  });
+});
+
+describe('getCustomLabelHistory', () => {
+  it('returns an empty array when nothing is stored', () => {
+    expect(getCustomLabelHistory()).toEqual([]);
+  });
+
+  it('returns an empty array for non-array stored JSON', () => {
+    localStorage.setItem(HISTORY_KEY, JSON.stringify({ not: 'an array' }));
+    expect(getCustomLabelHistory()).toEqual([]);
+  });
+
+  it('returns an empty array for invalid JSON', () => {
+    localStorage.setItem(HISTORY_KEY, '{broken');
+    expect(getCustomLabelHistory()).toEqual([]);
+  });
+
+  it('filters out malformed entries', () => {
+    localStorage.setItem(
+      HISTORY_KEY,
+      JSON.stringify([
+        { positive: 'A', negative: 'B', neutral: 'U' },
+        { positive: 'A', negative: 'B' }, // missing neutral
+        null,
+        'string',
+      ]),
+    );
+    expect(getCustomLabelHistory()).toEqual([{ positive: 'A', negative: 'B', neutral: 'U' }]);
+  });
+});
+
+describe('saveCustomLabelToHistory', () => {
+  it('adds a custom label to the front of the history', () => {
+    saveCustomLabelToHistory({ positive: 'Hot', negative: 'Cold', neutral: 'Warm' });
+    expect(getCustomLabelHistory()).toEqual([{ positive: 'Hot', negative: 'Cold', neutral: 'Warm' }]);
+  });
+
+  it('does not store sets that match a preset (case-insensitive)', () => {
+    saveCustomLabelToHistory({ positive: 'agree', negative: 'disagree', neutral: 'pass' });
+    expect(getCustomLabelHistory()).toEqual([]);
+  });
+
+  it('de-duplicates and moves an existing entry to the front', () => {
+    saveCustomLabelToHistory({ positive: 'A1', negative: 'B1', neutral: 'C1' });
+    saveCustomLabelToHistory({ positive: 'A2', negative: 'B2', neutral: 'C2' });
+    saveCustomLabelToHistory({ positive: 'A1', negative: 'B1', neutral: 'C1' });
+    const history = getCustomLabelHistory();
+    expect(history).toEqual([
+      { positive: 'A1', negative: 'B1', neutral: 'C1' },
+      { positive: 'A2', negative: 'B2', neutral: 'C2' },
+    ]);
+  });
+
+  it('caps the history at five entries', () => {
+    for (let i = 0; i < 7; i++) {
+      saveCustomLabelToHistory({ positive: `P${i}`, negative: `N${i}`, neutral: `Z${i}` });
+    }
+    const history = getCustomLabelHistory();
+    expect(history).toHaveLength(5);
+    expect(history[0]).toEqual({ positive: 'P6', negative: 'N6', neutral: 'Z6' });
+  });
+});
+
+describe('removeCustomLabelFromHistory', () => {
+  it('removes the entry at the given index and returns the result', () => {
+    saveCustomLabelToHistory({ positive: 'A1', negative: 'B1', neutral: 'C1' });
+    saveCustomLabelToHistory({ positive: 'A2', negative: 'B2', neutral: 'C2' });
+    // history is [A2, A1]; remove index 0 → [A1]
+    const result = removeCustomLabelFromHistory(0);
+    expect(result).toEqual([{ positive: 'A1', negative: 'B1', neutral: 'C1' }]);
+    expect(getCustomLabelHistory()).toEqual([{ positive: 'A1', negative: 'B1', neutral: 'C1' }]);
+  });
+});
+
+describe('getReactionLabelSet', () => {
+  it('returns a named preset', () => {
+    expect(getReactionLabelSet('genz')).toEqual(REACTION_LABEL_PRESETS.genz);
+  });
+
+  it('returns null for the "none" sentinel', () => {
+    expect(getReactionLabelSet('none')).toBeNull();
+  });
+
+  it('decodes a custom base64 key', () => {
+    const encoded = encodeCustomLabels('Yes', 'No', 'Skip');
+    expect(getReactionLabelSet(encoded)).toEqual({ positive: 'Yes', negative: 'No', neutral: 'Skip' });
+  });
+
+  it('falls back to the default preset for an unknown key', () => {
+    expect(getReactionLabelSet('not-a-real-preset')).toEqual(REACTION_LABEL_PRESETS.default);
+  });
+
+  it('reads from localStorage when no name is provided', () => {
+    localStorage.setItem(SET_KEY, 'abu');
+    expect(getReactionLabelSet()).toEqual(REACTION_LABEL_PRESETS.abu);
+  });
+
+  it('returns the default preset when nothing is stored and no name is given', () => {
+    expect(getReactionLabelSet()).toEqual(REACTION_LABEL_PRESETS.default);
+  });
+});

--- a/tests/voteRegion.test.ts
+++ b/tests/voteRegion.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_ANCHORS,
+  computeReactionRegion,
+  computeCursorValence,
+  valenceToPosition,
+  reactionLabelStyle,
+  type ReactionAnchors,
+} from '../app/utils/voteRegion';
+
+// DEFAULT_ANCHORS (0–100 canvas space):
+//   positive top-right    (95, 5)
+//   negative bottom-left  (5, 95)
+//   neutral  bottom-right  (95, 95)
+
+describe('computeReactionRegion', () => {
+  it('classifies a point at the positive anchor as positive', () => {
+    expect(computeReactionRegion(95, 5)).toBe('positive');
+  });
+
+  it('classifies a point at the negative anchor as negative', () => {
+    expect(computeReactionRegion(5, 95)).toBe('negative');
+  });
+
+  it('classifies a point at the neutral anchor as neutral', () => {
+    expect(computeReactionRegion(95, 95)).toBe('neutral');
+  });
+
+  it('classifies the top-right corner near the positive anchor', () => {
+    expect(computeReactionRegion(90, 10)).toBe('positive');
+  });
+
+  it('classifies the bottom-left corner near the negative anchor', () => {
+    expect(computeReactionRegion(10, 90)).toBe('negative');
+  });
+
+  it('respects custom anchors (swapped positive/negative)', () => {
+    const swapped: ReactionAnchors = {
+      positive: { x: 5, y: 95 },
+      negative: { x: 95, y: 5 },
+      neutral: { x: 95, y: 95 },
+    };
+    expect(computeReactionRegion(5, 95, swapped)).toBe('positive');
+    expect(computeReactionRegion(95, 5, swapped)).toBe('negative');
+  });
+
+  describe('degenerate (collinear) anchors → nearest-anchor fallback', () => {
+    const collinear: ReactionAnchors = {
+      positive: { x: 0, y: 0 },
+      negative: { x: 50, y: 50 },
+      neutral: { x: 100, y: 100 },
+    };
+
+    it('returns positive when nearest to the positive anchor', () => {
+      expect(computeReactionRegion(5, 5, collinear)).toBe('positive');
+    });
+
+    it('returns neutral when nearest to the neutral anchor', () => {
+      expect(computeReactionRegion(95, 95, collinear)).toBe('neutral');
+    });
+
+    it('returns negative when nearest to the negative anchor', () => {
+      expect(computeReactionRegion(50, 50, collinear)).toBe('negative');
+    });
+  });
+});
+
+describe('computeCursorValence', () => {
+  it('returns ~100 at the positive anchor', () => {
+    expect(computeCursorValence(95, 5)).toBeCloseTo(100, 5);
+  });
+
+  it('returns ~0 at the negative anchor', () => {
+    expect(computeCursorValence(5, 95)).toBeCloseTo(0, 5);
+  });
+
+  it('returns ~50 at the neutral anchor', () => {
+    expect(computeCursorValence(95, 95)).toBeCloseTo(50, 5);
+  });
+
+  it('clamps to the 0–100 range', () => {
+    for (let x = -50; x <= 150; x += 25) {
+      for (let y = -50; y <= 150; y += 25) {
+        const v = computeCursorValence(x, y);
+        expect(v).toBeGreaterThanOrEqual(0);
+        expect(v).toBeLessThanOrEqual(100);
+      }
+    }
+  });
+
+  it('uses the inverse-distance fallback for degenerate anchors', () => {
+    const collinear: ReactionAnchors = {
+      positive: { x: 0, y: 0 },
+      negative: { x: 50, y: 50 },
+      neutral: { x: 100, y: 100 },
+    };
+    const v = computeCursorValence(0, 0, collinear);
+    expect(v).toBeGreaterThanOrEqual(0);
+    expect(v).toBeLessThanOrEqual(100);
+  });
+});
+
+describe('valenceToPosition', () => {
+  const centroid = {
+    x: (DEFAULT_ANCHORS.negative.x + DEFAULT_ANCHORS.neutral.x + DEFAULT_ANCHORS.positive.x) / 3,
+    y: (DEFAULT_ANCHORS.negative.y + DEFAULT_ANCHORS.neutral.y + DEFAULT_ANCHORS.positive.y) / 3,
+  };
+
+  it('maps valence -1 to the negative anchor', () => {
+    expect(valenceToPosition(-1, DEFAULT_ANCHORS)).toEqual(DEFAULT_ANCHORS.negative);
+  });
+
+  it('maps valence 0 to the centroid', () => {
+    expect(valenceToPosition(0, DEFAULT_ANCHORS)).toEqual(centroid);
+  });
+
+  it('maps valence 1 to the positive anchor', () => {
+    const p = valenceToPosition(1, DEFAULT_ANCHORS);
+    expect(p.x).toBeCloseTo(DEFAULT_ANCHORS.positive.x, 5);
+    expect(p.y).toBeCloseTo(DEFAULT_ANCHORS.positive.y, 5);
+  });
+
+  it('clamps valence below -1 to the negative anchor', () => {
+    expect(valenceToPosition(-5, DEFAULT_ANCHORS)).toEqual(DEFAULT_ANCHORS.negative);
+  });
+
+  it('clamps valence above 1 to the positive anchor', () => {
+    const p = valenceToPosition(5, DEFAULT_ANCHORS);
+    expect(p.x).toBeCloseTo(DEFAULT_ANCHORS.positive.x, 5);
+    expect(p.y).toBeCloseTo(DEFAULT_ANCHORS.positive.y, 5);
+  });
+});
+
+describe('reactionLabelStyle', () => {
+  it('anchors a top-right label by translating up and left', () => {
+    expect(reactionLabelStyle({ x: 95, y: 5 })).toEqual({
+      position: 'absolute',
+      left: '95%',
+      top: '5%',
+      transform: 'translate(-100%, 0%)',
+    });
+  });
+
+  it('anchors a bottom-left label by translating down and right', () => {
+    expect(reactionLabelStyle({ x: 5, y: 95 })).toEqual({
+      position: 'absolute',
+      left: '5%',
+      top: '95%',
+      transform: 'translate(0%, -100%)',
+    });
+  });
+
+  it('centers a dead-center label on both axes', () => {
+    expect(reactionLabelStyle({ x: 50, y: 50 }).transform).toBe('translate(-50%, -50%)');
+  });
+});

--- a/tests/vttUtils.test.ts
+++ b/tests/vttUtils.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { extractPlainText } from '../app/utils/vttUtils';
+
+describe('extractPlainText', () => {
+  it('strips the WEBVTT header, cue timings and blank lines', () => {
+    const vtt = [
+      'WEBVTT',
+      '',
+      '00:00:01.000 --> 00:00:04.000',
+      'Hello there',
+      '',
+      '00:00:04.000 --> 00:00:06.000',
+      'General Kenobi',
+    ].join('\n');
+    expect(extractPlainText(vtt)).toBe('Hello there General Kenobi');
+  });
+
+  it('returns an empty string for a header-only file', () => {
+    expect(extractPlainText('WEBVTT\n\n')).toBe('');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(extractPlainText('')).toBe('');
+  });
+
+  it('keeps caption lines that are plain text', () => {
+    const vtt = ['WEBVTT', '', '00:00:00.000 --> 00:00:02.000', 'Just one line'].join('\n');
+    expect(extractPlainText(vtt)).toBe('Just one line');
+  });
+});


### PR DESCRIPTION
First two batches of the test-coverage improvement work. Tests only — no source changes (one stale comment fixed).

## 1. Pure-logic utilities

Unit tests for previously-untested deterministic helpers at the core of the product:

| File | What's now covered |
|------|--------------------|
| `app/utils/voteRegion.ts` | Barycentric region detection, valence mapping, label positioning, and the degenerate/collinear-anchor fallback paths |
| `app/voteLabels.ts` | Custom-label encode/decode round-trip, history dedup / preset-skip / 5-entry cap, and `getReactionLabelSet` precedence |
| `app/utils/polisImport.ts` | CSV parsing, vote→region mapping, top-N voter→user assignment, synthetic-id generation, timestamp scaling |
| `app/utils/inviteChain.ts` | parse / append-self / edges / build-url + localStorage round-trip |
| `app/utils/vttUtils.ts` | WEBVTT plain-text extraction |
| `app/utils/userId.ts` | `generateUUID` v4 format + Math.random fallback for insecure (HTTP LAN) contexts, plus persistence |
| `app/utils/partyHost.ts` | Socket host/protocol detection by port (dev vs deployed; ws vs wss) |

**Impact:** `app/utils` line coverage **~24% → ~73%**; `voteRegion.ts` ~96%.

## 2. Server HTTP surface

Tests for the PartyKit server's request handling in `party/tests/onRequest.test.ts`:

- **`onRequest` REST endpoints** — `POST /vote` (valid, validation failures, timestamp defaulting, malformed-body 500, all valid vote values), `GET`/`DELETE /votes` round-trip, github-submissions, debug-state storage read/delete, and the default health response.
- **Polis statements-pool proxy** (via the `updateStatementsPool` message) — API fetch + broadcast, custom `baseUrl`, non-OK error broadcast, and inline-JSON (`DefaultStatement → PolisStatement`) conversion.

Plugins are mocked to an empty registry so these exercise only the server's own request handling, not plugin `onRequest` delegation.

**Impact:** `party/server.ts` line coverage **~42% → ~60%**.

Also replaces a stale `routing.test.ts` comment that pointed at a never-created `party/utils/onFetch.test.ts` — `.html`/SPA routing is handled by PartyKit's `serve.singlePageApp` config, not application code, so there's nothing to unit-test there.

## Notes

- Files needing `localStorage` / `window` use a per-file `// @vitest-environment jsdom` docblock so they stay in the existing `unit` project glob.
- All 284 unit + component tests pass; `pnpm run typecheck` is clean.

Remaining proposed areas (separate PRs): `ghostCursors.ts`, AdminPanelNoDB hooks, and wiring up coverage thresholds in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)