### PR TITLE
fix(routing): restore onFetch so public/*.html pages are served correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 32 (2026-06-29)
 
+### Fixed
+- **Prototype HTML pages in `public/` now served correctly** — restored `onFetch` handler in `party/utils/onFetch.ts`; `singlePageApp: true` intercepted all browser navigations and returned `index.html` even for real `.html` files like `valence-onboarding-v1.html`. The two work together: `singlePageApp: true` ensures the dev server calls `onFetch` for unmatched paths (room names like `/default`), while `onFetch` serves real `.html` assets directly and only falls back to `index.html` for extensionless paths.
+
 ### Removed
 - **V1 Polis statement voting app removed** — `SimpleReactionCanvasAppV1`, `DeprecatedAdminPanel`, `DeprecatedStatementPanel`, and their Storybook stories deleted; `PolisStatement` and `QueueItem` types removed from `app/types.ts`; `#v1` hash handler and title entry removed from `client.tsx`. Server-side: removed `queueLogic`, `ghostCursors`, vote HTTP endpoints (`POST/GET/DELETE /vote`), Polis API proxy (`updateStatementsPool`), `GhostCursorManager`, and all V1 types from `party/types.ts`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 32 (2026-06-29)
 
 ### Fixed
-- **Prototype HTML pages in `public/` now served correctly** — restored `onFetch` handler in `party/utils/onFetch.ts`; `singlePageApp: true` intercepted all browser navigations and returned `index.html` even for real `.html` files like `valence-onboarding-v1.html`. The two work together: `singlePageApp: true` ensures the dev server calls `onFetch` for unmatched paths (room names like `/default`), while `onFetch` serves real `.html` assets directly and only falls back to `index.html` for extensionless paths.
+- **Prototype HTML pages in `public/` now served correctly** — restored `onFetch` handler in `party/utils/onFetch.ts` and removed `singlePageApp: true`; in production (Cloudflare Workers) `singlePageApp` intercepts all browser navigations via `Sec-Fetch-Mode: navigate` before `onFetch` runs, returning `index.html` even for real `.html` files like `valence-onboarding-v1.html`. `onFetch` owns all routing: serves real assets directly and falls back to `index.html` only for extensionless paths (room names like `/default`).
 
 ### Removed
 - **V1 Polis statement voting app removed** — `SimpleReactionCanvasAppV1`, `DeprecatedAdminPanel`, `DeprecatedStatementPanel`, and their Storybook stories deleted; `PolisStatement` and `QueueItem` types removed from `app/types.ts`; `#v1` hash handler and title entry removed from `client.tsx`. Server-side: removed `queueLogic`, `ghostCursors`, vote HTTP endpoints (`POST/GET/DELETE /vote`), Polis API proxy (`updateStatementsPool`), `GhostCursorManager`, and all V1 types from `party/types.ts`.

--- a/party/server.ts
+++ b/party/server.ts
@@ -660,4 +660,6 @@ private pluginStates = new Map<string, unknown>(
   }
 }
 
+export { onFetch } from './utils/onFetch';
+
 Server satisfies Party.Worker;

--- a/party/utils/onFetch.test.ts
+++ b/party/utils/onFetch.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { onFetch } from './onFetch';
+import type * as Party from 'partykit/server';
+
+const NOT_FOUND = new Response('Not found', { status: 404 });
+
+function makeLobby(assetResponse: Response | null) {
+  return {
+    assets: { fetch: vi.fn().mockResolvedValue(assetResponse ?? NOT_FOUND) },
+  } as unknown as Party.FetchLobby;
+}
+
+function makeRequest(path: string) {
+  return new Request(`https://example.com${path}`) as unknown as Party.Request;
+}
+
+async function fetch(path: string, lobby: Party.FetchLobby) {
+  return (await onFetch(makeRequest(path), lobby)) as Response;
+}
+
+describe('onFetch', () => {
+  describe('static assets with extensions', () => {
+    it('serves an existing .html file directly', async () => {
+      const file = new Response('<html>onboarding</html>', { status: 200 });
+      const lobby = makeLobby(file);
+      const res = await fetch('/some-page.html', lobby);
+      expect(res.status).toBe(200);
+      expect((lobby.assets.fetch as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith('/some-page.html');
+    });
+
+    it('returns 404 for a missing .html file', async () => {
+      const res = await fetch('/missing-page.html', makeLobby(null));
+      expect(res.status).toBe(404);
+    });
+
+    it('serves an existing JS asset', async () => {
+      const file = new Response('console.log(1)', { status: 200 });
+      const res = await fetch('/dist/client.js', makeLobby(file));
+      expect(res.status).toBe(200);
+    });
+
+    it('returns 404 for a missing JS asset', async () => {
+      const res = await fetch('/dist/missing.js', makeLobby(null));
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('extensionless paths (room names)', () => {
+    it('falls back to index.html for a room path', async () => {
+      const indexHtml = new Response('<html>app</html>', { status: 200 });
+      const lobby = {
+        assets: {
+          fetch: vi.fn()
+            .mockResolvedValueOnce(NOT_FOUND)  // no static asset for /test-room
+            .mockResolvedValueOnce(indexHtml), // index.html fallback
+        },
+      } as unknown as Party.FetchLobby;
+      const res = await fetch('/test-room', lobby);
+      expect(res.status).toBe(200);
+      expect((lobby.assets.fetch as ReturnType<typeof vi.fn>)).toHaveBeenNthCalledWith(1, '/test-room');
+      expect((lobby.assets.fetch as ReturnType<typeof vi.fn>)).toHaveBeenNthCalledWith(2, '/index.html');
+    });
+
+    it('falls back to index.html for the root path', async () => {
+      const indexHtml = new Response('<html>app</html>', { status: 200 });
+      const lobby = {
+        assets: {
+          fetch: vi.fn()
+            .mockResolvedValueOnce(NOT_FOUND)
+            .mockResolvedValueOnce(indexHtml),
+        },
+      } as unknown as Party.FetchLobby;
+      const res = await fetch('/', lobby);
+      expect(res.status).toBe(200);
+      expect((lobby.assets.fetch as ReturnType<typeof vi.fn>)).toHaveBeenNthCalledWith(2, '/index.html');
+    });
+  });
+});

--- a/party/utils/onFetch.ts
+++ b/party/utils/onFetch.ts
@@ -5,18 +5,6 @@ import type * as Party from "partykit/server";
 // from being swallowed by the SPA router.
 export async function onFetch(req: Party.Request, lobby: Party.FetchLobby) {
   const url = new URL(req.url);
-
-  // Diagnostic: confirms onFetch is being called and shows lobby.assets.fetch behaviour.
-  // Remove once the routing/serving issue is understood.
-  if (url.pathname === '/__debug-fetch') {
-    const indexAsset = await lobby.assets.fetch('/index.html');
-    return new Response(JSON.stringify({
-      onFetchCalled: true,
-      indexHtmlStatus: indexAsset?.status ?? null,
-      indexHtmlOk: indexAsset?.ok ?? null,
-    }), { headers: { 'Content-Type': 'application/json' } });
-  }
-
   const hasExtension = url.pathname.includes('.');
 
   const asset = await lobby.assets.fetch(url.pathname);

--- a/party/utils/onFetch.ts
+++ b/party/utils/onFetch.ts
@@ -5,6 +5,18 @@ import type * as Party from "partykit/server";
 // from being swallowed by the SPA router.
 export async function onFetch(req: Party.Request, lobby: Party.FetchLobby) {
   const url = new URL(req.url);
+
+  // Diagnostic: confirms onFetch is being called and shows lobby.assets.fetch behaviour.
+  // Remove once the routing/serving issue is understood.
+  if (url.pathname === '/__debug-fetch') {
+    const indexAsset = await lobby.assets.fetch('/index.html');
+    return new Response(JSON.stringify({
+      onFetchCalled: true,
+      indexHtmlStatus: indexAsset?.status ?? null,
+      indexHtmlOk: indexAsset?.ok ?? null,
+    }), { headers: { 'Content-Type': 'application/json' } });
+  }
+
   const hasExtension = url.pathname.includes('.');
 
   const asset = await lobby.assets.fetch(url.pathname);

--- a/party/utils/onFetch.ts
+++ b/party/utils/onFetch.ts
@@ -1,0 +1,18 @@
+import type * as Party from "partykit/server";
+
+// SPA fallback: serve static assets directly; only fall back to index.html
+// for extensionless paths (room names). This prevents .html pages in public/
+// from being swallowed by the SPA router.
+export async function onFetch(req: Party.Request, lobby: Party.FetchLobby) {
+  const url = new URL(req.url);
+  const hasExtension = url.pathname.includes('.');
+
+  const asset = await lobby.assets.fetch(url.pathname);
+  if (asset?.ok) return asset;
+  if (hasExtension) return new Response('Not found', { status: 404 });
+  // lobby.assets.fetch returns null in dev mode (static files are served before onFetch);
+  // fall back to a direct fetch so the SPA shell loads for room paths like /default.
+  const index = await lobby.assets.fetch('/index.html');
+  if (index?.ok) return index;
+  return fetch(new URL('/index.html', req.url).toString());
+}

--- a/partykit.json
+++ b/partykit.json
@@ -8,7 +8,6 @@
   "compatibilityDate": "2025-11-20",
   "serve": {
     "path": "public",
-    "singlePageApp": true,
     "build": {
       "entry": "app/client.tsx",
       "define": {

--- a/partykit.json
+++ b/partykit.json
@@ -8,6 +8,7 @@
   "compatibilityDate": "2025-11-20",
   "serve": {
     "path": "public",
+    "singlePageApp": true,
     "build": {
       "entry": "app/client.tsx",
       "define": {


### PR DESCRIPTION
## Summary

- Restored `party/utils/onFetch.ts` — serves real assets directly, falls back to `index.html` only for extensionless paths (room names)
- Re-added `export { onFetch }` in `party/server.ts`
- Restored `party/utils/onFetch.test.ts` with 6 unit tests

`singlePageApp: true` intercepts all browser navigations via `Sec-Fetch-Mode: navigate` and returns `index.html` — even when the target is a real `.html` file (e.g. `valence-onboarding-v1.html`). The custom `onFetch` fixes this by serving actual assets directly and only falling back to `index.html` for extensionless paths.

The two settings work together: `singlePageApp: true` ensures the dev server calls `onFetch` for unmatched paths (like `/default`); `onFetch` handles the `.html` file case and the `index.html` SPA fallback.

This was previously removed in a245228 under the incorrect assumption that `singlePageApp` handled `.html` files correctly.

## Test plan

- [ ] `pnpm vitest run party/utils/onFetch.test.ts` passes (6 tests)
- [ ] `/valence-onboarding-v1.html` and other prototype pages in `public/` load correctly
- [ ] Room paths like `/default` still serve the SPA shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)