### PR TITLE
refactor: extract RoomSocketContext, consolidate Canvas+TouchLayer WebSocket connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file. Releases cu
 ### Removed
 - **V1 Polis statement voting app removed** — `SimpleReactionCanvasAppV1`, `DeprecatedAdminPanel`, `DeprecatedStatementPanel`, and their Storybook stories deleted; `PolisStatement` and `QueueItem` types removed from `app/types.ts`; `#v1` hash handler and title entry removed from `client.tsx`. Server-side: removed `queueLogic`, `ghostCursors`, vote HTTP endpoints (`POST/GET/DELETE /vote`), Polis API proxy (`updateStatementsPool`), `GhostCursorManager`, and all V1 types from `party/types.ts`.
 
+### Added
+- **`RoomSocketContext` extracts shared WebSocket connection** — `Canvas` and `TouchLayer` now consume a single shared `usePartySocket` connection from `RoomSocketProvider` instead of each opening their own, reducing connections per participant from two to one and eliminating reconnect latency on activity switch. Dead code removed: `TouchLayer`'s `onActiveStatementChange` prop, `ServerMessage` type, and its `onMessage` handler (the server never sent `activeStatementId` or `activeStatementChanged`). New vitest component tests cover socket plumbing for both components.
+
 ### Changed
 - **Typecheck and tests gate PR staging deploys** — `staging-deploy.yml` now runs a `check` job (typecheck + Storybook/vitest tests) before deploying to staging; deploy is blocked if checks fail.
 - **PR preview deployments replaced with shared staging env** — per-PR preview, cleanup, and event-preview workflows disabled (broken upstream: partykit/partykit#985); new `staging-deploy.yml` deploys every PR to the shared `staging` preview environment instead. Staging is never torn down.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file. Releases cu
 ### Added
 - **`RoomSocketContext` extracts shared WebSocket connection** — `Canvas` and `TouchLayer` now consume a single shared `usePartySocket` connection from `RoomSocketProvider` instead of each opening their own, reducing connections per participant from two to one and eliminating reconnect latency on activity switch. Dead code removed: `TouchLayer`'s `onActiveStatementChange` prop, `ServerMessage` type, and its `onMessage` handler (the server never sent `activeStatementId` or `activeStatementChanged`). New vitest component tests cover socket plumbing for both components.
 
+### Fixed
+- **Reaction labels default to Agree/Disagree/Pass before server responds** — `ReactionCanvasParticipant` and `ReactionCanvasAppV4` now fall back to `REACTION_LABEL_PRESETS.default` when `serverLabels` is null, so labels are visible immediately on slow connections instead of appearing blank until the `connected` message arrives. Mirrors the existing `serverAnchors ?? DEFAULT_ANCHORS` pattern.
+
 ### Changed
 - **Typecheck and tests gate PR staging deploys** — `staging-deploy.yml` now runs a `check` job (typecheck + Storybook/vitest tests) before deploying to staging; deploy is blocked if checks fail.
 - **PR preview deployments replaced with shared staging env** — per-PR preview, cleanup, and event-preview workflows disabled (broken upstream: partykit/partykit#985); new `staging-deploy.yml` deploys every PR to the shared `staging` preview environment instead. Staging is never torn down.

--- a/app/components/apps/PerfCanvasApp.tsx
+++ b/app/components/apps/PerfCanvasApp.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef } from "react";
 import Canvas from "../shared/Canvas";
 import TouchLayer from "../shared/TouchLayer";
+import { RoomSocketProvider } from "../../contexts/RoomSocketContext";
 import { getPersistentUserId } from "../../utils/userId";
 import { CURSOR_THROTTLE_MS, SMOOTH_CURSOR_CONFIG } from "../../utils/cursor";
 
@@ -51,9 +52,8 @@ export default function PerfCanvasApp({ room }: { room: string }) {
 
   return (
     <div style={{ position: "relative", width: "100%", height: "100dvh", background: "#111", overflow: "hidden" }}>
+      <RoomSocketProvider room={room} userId={userId} party="perf">
       <Canvas
-        party="perf"
-        room={room}
         userId={userId}
         onPresenceCount={setPresenceCount}
         disableBackgroundValence
@@ -61,15 +61,13 @@ export default function PerfCanvasApp({ room }: { room: string }) {
         hideActualCursors={smoothCursorEnabled && !showActualCursor}
       />
       <TouchLayer
-        party="perf"
-        room={room}
         userId={userId}
-        onActiveStatementChange={() => {}}
         onReactionStateChange={() => {}}
         onBackgroundColorChange={() => {}}
         reactionStateRef={reactionStateRef}
         throttleMs={throttleMs}
       />
+      </RoomSocketProvider>
       <div style={{
         position: "absolute", top: 12, left: 0, right: 0,
         textAlign: "center", color: "rgba(255,255,255,0.4)",

--- a/app/components/apps/ReactionCanvasAppV2.tsx
+++ b/app/components/apps/ReactionCanvasAppV2.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { QRCodeCanvas } from "qrcode.react";
 import Canvas from "../shared/Canvas";
 import TouchLayer from "../shared/TouchLayer";
+import { RoomSocketProvider } from "../../contexts/RoomSocketContext";
 import { getReactionLabelSet } from "../../voteLabels";
 import type { ReactionLabelSet } from "../../voteLabels";
 import { DEFAULT_ANCHORS, reactionLabelStyle } from "../../utils/voteRegion";
@@ -207,8 +208,8 @@ export default function ReactionCanvasAppV2({ videoId: videoIdProp }: { videoId?
             style={{ left: touchPos.x, top: touchPos.y }}
           />
         )}
+        <RoomSocketProvider room={room} userId={userId}>
         <Canvas
-          room={room}
           userId={userId}
           colorCursorsByVote={true}
           currentReactionState={canvasBackgroundReactionState}
@@ -227,9 +228,7 @@ export default function ReactionCanvasAppV2({ videoId: videoIdProp }: { videoId?
         />
         {!isViewer && (
           <TouchLayer
-            room={room}
             userId={userId}
-            onActiveStatementChange={() => {}}
             onReactionStateChange={() => {}}
             reactionStateRef={reactionStateRef}
             onBackgroundColorChange={setCanvasBackgroundReactionState}
@@ -239,6 +238,7 @@ export default function ReactionCanvasAppV2({ videoId: videoIdProp }: { videoId?
             anchors={anchors}
           />
         )}
+        </RoomSocketProvider>
       </div>
     </div>
   );

--- a/app/components/apps/ReactionCanvasAppV4.tsx
+++ b/app/components/apps/ReactionCanvasAppV4.tsx
@@ -21,7 +21,7 @@ import { WebHaptics } from "web-haptics";
 import { useWebHaptics } from "web-haptics/react";
 import { DEFAULT_ANCHORS, valenceToPosition, computeReactionRegion } from "../../utils/voteRegion";
 import type { ReactionAnchors } from "../../utils/voteRegion";
-import { getReactionLabelSet } from "../../voteLabels";
+import { getReactionLabelSet, REACTION_LABEL_PRESETS } from "../../voteLabels";
 import type { ReactionLabelSet } from "../../voteLabels";
 import { getPersistentUserId } from "../../utils/userId";
 import QRWithCopy from "../shared/QRWithCopy";
@@ -341,7 +341,7 @@ export default function ReactionCanvasAppV4({ room }: { room: string }) {
 
   // URL param overrides server; server overrides default; null = admin explicitly hid labels
   const urlLabelParam = getLabelsParamFromUrl();
-  const labels = urlLabelParam ? getReactionLabelSet(urlLabelParam) : serverLabels;
+  const labels = urlLabelParam ? getReactionLabelSet(urlLabelParam) : (serverLabels ?? REACTION_LABEL_PRESETS.default);
 
   const showChipBar = unlockedInterfaces.length >= 2;
   const chipBarOffset = showChipBar ? CHIP_BAR_HEIGHT : 0;

--- a/app/components/apps/ReactionCanvasAppV5.tsx
+++ b/app/components/apps/ReactionCanvasAppV5.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "react";
 import Canvas from "../shared/Canvas";
 import TouchLayer from "../shared/TouchLayer";
+import { RoomSocketProvider } from "../../contexts/RoomSocketContext";
 import AdminPanelWithDB from "../panels/AdminPanelWithDB";
 import ReplayCanvas from "../canvas/ReplayCanvas";
 import { getReactionLabelSet } from "../../voteLabels";
@@ -264,8 +265,8 @@ export default function ReactionCanvasAppV5({ room: roomProp, testConnectionFn =
           currentTimecode={currentTimecode}
           heightOffset={youtubeHeight}
         />
+        <RoomSocketProvider room={room} userId={userId}>
         <Canvas
-          room={room}
           userId={userId}
           colorCursorsByVote={false}
           hideActualCursors={true}
@@ -276,9 +277,7 @@ export default function ReactionCanvasAppV5({ room: roomProp, testConnectionFn =
           debug={debug}
         />
         <TouchLayer
-          room={room}
           userId={userId}
-          onActiveStatementChange={() => {}}
           onReactionStateChange={() => {}}
           reactionStateRef={reactionStateRef}
           onBackgroundColorChange={setCanvasBackgroundReactionState}
@@ -287,6 +286,7 @@ export default function ReactionCanvasAppV5({ room: roomProp, testConnectionFn =
           anchors={anchors}
           onCursorEvent={handleCursorEvent}
         />
+        </RoomSocketProvider>
       </div>
     </div>
   );

--- a/app/components/panels/AdminPanelWithDB/index.tsx
+++ b/app/components/panels/AdminPanelWithDB/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import usePartySocket from "partysocket/react";
 import { getPartySocketConfig } from "../../../utils/partyHost";
+import { RoomSocketProvider } from "../../../contexts/RoomSocketContext";
 import { DEFAULT_ANCHORS } from "../../../utils/voteRegion";
 import type { ReactionAnchors } from "../../../utils/voteRegion";
 import { REACTION_LABEL_PRESETS } from "../../../voteLabels";
@@ -234,14 +235,14 @@ export default function AdminPanelWithDB({ room }: AdminPanelWithDBProps) {
 
       {mainTab === 'peek' && (
         <div style={{ flex: 1, overflow: 'hidden' }}>
-          <Canvas
-            room={room}
-            userId="admin-peek"
-            readOnly={true}
-            colorCursorsByVote={true}
-            debug={true}
-            heightOffset={tabBarHeight}
-          />
+          <RoomSocketProvider room={room} userId="admin-peek" readOnly>
+            <Canvas
+              userId="admin-peek"
+              colorCursorsByVote={true}
+              debug={true}
+              heightOffset={tabBarHeight}
+            />
+          </RoomSocketProvider>
         </div>
       )}
 

--- a/app/components/shared/Canvas.tsx
+++ b/app/components/shared/Canvas.tsx
@@ -1,9 +1,8 @@
 import { useRef, useEffect, useState } from "react";
-import usePartySocket from "partysocket/react";
 import * as d3 from "d3";
 import { computeReactionRegion, DEFAULT_ANCHORS } from "../../utils/voteRegion";
 import { makeImageCoordTransform } from "../../utils/imageCanvasCoords";
-import { getPartySocketConfig } from "../../utils/partyHost";
+import { useRoomSocket, useMessageSubscription } from "../../contexts/RoomSocketContext";
 import type { ReactionAnchors } from "../../utils/voteRegion";
 import type { ActivityMode } from "../../types";
 import type { GreeterConfig } from "../../../plugins/greeter/types";
@@ -23,9 +22,7 @@ interface CursorEvent {
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
 
 interface CanvasProps {
-  room: string;
   userId: string;
-  readOnly?: boolean; // When true, connects as admin (excluded from presence count, no cursor sent)
   colorCursorsByVote?: boolean; // Optional prop to enable reaction-based coloring
   hideActualCursors?: boolean; // When true, raw cursor dots are not rendered (labels/anchors still sync; use when smooth cursors replace them)
   currentReactionState?: ReactionState; // Current reaction state for background color
@@ -65,7 +62,6 @@ interface CanvasProps {
   onConnectedUsers?: (ids: string[]) => void;
   onUserJoined?: (userId: string) => void;
   onUserLeft?: (userId: string) => void;
-  party?: string;
   cursorSmoothingConfig?: CursorSmoothingConfig;
 }
 
@@ -97,7 +93,7 @@ function clipLineToRect(
   return [px + tMin * dx, py + tMin * dy, px + tMax * dx, py + tMax * dy];
 }
 
-export default function Canvas({ room, userId, readOnly = false, colorCursorsByVote: colorCursorsByVoteProp = false, disableCursorValence = false, disableBackgroundValence = false, hideActualCursors = false, currentReactionState, heightOffset, autoSize = false, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onInterfacePushed, onPushedInterfacesCleared, onHapticPushed, onRoomImageUrlChange, onActivityChange, onSocialConfigChange, onGreeterConfigChange, onConnected, onNowLabelChange, onInviteEdges, onOwnValenceDisplayChange, onValenceInputModeChange, onStrokeSegment, onSignatureCleared, onConnectedUsers, onUserJoined, onUserLeft, party = "main", debug = false, cursorSmoothingConfig }: CanvasProps) {
+export default function Canvas({ userId, colorCursorsByVote: colorCursorsByVoteProp = false, disableCursorValence = false, disableBackgroundValence = false, hideActualCursors = false, currentReactionState, heightOffset, autoSize = false, onPresenceCount, onActiveCursorCountChange, onSimulatedCursorCountChange, onTimecodeUpdate, onRecordingStateChange, onRoomLabelsChange, onRoomAnchorsChange, onRoomAvatarStyleChange, onViewerCount, onConnectedAsViewer, onUserCapChanged, onJoinApproved, onSocketReady, onActivityTriggered, onInterfacePushed, onPushedInterfacesCleared, onHapticPushed, onRoomImageUrlChange, onActivityChange, onSocialConfigChange, onGreeterConfigChange, onConnected, onNowLabelChange, onInviteEdges, onOwnValenceDisplayChange, onValenceInputModeChange, onStrokeSegment, onSignatureCleared, onConnectedUsers, onUserJoined, onUserLeft, debug = false, cursorSmoothingConfig }: CanvasProps) {
   const svgRef = useRef<SVGSVGElement>(null);
   const smoothCursorLayerRef = useRef<SVGSVGElement>(null);
   const [cursors, setCursors] = useState<Map<string, CursorPosition>>(new Map());
@@ -316,13 +312,10 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
     smoothCursorStyleRef.current = styleMap;
   }, [cursors, dimensions, anchors, colorCursorsByVote, disableCursorValence, defaultCursorColor, avatarStyle, customAvatars]);
 
-  const socket = usePartySocket({
-    ...getPartySocketConfig(),
-    party,
-    room: room,
-    query: readOnly ? { isAdmin: 'true' } : { userId },
-    onMessage(evt) {
-      try {
+  const { send } = useRoomSocket();
+
+  useMessageSubscription((evt) => {
+    try {
         const data = JSON.parse(evt.data);
 
         if (data.type === 'presenceCount') {
@@ -613,12 +606,11 @@ export default function Canvas({ room, userId, readOnly = false, colorCursorsByV
       } catch (e) {
         console.error('Failed to parse message:', e);
       }
-    },
   });
 
-  // Expose socket.send to parent via onSocketReady
+  // Expose send to parent via onSocketReady
   useEffect(() => {
-    onSocketReady?.((msg) => socket.send(msg));
+    onSocketReady?.(send);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Update background color based on current reaction state

--- a/app/components/shared/ReactionCanvasParticipant.tsx
+++ b/app/components/shared/ReactionCanvasParticipant.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, type ReactNode } from "react";
 import Canvas from "./Canvas";
 import TouchLayer from "./TouchLayer";
 import ShareQRButton from "./ShareQRButton";
+import { RoomSocketProvider } from "../../contexts/RoomSocketContext";
 import { DEFAULT_ANCHORS, reactionLabelStyle } from "../../utils/voteRegion";
 import type { ReactionAnchors } from "../../utils/voteRegion";
 import { SMOOTH_CURSOR_ENABLED, SMOOTH_CURSOR_CONFIG } from "../../utils/cursor";
@@ -215,7 +216,7 @@ export default function ReactionCanvasParticipant({
   };
 
   return (
-    <>
+    <RoomSocketProvider room={room} userId={userId}>
       {backgroundOverlay}
       {labels && showLabels && (
         <div className="reaction-label reaction-label-positive" style={{ ...reactionLabelStyle(anchors.positive), ...(ownValenceDisplay === 'labels' && effectiveReaction === 'positive' ? { background: 'rgba(0, 255, 0, 0.2)' } : {}) }}>{labels.positive}</div>
@@ -243,7 +244,6 @@ export default function ReactionCanvasParticipant({
         <div className="v2-touch-indicator" style={{ left: effectiveTouchPos.x, top: effectiveTouchPos.y }} />
       )}
       <Canvas
-        room={room}
         userId={userId}
         autoSize={autoSize}
         heightOffset={autoSize ? undefined : heightOffset}
@@ -290,10 +290,8 @@ export default function ReactionCanvasParticipant({
       {canvasOverlay}
       {!hideTouchLayer && (
         <TouchLayer
-          room={room}
           userId={userId}
           autoSize={autoSize}
-          onActiveStatementChange={() => {}}
           onReactionStateChange={() => {}}
           reactionStateRef={reactionStateRef}
           onBackgroundColorChange={handleBackgroundColor}
@@ -304,6 +302,6 @@ export default function ReactionCanvasParticipant({
           disabled={touchDisabled}
         />
       )}
-    </>
+    </RoomSocketProvider>
   );
 }

--- a/app/components/shared/ReactionCanvasParticipant.tsx
+++ b/app/components/shared/ReactionCanvasParticipant.tsx
@@ -6,6 +6,7 @@ import { RoomSocketProvider } from "../../contexts/RoomSocketContext";
 import { DEFAULT_ANCHORS, reactionLabelStyle } from "../../utils/voteRegion";
 import type { ReactionAnchors } from "../../utils/voteRegion";
 import { SMOOTH_CURSOR_ENABLED, SMOOTH_CURSOR_CONFIG } from "../../utils/cursor";
+import { REACTION_LABEL_PRESETS } from "../../voteLabels";
 import type { ReactionLabelSet } from "../../voteLabels";
 import type { ActivityMode } from "../../types";
 import type { GreeterConfig } from "../../../plugins/greeter/types";
@@ -182,7 +183,7 @@ export default function ReactionCanvasParticipant({
   const effectiveTouchPos = isTouchPosControlled ? touchPos : internalTouchPos;
 
   // Derived
-  const labels = labelsOverride !== undefined ? labelsOverride : serverLabels;
+  const labels = labelsOverride !== undefined ? labelsOverride : (serverLabels ?? REACTION_LABEL_PRESETS.default);
   const anchors = serverAnchors ?? DEFAULT_ANCHORS;
 
   // Dual-callback handlers: update own state AND forward to the parent shell.

--- a/app/components/shared/TouchLayer.tsx
+++ b/app/components/shared/TouchLayer.tsx
@@ -1,8 +1,7 @@
 import { useRef, useEffect, useState } from "react";
-import usePartySocket from "partysocket/react";
 import { computeReactionRegion, DEFAULT_ANCHORS } from "../../utils/voteRegion";
-import { getPartySocketConfig } from "../../utils/partyHost";
 import { CURSOR_THROTTLE_MS } from "../../utils/cursor";
+import { useRoomSocket } from "../../contexts/RoomSocketContext";
 import type { ReactionAnchors } from "../../utils/voteRegion";
 
 interface CursorPosition {
@@ -17,18 +16,9 @@ interface CursorEvent {
   position: CursorPosition;
 }
 
-interface ServerMessage {
-  type: 'connected' | 'activeStatementChanged';
-  connectionId?: string;
-  activeStatementId?: number;
-  statementId?: number;
-}
-
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
 
 interface TouchLayerProps {
-  room: string;
-  onActiveStatementChange: (statementId: number) => void;
   onReactionStateChange: (reactionState: ReactionState) => void;
   userId: string;
   reactionStateRef?: React.MutableRefObject<ReactionState>;
@@ -39,15 +29,12 @@ interface TouchLayerProps {
   anchors?: ReactionAnchors;
   onCursorEvent?: (type: 'move' | 'touch' | 'remove', pos: { x: number; y: number }) => void;
   imageUrl?: string; // When set, normalize coordinates relative to displayed image bounds
-  disabled?: boolean; // When true, keeps socket alive but ignores all pointer events
+  disabled?: boolean; // When true, ignores all pointer events
   autoSize?: boolean; // When true, normalize against this layer's own size (ResizeObserver) instead of the window. For embedding in constrained containers (e.g. demo phone frames). Ignores heightOffset.
-  party?: string;
   throttleMs?: number; // Min ms between cursor sends (0 = no throttle)
 }
 
 export default function TouchLayer({
-  room,
-  onActiveStatementChange,
   onReactionStateChange,
   userId,
   reactionStateRef,
@@ -60,7 +47,6 @@ export default function TouchLayer({
   imageUrl,
   disabled = false,
   autoSize = false,
-  party = "main",
   throttleMs = CURSOR_THROTTLE_MS,
 }: TouchLayerProps) {
   const layerRef = useRef<HTMLDivElement>(null);
@@ -87,26 +73,7 @@ export default function TouchLayer({
   const currentReactionStateRef = useRef<ReactionState>(null);
   const lastPositionRef = useRef<CursorPosition | null>(null);
 
-  const socket = usePartySocket({
-    ...getPartySocketConfig(),
-    party,
-    room: room,
-    query: { userId },
-    onMessage(evt) {
-      try {
-        const data = JSON.parse(evt.data);
-
-        // Handle server messages (connected, activeStatementChanged)
-        if (data.type === 'connected' && data.activeStatementId) {
-          onActiveStatementChange(data.activeStatementId);
-        } else if (data.type === 'activeStatementChanged') {
-          onActiveStatementChange(data.statementId);
-        }
-      } catch (e) {
-        console.error('Failed to parse message:', e);
-      }
-    },
-  });
+  const { send } = useRoomSocket();
 
   const sendCursorEvent = (type: CursorEvent['type'], position: CursorPosition) => {
     if (type !== 'remove' && throttleMsRef.current > 0) {
@@ -115,12 +82,12 @@ export default function TouchLayer({
       lastSentRef.current = now;
     }
     const event: CursorEvent = { type, position };
-    socket.send(JSON.stringify(event));
+    send(JSON.stringify(event));
   };
 
   const sendTimecode = () => {
     if (getTimecode) {
-      socket.send(JSON.stringify({ type: 'setTimecode', timecode: getTimecode() }));
+      send(JSON.stringify({ type: 'setTimecode', timecode: getTimecode() }));
     }
   };
 

--- a/app/contexts/RoomSocketContext.tsx
+++ b/app/contexts/RoomSocketContext.tsx
@@ -1,0 +1,69 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef } from "react";
+import usePartySocket from "partysocket/react";
+import { getPartySocketConfig } from "../utils/partyHost";
+
+interface RoomSocketContextValue {
+  send: (msg: string) => void;
+  subscribe: (cb: (evt: MessageEvent) => void) => void;
+  unsubscribe: (cb: (evt: MessageEvent) => void) => void;
+}
+
+const RoomSocketContext = createContext<RoomSocketContextValue | null>(null);
+
+interface RoomSocketProviderProps {
+  room: string;
+  userId: string;
+  party?: string;
+  readOnly?: boolean;
+  children: React.ReactNode;
+}
+
+export function RoomSocketProvider({ room, userId, party = "main", readOnly = false, children }: RoomSocketProviderProps) {
+  const subscribersRef = useRef(new Set<(evt: MessageEvent) => void>());
+
+  const subscribe = useCallback((cb: (evt: MessageEvent) => void) => {
+    subscribersRef.current.add(cb);
+  }, []);
+
+  const unsubscribe = useCallback((cb: (evt: MessageEvent) => void) => {
+    subscribersRef.current.delete(cb);
+  }, []);
+
+  const socket = usePartySocket({
+    ...getPartySocketConfig(),
+    party,
+    room,
+    query: readOnly ? { isAdmin: "true" } : { userId },
+    onMessage(evt) {
+      subscribersRef.current.forEach(cb => cb(evt));
+    },
+  });
+
+  const send = useCallback((msg: string) => socket.send(msg), [socket]);
+
+  const value = useMemo(() => ({ send, subscribe, unsubscribe }), [send, subscribe, unsubscribe]);
+
+  return (
+    <RoomSocketContext.Provider value={value}>
+      {children}
+    </RoomSocketContext.Provider>
+  );
+}
+
+export function useRoomSocket(): RoomSocketContextValue {
+  const ctx = useContext(RoomSocketContext);
+  if (!ctx) throw new Error("useRoomSocket must be used inside RoomSocketProvider");
+  return ctx;
+}
+
+export function useMessageSubscription(callback: (evt: MessageEvent) => void): void {
+  const { subscribe, unsubscribe } = useRoomSocket();
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  useEffect(() => {
+    const handler = (evt: MessageEvent) => callbackRef.current(evt);
+    subscribe(handler);
+    return () => unsubscribe(handler);
+  }, [subscribe, unsubscribe]);
+}

--- a/stories/Canvas.stories.tsx
+++ b/stories/Canvas.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 import Canvas from '../app/components/shared/Canvas';
 import { RoomSocketProvider } from '../app/contexts/RoomSocketContext';
+import { emitToRoom } from '../.storybook/mocks/partysocket-react';
 
 // Canvas uses RoomSocketContext for its WebSocket connection (mocked in Storybook).
 // Cursor dots come from real-time socket messages so won't appear here.
@@ -43,14 +44,23 @@ export const Default: Story = {
 // Cursor is in the POSITIVE region — green background tint.
 export const PositiveBackground: Story = {
   args: { ...baseArgs, currentReactionState: 'positive' },
+  play: async () => {
+    emitToRoom('storybook', { type: 'ownValenceDisplayChanged', ownValenceDisplay: 'background' });
+  },
 };
 
 // Cursor is in the NEGATIVE region — red background tint.
 export const NegativeBackground: Story = {
   args: { ...baseArgs, currentReactionState: 'negative' },
+  play: async () => {
+    emitToRoom('storybook', { type: 'ownValenceDisplayChanged', ownValenceDisplay: 'background' });
+  },
 };
 
 // Cursor is in the NEUTRAL region — yellow background tint.
 export const NeutralBackground: Story = {
   args: { ...baseArgs, currentReactionState: 'neutral' },
+  play: async () => {
+    emitToRoom('storybook', { type: 'ownValenceDisplayChanged', ownValenceDisplay: 'background' });
+  },
 };

--- a/stories/Canvas.stories.tsx
+++ b/stories/Canvas.stories.tsx
@@ -5,8 +5,8 @@ import { RoomSocketProvider } from '../app/contexts/RoomSocketContext';
 import { emitToRoom } from '../.storybook/mocks/partysocket-react';
 
 // Canvas uses RoomSocketContext for its WebSocket connection (mocked in Storybook).
-// Cursor dots come from real-time socket messages so won't appear here.
-// These stories focus on the background colour states driven by the currentReactionState prop.
+// Socket-driven states are exercised via emitToRoom() in play functions, which feeds
+// messages through the same socketMessageBus the real server uses.
 
 const meta = {
   title: 'App/Canvas',
@@ -62,5 +62,88 @@ export const NeutralBackground: Story = {
   args: { ...baseArgs, currentReactionState: 'neutral' },
   play: async () => {
     emitToRoom('storybook', { type: 'ownValenceDisplayChanged', ownValenceDisplay: 'background' });
+  },
+};
+
+// Multiple cursors scattered across the canvas, coloured by reaction region.
+export const CursorBatchColored: Story = {
+  args: { ...baseArgs, colorCursorsByVote: true },
+  play: async () => {
+    emitToRoom('storybook', {
+      type: 'cursorBatch',
+      cursors: [
+        { type: 'move', position: { userId: 'user-a', x: 80, y: 10,  timestamp: Date.now() } },
+        { type: 'move', position: { userId: 'user-b', x: 10, y: 80,  timestamp: Date.now() } },
+        { type: 'move', position: { userId: 'user-c', x: 85, y: 85,  timestamp: Date.now() } },
+        { type: 'move', position: { userId: 'user-d', x: 50, y: 50,  timestamp: Date.now() } },
+        { type: 'move', position: { userId: 'user-e', x: 30, y: 30,  timestamp: Date.now() } },
+      ],
+    });
+  },
+};
+
+// Custom anchor positions — horizontal layout with NEGATIVE on the left,
+// POSITIVE on the right, NEUTRAL at the top centre.
+export const CustomAnchors: Story = {
+  args: { ...baseArgs, debug: true },
+  play: async () => {
+    emitToRoom('storybook', {
+      type: 'roomAnchorsChanged',
+      anchors: {
+        negative: { x: 5,  y: 50 },
+        positive: { x: 95, y: 50 },
+        neutral:  { x: 50, y: 5  },
+      },
+    });
+  },
+};
+
+// Custom reaction labels pushed from the server.
+export const CustomLabels: Story = {
+  args: { ...baseArgs },
+  play: async () => {
+    emitToRoom('storybook', {
+      type: 'roomLabelsChanged',
+      labels: { positive: '👍 Yes', negative: '👎 No', neutral: '🤷 Maybe' },
+    });
+  },
+};
+
+// Soccer activity mode — shows the pitch and hides the reaction regions.
+export const SoccerActivity: Story = {
+  args: { ...baseArgs },
+  play: async () => {
+    emitToRoom('storybook', { type: 'activityChanged', activity: 'soccer' });
+  },
+};
+
+// Image canvas mode — overlays the canvas on a background image;
+// cursors are positioned relative to the displayed image bounds.
+export const ImageCanvas: Story = {
+  args: { ...baseArgs },
+  play: async () => {
+    emitToRoom('storybook', { type: 'activityChanged', activity: 'image-canvas' });
+    emitToRoom('storybook', { type: 'imageUrlChanged', url: 'https://pbs.twimg.com/media/DY_tjS0WsAADhmT.jpg' });
+  },
+};
+
+// Debug overlay — draws region boundary lines and anchor markers.
+export const DebugOverlay: Story = {
+  args: { ...baseArgs, debug: true },
+};
+
+// Cursor coloring disabled — all cursors render in the default colour regardless of region.
+export const CursorBatchUncolored: Story = {
+  args: { ...baseArgs, colorCursorsByVote: false },
+  play: async () => {
+    emitToRoom('storybook', {
+      type: 'cursorBatch',
+      cursors: [
+        { type: 'move', position: { userId: 'user-a', x: 80, y: 10,  timestamp: Date.now() } },
+        { type: 'move', position: { userId: 'user-b', x: 10, y: 80,  timestamp: Date.now() } },
+        { type: 'move', position: { userId: 'user-c', x: 85, y: 85,  timestamp: Date.now() } },
+        { type: 'move', position: { userId: 'user-d', x: 50, y: 50,  timestamp: Date.now() } },
+      ],
+    });
   },
 };

--- a/stories/Canvas.stories.tsx
+++ b/stories/Canvas.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
 import Canvas from '../app/components/shared/Canvas';
+import { RoomSocketProvider } from '../app/contexts/RoomSocketContext';
 
-// Note: Canvas uses usePartySocket internally (mocked in Storybook).
+// Canvas uses RoomSocketContext for its WebSocket connection (mocked in Storybook).
 // Cursor dots come from real-time socket messages so won't appear here.
 // These stories focus on the background colour states driven by the currentReactionState prop.
 
@@ -16,13 +18,19 @@ const meta = {
       options: ['positive', 'negative', 'neutral'],
     },
   },
+  decorators: [
+    (Story) => (
+      <RoomSocketProvider room="storybook" userId="story-user">
+        <Story />
+      </RoomSocketProvider>
+    ),
+  ],
 } satisfies Meta<typeof Canvas>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 const baseArgs = {
-  room: 'storybook',
   userId: 'story-user',
   colorCursorsByVote: true,
 };

--- a/stories/Canvas.stories.tsx
+++ b/stories/Canvas.stories.tsx
@@ -98,32 +98,15 @@ export const CustomAnchors: Story = {
   },
 };
 
-// Custom reaction labels pushed from the server.
-export const CustomLabels: Story = {
-  args: { ...baseArgs },
-  play: async () => {
-    emitToRoom('storybook', {
-      type: 'roomLabelsChanged',
-      labels: { positive: '👍 Yes', negative: '👎 No', neutral: '🤷 Maybe' },
-    });
-  },
-};
+// Custom labels and image-canvas mode live in ReactionCanvas.stories.tsx — Canvas alone
+// does not render labels (fired via onRoomLabelsChange callback to parent) or the background
+// image (rendered by the ImageCanvasBackground plugin component outside Canvas).
 
 // Soccer activity mode — shows the pitch and hides the reaction regions.
 export const SoccerActivity: Story = {
   args: { ...baseArgs },
   play: async () => {
     emitToRoom('storybook', { type: 'activityChanged', activity: 'soccer' });
-  },
-};
-
-// Image canvas mode — overlays the canvas on a background image;
-// cursors are positioned relative to the displayed image bounds.
-export const ImageCanvas: Story = {
-  args: { ...baseArgs },
-  play: async () => {
-    emitToRoom('storybook', { type: 'activityChanged', activity: 'image-canvas' });
-    emitToRoom('storybook', { type: 'imageUrlChanged', url: 'https://pbs.twimg.com/media/DY_tjS0WsAADhmT.jpg' });
   },
 };
 

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -82,21 +82,23 @@ const meta = {
     userId: 'story-user-1',
     labels: REACTION_LABEL_PRESETS['default'],
   },
+  // CanvasComposition uses height:100% which resolves to 0 without a sized parent.
+  decorators: [
+    (Story) => <div style={{ height: '100vh' }}><Story /></div>,
+  ],
 } satisfies Meta<typeof CanvasComposition>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Interactive: Story = {};
+export const Default: Story = {};
 
 // Custom reaction labels — Canvas fires onRoomLabelsChange to the parent; labels are
 // rendered as HTML overlays in LabelOverlay, not inside the Canvas SVG.
 // Dark background: LabelOverlay renders white text, canvas bg is near-transparent.
-// Explicit height: CanvasComposition uses height:100% which resolves to 0 without a
-// sized parent (same issue affects Interactive — Recorder works because it sets 100vh).
 export const CustomLabels: Story = {
   render: (args) => (
-    <div style={{ height: '100vh', background: '#222' }}>
+    <div style={{ height: '100%', background: '#222' }}>
       <CanvasComposition {...args} />
     </div>
   ),

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -4,6 +4,9 @@ import Canvas from '../app/components/shared/Canvas';
 import TouchLayer from '../app/components/shared/TouchLayer';
 import { RoomSocketProvider } from '../app/contexts/RoomSocketContext';
 import { REACTION_LABEL_PRESETS } from '../app/voteLabels';
+import { emitToRoom } from '../.storybook/mocks/partysocket-react';
+import { ImageCanvasConfigProvider } from '../plugins/imageCanvas/context';
+import ImageCanvasBackground from '../plugins/imageCanvas/background';
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
 type CursorEventType = 'move' | 'touch' | 'remove';
@@ -85,6 +88,49 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Interactive: Story = {};
+
+// Custom reaction labels — Canvas fires onRoomLabelsChange to the parent; labels are
+// rendered as HTML overlays in LabelOverlay, not inside the Canvas SVG.
+// Dark background: LabelOverlay renders white text, canvas bg is near-transparent.
+// Explicit height: CanvasComposition uses height:100% which resolves to 0 without a
+// sized parent (same issue affects Interactive — Recorder works because it sets 100vh).
+export const CustomLabels: Story = {
+  render: (args) => (
+    <div style={{ height: '100vh', background: '#222' }}>
+      <CanvasComposition {...args} />
+    </div>
+  ),
+  args: {
+    labels: { positive: '👍 Yes', negative: '👎 No', neutral: '🤷 Maybe' },
+  },
+};
+
+// Image canvas mode — background image rendered by ImageCanvasBackground (plugin component
+// outside Canvas); Canvas uses the URL only for cursor coordinate transforms.
+export const ImageCanvas: Story = {
+  render: () => {
+    const [imageUrl, setImageUrl] = useState('');
+    return (
+      <div style={{ position: 'relative', height: '100vh' }}>
+        <ImageCanvasConfigProvider value={{ imageUrl }}>
+          <RoomSocketProvider room="storybook-canvas" userId="story-user-1">
+            <ImageCanvasBackground />
+            <Canvas
+              userId="story-user-1"
+              heightOffset={0}
+              colorCursorsByVote
+              onRoomImageUrlChange={setImageUrl}
+            />
+          </RoomSocketProvider>
+        </ImageCanvasConfigProvider>
+      </div>
+    );
+  },
+  play: async () => {
+    emitToRoom('storybook-canvas', { type: 'activityChanged', activity: 'image-canvas' });
+    emitToRoom('storybook-canvas', { type: 'imageUrlChanged', url: 'https://pbs.twimg.com/media/DY_tjS0WsAADhmT.jpg' });
+  },
+};
 
 const btnStyle: React.CSSProperties = {
   padding: '3px 10px',

--- a/stories/ReactionCanvas.stories.tsx
+++ b/stories/ReactionCanvas.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import Canvas from '../app/components/shared/Canvas';
 import TouchLayer from '../app/components/shared/TouchLayer';
+import { RoomSocketProvider } from '../app/contexts/RoomSocketContext';
 import { REACTION_LABEL_PRESETS } from '../app/voteLabels';
 
 type ReactionState = 'positive' | 'negative' | 'neutral' | null;
@@ -48,23 +49,22 @@ function CanvasComposition({ room, userId, labels, onCursorEvent }: CanvasCompos
 
   return (
     <div className="v2-app-container" style={{ position: 'relative', height: '100%', overflow: 'hidden' }}>
-      <LabelOverlay labels={effectiveLabels} />
-      <Canvas
-        room={room}
-        userId={userId}
-        currentReactionState={reactionState}
-        heightOffset={0}
-        colorCursorsByVote
-      />
-      <TouchLayer
-        room={room}
-        userId={userId}
-        onActiveStatementChange={() => {}}
-        onReactionStateChange={setReactionState}
-        onBackgroundColorChange={() => {}}
-        heightOffset={0}
-        onCursorEvent={onCursorEvent}
-      />
+      <RoomSocketProvider room={room} userId={userId}>
+        <LabelOverlay labels={effectiveLabels} />
+        <Canvas
+          userId={userId}
+          currentReactionState={reactionState}
+          heightOffset={0}
+          colorCursorsByVote
+        />
+        <TouchLayer
+          userId={userId}
+          onReactionStateChange={setReactionState}
+          onBackgroundColorChange={() => {}}
+          heightOffset={0}
+          onCursorEvent={onCursorEvent}
+        />
+      </RoomSocketProvider>
     </div>
   );
 }

--- a/stories/TouchLayer.stories.tsx
+++ b/stories/TouchLayer.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
 import { fn } from 'storybook/test';
 import TouchLayer from '../app/components/shared/TouchLayer';
+import { RoomSocketProvider } from '../app/contexts/RoomSocketContext';
 
 // TouchLayer is a fully transparent overlay div that captures mouse/touch events
 // and translates cursor position into reaction state (positive/negative/neutral) based on
@@ -21,10 +23,16 @@ const meta = {
   },
   tags: ['autodocs'],
   args: {
-    onActiveStatementChange: fn(),
     onReactionStateChange: fn(),
     onBackgroundColorChange: fn(),
   },
+  decorators: [
+    (Story) => (
+      <RoomSocketProvider room="storybook" userId="story-user">
+        <Story />
+      </RoomSocketProvider>
+    ),
+  ],
 } satisfies Meta<typeof TouchLayer>;
 
 export default meta;
@@ -32,7 +40,6 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    room: 'storybook',
     userId: 'story-user',
   },
 };

--- a/tests/Canvas.test.tsx
+++ b/tests/Canvas.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import Canvas from '../app/components/shared/Canvas'
+import { RoomSocketProvider } from '../app/contexts/RoomSocketContext'
+
+const mockSend = vi.hoisted(() => vi.fn())
+const capturedConfig = vi.hoisted(() => ({ current: null as any }))
+const capturedOnMessage = vi.hoisted(() => ({ fn: null as ((evt: MessageEvent) => void) | null }))
+
+vi.mock('partysocket/react', () => ({
+  default: vi.fn((config: any) => {
+    capturedConfig.current = config
+    capturedOnMessage.fn = config.onMessage ?? null
+    config.onOpen?.()
+    return { send: mockSend, readyState: 1, close: vi.fn(), reconnect: vi.fn() }
+  })
+}))
+
+function emitMessage(data: object) {
+  capturedOnMessage.fn?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+}
+
+function renderWithProvider(ui: React.ReactElement, { readOnly = false } = {}) {
+  return render(
+    <RoomSocketProvider room="test" userId="user1" readOnly={readOnly}>
+      {ui}
+    </RoomSocketProvider>
+  )
+}
+
+beforeEach(() => {
+  mockSend.mockClear()
+  capturedConfig.current = null
+  capturedOnMessage.fn = null
+})
+
+describe('Canvas socket behaviour', () => {
+  it('calls onSocketReady with a send function on mount', () => {
+    const onSocketReady = vi.fn()
+    renderWithProvider(<Canvas userId="user1" onSocketReady={onSocketReady} />)
+    expect(onSocketReady).toHaveBeenCalledOnce()
+    expect(typeof onSocketReady.mock.calls[0][0]).toBe('function')
+  })
+
+  it('calls onPresenceCount when presenceCount message is received', () => {
+    const onPresenceCount = vi.fn()
+    renderWithProvider(<Canvas userId="user1" onPresenceCount={onPresenceCount} />)
+    act(() => emitMessage({ type: 'presenceCount', count: 42, viewerCount: 3 }))
+    expect(onPresenceCount).toHaveBeenCalledWith(42)
+  })
+
+  it('calls onActivityChange when activityChanged message is received', () => {
+    const onActivityChange = vi.fn()
+    renderWithProvider(<Canvas userId="user1" onActivityChange={onActivityChange} />)
+    act(() => emitMessage({ type: 'activityChanged', activity: 'soccer' }))
+    expect(onActivityChange).toHaveBeenCalledWith('soccer')
+  })
+
+  it('calls onConnected with inviteEdges and currentActivity from connected message', () => {
+    const onConnected = vi.fn()
+    renderWithProvider(<Canvas userId="user1" onConnected={onConnected} />)
+    act(() => emitMessage({
+      type: 'connected',
+      inviteEdges: { user2: 'user1' },
+      currentActivity: 'canvas',
+    }))
+    expect(onConnected).toHaveBeenCalledWith({ user2: 'user1' }, 'canvas')
+  })
+
+  it('opens socket as admin when readOnly is true', () => {
+    renderWithProvider(<Canvas userId="user1" />, { readOnly: true })
+    expect(capturedConfig.current.query).toEqual({ isAdmin: 'true' })
+  })
+})

--- a/tests/TouchLayer.test.tsx
+++ b/tests/TouchLayer.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent, act } from '@testing-library/react'
+import TouchLayer from '../app/components/shared/TouchLayer'
+import { RoomSocketProvider } from '../app/contexts/RoomSocketContext'
+
+const mockSend = vi.hoisted(() => vi.fn())
+
+vi.mock('partysocket/react', () => ({
+  default: vi.fn((config: any) => {
+    config.onOpen?.()
+    return { send: mockSend, readyState: 1, close: vi.fn(), reconnect: vi.fn() }
+  })
+}))
+
+const defaultProps = {
+  userId: 'test-user',
+  onReactionStateChange: vi.fn(),
+  onBackgroundColorChange: vi.fn(),
+  throttleMs: 0,
+}
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(
+    <RoomSocketProvider room="test-room" userId="test-user">
+      {ui}
+    </RoomSocketProvider>
+  )
+}
+
+beforeEach(() => {
+  mockSend.mockClear()
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    left: 0, top: 0, width: 1000, height: 800, right: 1000, bottom: 800,
+    x: 0, y: 0, toJSON: () => {},
+  } as DOMRect)
+})
+
+describe('TouchLayer socket behaviour', () => {
+  it('sends a move event when the mouse moves over the layer', () => {
+    const { container } = renderWithProvider(<TouchLayer {...defaultProps} />)
+    const layer = container.firstChild as HTMLElement
+    fireEvent.mouseMove(layer, { clientX: 500, clientY: 400 })
+    expect(mockSend).toHaveBeenCalledOnce()
+    const sent = JSON.parse(mockSend.mock.calls[0][0])
+    expect(sent.type).toBe('move')
+    expect(sent.position.userId).toBe('test-user')
+  })
+
+  it('sends a remove event when the mouse leaves the layer', () => {
+    const { container } = renderWithProvider(<TouchLayer {...defaultProps} />)
+    const layer = container.firstChild as HTMLElement
+    fireEvent.mouseMove(layer, { clientX: 500, clientY: 400 })
+    mockSend.mockClear()
+    fireEvent.mouseLeave(layer)
+    const calls = mockSend.mock.calls.map((args: string[]) => JSON.parse(args[0]))
+    expect(calls.some((c: any) => c.type === 'remove')).toBe(true)
+  })
+
+  it('sends a touch event on touch start', () => {
+    const { container } = renderWithProvider(<TouchLayer {...defaultProps} />)
+    const layer = container.firstChild as HTMLElement
+    fireEvent.touchStart(layer, { touches: [{ clientX: 300, clientY: 200 }] })
+    expect(mockSend).toHaveBeenCalledOnce()
+    const sent = JSON.parse(mockSend.mock.calls[0][0])
+    expect(sent.type).toBe('touch')
+    expect(sent.position.userId).toBe('test-user')
+  })
+
+  it('sends a remove event on touch end', () => {
+    const { container } = renderWithProvider(<TouchLayer {...defaultProps} />)
+    const layer = container.firstChild as HTMLElement
+    fireEvent.touchStart(layer, { touches: [{ clientX: 300, clientY: 200 }] })
+    mockSend.mockClear()
+    fireEvent.touchEnd(layer, { changedTouches: [{ clientX: 300, clientY: 200 }] })
+    const calls = mockSend.mock.calls.map((args: string[]) => JSON.parse(args[0]))
+    expect(calls.some((c: any) => c.type === 'remove')).toBe(true)
+  })
+
+  it('does not send cursor events when disabled', () => {
+    const { container } = renderWithProvider(<TouchLayer {...defaultProps} disabled />)
+    const layer = container.firstChild as HTMLElement
+    fireEvent.mouseMove(layer, { clientX: 500, clientY: 400 })
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('sends a setTimecode event on mouse leave when getTimecode is provided', () => {
+    const getTimecode = () => 42000
+    const { container } = renderWithProvider(<TouchLayer {...defaultProps} getTimecode={getTimecode} />)
+    const layer = container.firstChild as HTMLElement
+    fireEvent.mouseMove(layer, { clientX: 500, clientY: 400 })
+    mockSend.mockClear()
+    fireEvent.mouseLeave(layer)
+    const calls = mockSend.mock.calls.map((args: string[]) => JSON.parse(args[0]))
+    const timecodeCall = calls.find((c: any) => c.type === 'setTimecode')
+    expect(timecodeCall).toBeDefined()
+    expect(timecodeCall.timecode).toBe(42000)
+  })
+})


### PR DESCRIPTION
## Summary

Part of #149 (step 1.5 — between the issue's step 1 and step 2).

- Introduces `RoomSocketProvider` in `app/contexts/RoomSocketContext.tsx`. It owns a single `usePartySocket` connection and exposes `send`, `subscribe`, and `unsubscribe` via context. `useRoomSocket()` and `useMessageSubscription()` hooks are exported for consumers.
- `Canvas.tsx` and `TouchLayer.tsx` now consume the shared socket from context instead of each opening their own connection — reducing connections per participant from two to one, and removing reconnect latency on activity switch.
- Removes dead code from `TouchLayer`: `onActiveStatementChange` prop, `ServerMessage` type, and its entire `onMessage` handler. The server has never sent `activeStatementId` or `activeStatementChanged`; all callers already passed `() => {}`.
- Adds vitest component tests (`tests/Canvas.test.tsx`, `tests/TouchLayer.test.tsx`) covering socket plumbing for both components.

## Test plan

- [x] `pnpm exec tsc --noEmit` — no type errors
- [x] `pnpm vitest run --project=unit --project=components` — 285 tests pass
- [ ] Open app in browser, open DevTools → Network → WS tab, confirm only **one** WebSocket connection opens per participant (not two)
- [x] Storybook stories for Canvas and TouchLayer still render without errors (`pnpm run storybook`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)