### PR TITLE
feat(sim): Valence Shift simulator program with organic chord-based positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ All notable changes to this project will be documented in this file. Releases cu
 
 ## Week 33 (2026-07-06)
 
+### Added
+- **"Valence Shift (groups)" simulator program** — a new demo-page program where sim cursors split into Fibonacci-sized opinion groups (weights `[1,2,3,5,8,13,21]`, matching the group model in `docs/pages/valence-onboarding-v3.html`) and periodically re-randomize their group's target valence together, reading as a correlated "shift" event. Group count (1–7) is settable via a new "Groups" select in `SimControlBar`, shown only for group-aware programs; drift speed and shift interval are fixed for now. Registered in `PROGRAMS` alongside the existing Drift/Region-hoppers/Recorded-playback programs.
+
 ### Changed
 - **Prototype pages moved to GitHub Pages** — `valence-onboarding-v1.html`, `valence-onboarding-v2.html`, `valence-onboarding-v3.html`, and `mood-sounds.html` moved from `public/` to `docs/pages/` and now deploy to `https://patcon.github.io/polislike-partykit-reaction-canvas/` via a new GitHub Actions workflow. Pages with WebSocket connections gain a **server URL input** (default: `wss://whispering-gallery.patcon.partykit.dev`) so the PartyKit host can be specified when accessed from a different origin. Links in `OldFrontPage` and `NewFrontPage` updated to the GitHub Pages URLs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 33 (2026-07-06)
 
 ### Added
-- **"Valence Shift (groups)" simulator program** — sim cursors split into Fibonacci-sized opinion groups (matching `docs/pages/valence-onboarding-v3.html`) and periodically re-randomize their group's target valence together. Users glide to the new target (eased, shared with Region-hoppers realistic) then wander gently in place until the next shift. Group count (1–7) is configurable via `SimControlBar`.
+- **"Valence Shift (groups)" simulator program** — sim cursors split into Fibonacci-sized opinion groups (matching `docs/pages/valence-onboarding-v3.html`) and periodically re-randomize their group's target valence together. Users glide (eased, shared with Region-hoppers realistic) to a point sampled from the full range of canvas positions matching their target valence, rather than one fixed line, with a tunable spread constant for tight-cluster vs. full-scatter looks; each member's personal offset from the group target rescrambles on every shift. Group count (1–7) is configurable via `SimControlBar`.
 
 ### Changed
 - **Prototype pages moved to GitHub Pages** — `valence-onboarding-v1.html`, `valence-onboarding-v2.html`, `valence-onboarding-v3.html`, and `mood-sounds.html` moved from `public/` to `docs/pages/` and now deploy to `https://patcon.github.io/polislike-partykit-reaction-canvas/` via a new GitHub Actions workflow. Pages with WebSocket connections gain a **server URL input** (default: `wss://whispering-gallery.patcon.partykit.dev`) so the PartyKit host can be specified when accessed from a different origin. Links in `OldFrontPage` and `NewFrontPage` updated to the GitHub Pages URLs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file. Releases cu
 ## Week 33 (2026-07-06)
 
 ### Added
-- **"Valence Shift (groups)" simulator program** — a new demo-page program where sim cursors split into Fibonacci-sized opinion groups (weights `[1,2,3,5,8,13,21]`, matching the group model in `docs/pages/valence-onboarding-v3.html`) and periodically re-randomize their group's target valence together, reading as a correlated "shift" event. Group count (1–7) is settable via a new "Groups" select in `SimControlBar`, shown only for group-aware programs; drift speed and shift interval are fixed for now. Registered in `PROGRAMS` alongside the existing Drift/Region-hoppers/Recorded-playback programs.
+- **"Valence Shift (groups)" simulator program** — sim cursors split into Fibonacci-sized opinion groups (matching `docs/pages/valence-onboarding-v3.html`) and periodically re-randomize their group's target valence together. Users glide to the new target (eased, shared with Region-hoppers realistic) then wander gently in place until the next shift. Group count (1–7) is configurable via `SimControlBar`.
 
 ### Changed
 - **Prototype pages moved to GitHub Pages** — `valence-onboarding-v1.html`, `valence-onboarding-v2.html`, `valence-onboarding-v3.html`, and `mood-sounds.html` moved from `public/` to `docs/pages/` and now deploy to `https://patcon.github.io/polislike-partykit-reaction-canvas/` via a new GitHub Actions workflow. Pages with WebSocket connections gain a **server URL input** (default: `wss://whispering-gallery.patcon.partykit.dev`) so the PartyKit host can be specified when accessed from a different origin. Links in `OldFrontPage` and `NewFrontPage` updated to the GitHub Pages URLs.

--- a/app/components/demos/SimControlBar.test.tsx
+++ b/app/components/demos/SimControlBar.test.tsx
@@ -82,6 +82,28 @@ describe('SimControlBar', () => {
     expect(users.disabled).toBe(true); // recorded's crowd size is fixed by the recording
   });
 
+  it('enables the group-count select only for group-aware programs (Valence Shift)', () => {
+    const { getByLabelText } = renderBar();
+    const groups = getByLabelText('Groups') as HTMLSelectElement;
+    expect(groups.disabled).toBe(true); // drift doesn't use groups
+    fireEvent.change(getByLabelText('Program'), { target: { value: 'valence-shift' } });
+    expect(groups.disabled).toBe(false);
+  });
+
+  it('passes the selected group count through to the sim context', () => {
+    const { getByRole, getByLabelText } = renderBar();
+    fireEvent.change(getByLabelText('Program'), { target: { value: 'valence-shift' } });
+    fireEvent.change(getByLabelText('Groups'), { target: { value: '1' } });
+    act(() => { fireEvent.click(getByRole('button', { name: /play/i })); });
+    act(() => { vi.advanceTimersByTime(SIM_TICK_MS * 200); });
+
+    // With 1 group, all sim cursors should be tightly clustered (correlated),
+    // unlike the wide spread of an unconstrained program like Drift.
+    const last = simBatches().filter((b: any) => b.cursors.every((c: any) => c.type === 'move')).pop();
+    const xs = last.cursors.map((c: any) => c.position.x);
+    expect(Math.max(...xs) - Math.min(...xs)).toBeLessThan(20);
+  });
+
   it('disables a program whose availability probe fails', async () => {
     vi.useRealTimers(); // let findBy* poll for the async probe + state update
     vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false })));

--- a/app/components/demos/SimControlBar.tsx
+++ b/app/components/demos/SimControlBar.tsx
@@ -7,6 +7,8 @@ import { DEFAULT_ANCHORS } from "../../utils/voteRegion";
 
 /** User-count presets (see docs/specs/simulated-users.md). */
 const USER_COUNTS = [25, 50, 100];
+/** Group-count options for group-aware programs (e.g. Valence Shift). */
+const GROUP_COUNTS = [1, 2, 3, 4, 5, 6, 7];
 /** Fixed seed — demo motion is reproducible; the room is a random demo-<uuid>. */
 const SIM_SEED = 1;
 
@@ -22,6 +24,7 @@ export default function SimControlBar() {
   const engineRef = useRef<SimulationEngine | null>(null);
   const [programId, setProgramId] = useState(PROGRAMS[0].id);
   const [userCount, setUserCount] = useState(USER_COUNTS[0]);
+  const [groupCount, setGroupCount] = useState(3);
   const [state, setState] = useState<SimEngineState>("idle");
   const [unavailable, setUnavailable] = useState<Set<string>>(new Set());
 
@@ -54,7 +57,7 @@ export default function SimControlBar() {
       engineRef.current = new SimulationEngine(
         entry.create(),
         createSocketSink((msg) => sendRef.current(msg)),
-        { userCount, seed: SIM_SEED, regionAnchors: DEFAULT_ANCHORS },
+        { userCount, seed: SIM_SEED, regionAnchors: DEFAULT_ANCHORS, groupCount },
       );
       engineRef.current.play();
     } else if (state === "paused") {
@@ -77,6 +80,7 @@ export default function SimControlBar() {
   const active = state !== "idle";
   const selectedProgram = PROGRAMS.find((p) => p.id === programId);
   const userCountDisabled = active || Boolean(selectedProgram?.ignoresUserCount);
+  const groupCountDisabled = active || !selectedProgram?.usesGroupCount;
 
   return (
     <div className="sim-control-bar">
@@ -110,6 +114,18 @@ export default function SimControlBar() {
       >
         {USER_COUNTS.map((n) => (
           <option key={n} value={n}>{n} users</option>
+        ))}
+      </select>
+
+      <select
+        aria-label="Groups"
+        className="sim-control-select"
+        value={groupCount}
+        disabled={groupCountDisabled}
+        onChange={(e) => setGroupCount(Number(e.target.value))}
+      >
+        {GROUP_COUNTS.map((n) => (
+          <option key={n} value={n}>{n} group{n === 1 ? "" : "s"}</option>
         ))}
       </select>
 

--- a/app/lib/simulation/programs/_easing.test.ts
+++ b/app/lib/simulation/programs/_easing.test.ts
@@ -1,5 +1,30 @@
 import { describe, it, expect } from 'vitest';
-import { makePrng, createWanderField } from './_easing';
+import { makePrng, createWanderField, easeInOutCubic } from './_easing';
+
+describe('easeInOutCubic', () => {
+  it('maps 0 to 0 and 1 to 1', () => {
+    expect(easeInOutCubic(0)).toBe(0);
+    expect(easeInOutCubic(1)).toBe(1);
+  });
+
+  it('is symmetric around the midpoint (0.5 -> 0.5)', () => {
+    expect(easeInOutCubic(0.5)).toBeCloseTo(0.5, 10);
+  });
+
+  it('is monotonically increasing', () => {
+    let prev = -Infinity;
+    for (let t = 0; t <= 1; t += 0.1) {
+      const v = easeInOutCubic(t);
+      expect(v).toBeGreaterThanOrEqual(prev);
+      prev = v;
+    }
+  });
+
+  it('starts and ends slower than linear (ease-in / ease-out)', () => {
+    expect(easeInOutCubic(0.1)).toBeLessThan(0.1);
+    expect(easeInOutCubic(0.9)).toBeGreaterThan(0.9);
+  });
+});
 
 describe('makePrng', () => {
   it('is deterministic for a seed and differs across seeds', () => {

--- a/app/lib/simulation/programs/_easing.test.ts
+++ b/app/lib/simulation/programs/_easing.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { createNoise2D } from 'simplex-noise';
-import { makePrng, createWanderField, easeInOutCubic, noiseWanderOffset } from './_easing';
+import { makePrng, createWanderField, easeInOutCubic, easedProgress, noiseWanderOffset } from './_easing';
 
 describe('easeInOutCubic', () => {
   it('maps 0 to 0 and 1 to 1', () => {
@@ -24,6 +24,24 @@ describe('easeInOutCubic', () => {
   it('starts and ends slower than linear (ease-in / ease-out)', () => {
     expect(easeInOutCubic(0.1)).toBeLessThan(0.1);
     expect(easeInOutCubic(0.9)).toBeGreaterThan(0.9);
+  });
+});
+
+describe('easedProgress', () => {
+  it('equals easeInOutCubic of the elapsed/duration fraction', () => {
+    expect(easedProgress(500, 0, 1000)).toBeCloseTo(easeInOutCubic(0.5), 10);
+  });
+
+  it('clamps before start to 0', () => {
+    expect(easedProgress(-50, 0, 1000)).toBe(0);
+  });
+
+  it('clamps past the duration to 1', () => {
+    expect(easedProgress(5000, 0, 1000)).toBe(1);
+  });
+
+  it('reaches exactly 1 at tMs === start + duration', () => {
+    expect(easedProgress(1500, 500, 1000)).toBe(1);
   });
 });
 

--- a/app/lib/simulation/programs/_easing.test.ts
+++ b/app/lib/simulation/programs/_easing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { makePrng, createWanderField, easeInOutCubic } from './_easing';
+import { createNoise2D } from 'simplex-noise';
+import { makePrng, createWanderField, easeInOutCubic, noiseWanderOffset } from './_easing';
 
 describe('easeInOutCubic', () => {
   it('maps 0 to 0 and 1 to 1', () => {
@@ -40,6 +41,36 @@ describe('makePrng', () => {
       expect(n).toBeGreaterThanOrEqual(0);
       expect(n).toBeLessThan(1);
     }
+  });
+});
+
+describe('noiseWanderOffset', () => {
+  const noise2D = createNoise2D(makePrng(1));
+
+  it('is deterministic for the same inputs', () => {
+    const a = noiseWanderOffset(noise2D, 10, 20, 500, 1, 4);
+    const b = noiseWanderOffset(noise2D, 10, 20, 500, 1, 4);
+    expect(a).toEqual(b);
+  });
+
+  it('returns zero offset when radius is 0', () => {
+    const { x, y } = noiseWanderOffset(noise2D, 10, 20, 500, 1, 0);
+    expect(x).toBeCloseTo(0);
+    expect(y).toBeCloseTo(0);
+  });
+
+  it('bounds each axis offset to +/- radius', () => {
+    for (let t = 0; t < 2000; t += 137) {
+      const { x, y } = noiseWanderOffset(noise2D, 3, 7, t, 0.8, 5);
+      expect(Math.abs(x)).toBeLessThanOrEqual(5);
+      expect(Math.abs(y)).toBeLessThanOrEqual(5);
+    }
+  });
+
+  it('gives distinct offsets for distinct per-user noise streams (different offX/offY)', () => {
+    const a = noiseWanderOffset(noise2D, 1, 2, 400, 1, 4);
+    const b = noiseWanderOffset(noise2D, 99, 200, 400, 1, 4);
+    expect(a).not.toEqual(b);
   });
 });
 

--- a/app/lib/simulation/programs/_easing.ts
+++ b/app/lib/simulation/programs/_easing.ts
@@ -16,6 +16,16 @@ export function easeInOutCubic(t: number): number {
 }
 
 /**
+ * Eased 0..1 progress through a `duration`-long span starting at `start`,
+ * clamped before `start` (0) and past `start + duration` (1). The shared
+ * "how far through this glide am I" calculation used by every program that
+ * eases a value toward a target over a fixed duration.
+ */
+export function easedProgress(tMs: number, start: number, duration: number): number {
+  return easeInOutCubic(Math.max(0, Math.min((tMs - start) / duration, 1)));
+}
+
+/**
  * Sample a 2D simplex-noise offset for organic micro-wander around a point.
  * `offX`/`offY` give each user an independent stream from a shared `noise2D`
  * field; `speed` scales how fast the sample advances with `tMs`; `radius`

--- a/app/lib/simulation/programs/_easing.ts
+++ b/app/lib/simulation/programs/_easing.ts
@@ -16,6 +16,27 @@ export function easeInOutCubic(t: number): number {
 }
 
 /**
+ * Sample a 2D simplex-noise offset for organic micro-wander around a point.
+ * `offX`/`offY` give each user an independent stream from a shared `noise2D`
+ * field; `speed` scales how fast the sample advances with `tMs`; `radius`
+ * scales the offset magnitude (each axis stays within +/- radius).
+ */
+export function noiseWanderOffset(
+  noise2D: (x: number, y: number) => number,
+  offX: number,
+  offY: number,
+  tMs: number,
+  speed: number,
+  radius: number,
+): { x: number; y: number } {
+  const t = tMs * 0.001 * speed;
+  return {
+    x: noise2D(offX, t) * radius,
+    y: noise2D(offY, t) * radius,
+  };
+}
+
+/**
  * Deterministic LCG returning values in [0, 1). Seeded so a given seed always
  * produces the same sequence (unlike Math.random).
  * @param seed Any integer; 0 is coerced to 1 to avoid a stuck sequence.

--- a/app/lib/simulation/programs/_easing.ts
+++ b/app/lib/simulation/programs/_easing.ts
@@ -10,6 +10,11 @@ export const EASE = 0.02;
 /** Distance under which a user is "arrived" and picks a new target. */
 export const ARRIVE_DIST = 3;
 
+/** Cubic ease-in-out: slow start, fast middle, slow finish. `t` in 0..1. */
+export function easeInOutCubic(t: number): number {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
+
 /**
  * Deterministic LCG returning values in [0, 1). Seeded so a given seed always
  * produces the same sequence (unlike Math.random).

--- a/app/lib/simulation/programs/index.ts
+++ b/app/lib/simulation/programs/index.ts
@@ -6,6 +6,7 @@ import { createDriftProgram } from './drift';
 import { createRegionHoppersProgram } from './regionHoppers';
 import { createRealisticRegionHoppersProgram } from './regionHoppersRealistic';
 import { createRecordedPlaybackProgram, isRecordingAvailable } from './recordedPlayback';
+import { createValenceShiftProgram } from './valenceShift';
 
 /** A selectable program: stable id, human label, factory, and optional gating. */
 export interface ProgramEntry {
@@ -18,6 +19,8 @@ export interface ProgramEntry {
   unavailableHint?: string;
   /** True when the user-count control is meaningless (e.g. a fixed recording). */
   ignoresUserCount?: boolean;
+  /** True when the program reads `SimContext.groupCount` (shows the Groups control). */
+  usesGroupCount?: boolean;
 }
 
 /** All programs offered on the demo pages. Order is the dropdown order. */
@@ -25,6 +28,7 @@ export const PROGRAMS: ProgramEntry[] = [
   { id: 'drift', label: 'Drift / Wander', create: createDriftProgram },
   { id: 'region-hoppers-realistic', label: 'Region-hoppers (realistic)', create: createRealisticRegionHoppersProgram },
   { id: 'region-hoppers-simple', label: 'Region-hoppers (simple)', create: createRegionHoppersProgram },
+  { id: 'valence-shift', label: 'Valence Shift (groups)', create: createValenceShiftProgram, usesGroupCount: true },
   {
     id: 'recorded',
     label: 'Recorded playback',

--- a/app/lib/simulation/programs/regionHoppersRealistic.ts
+++ b/app/lib/simulation/programs/regionHoppersRealistic.ts
@@ -11,7 +11,7 @@
 import { createNoise2D } from 'simplex-noise';
 import type { CursorEvent, SimContext, SimulationProgram } from '../types';
 import type { ReactionAnchors } from '../../../utils/voteRegion';
-import { makePrng, easeInOutCubic, noiseWanderOffset } from './_easing';
+import { makePrng, easedProgress, noiseWanderOffset } from './_easing';
 
 const HOTSPOT_PULL = 0.3;     // fraction pulled from the anchor toward canvas centre
 const TARGET_JITTER = 6;      // spread of a picked target around its hotspot
@@ -98,11 +98,10 @@ export function createRealisticRegionHoppersProgram(): SimulationProgram {
       for (let i = 0; i < ghosts.length; i++) {
         const g = ghosts[i];
         if (g.phase === 'move') {
-          const p = Math.max(0, Math.min((tMs - g.moveStart) / g.moveDuration, 1));
-          const e = easeInOutCubic(p);
+          const e = easedProgress(tMs, g.moveStart, g.moveDuration);
           g.x = g.fromX + (g.targetX - g.fromX) * e;
           g.y = g.fromY + (g.targetY - g.fromY) * e;
-          if (p >= 1) {
+          if (e >= 1) {
             g.phase = 'rest';
             g.restStart = tMs;
             g.restDuration = REST_MIN + rnd() * REST_JITTER;
@@ -113,7 +112,7 @@ export function createRealisticRegionHoppersProgram(): SimulationProgram {
           const off = noiseWanderOffset(noise2D, g.noiseOffX, g.noiseOffY, tMs, g.restingSpeed, g.restingRadius);
           const nx = g.hotX + off.x;
           const ny = g.hotY + off.y;
-          const b = easeInOutCubic(Math.min((tMs - g.restStart) / BLEND_MS, 1));
+          const b = easedProgress(tMs, g.restStart, BLEND_MS);
           g.x = g.arriveX + (nx - g.arriveX) * b;
           g.y = g.arriveY + (ny - g.arriveY) * b;
           if (tMs - g.restStart >= g.restDuration) {

--- a/app/lib/simulation/programs/regionHoppersRealistic.ts
+++ b/app/lib/simulation/programs/regionHoppersRealistic.ts
@@ -11,7 +11,7 @@
 import { createNoise2D } from 'simplex-noise';
 import type { CursorEvent, SimContext, SimulationProgram } from '../types';
 import type { ReactionAnchors } from '../../../utils/voteRegion';
-import { makePrng } from './_easing';
+import { makePrng, easeInOutCubic } from './_easing';
 
 const HOTSPOT_PULL = 0.3;     // fraction pulled from the anchor toward canvas centre
 const TARGET_JITTER = 6;      // spread of a picked target around its hotspot
@@ -22,7 +22,6 @@ const BLEND_MS = 900;         // eased blend from arrival into the noise orbit
 const ENTRY_START_JITTER = 2000; // stagger of the initial move-in
 
 const clamp = (n: number) => Math.max(0, Math.min(100, n));
-const easeInOutCubic = (t: number) => (t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2);
 
 /** Region anchors pulled `pull` of the way toward the canvas centre (50,50). */
 export function regionHotspots(anchors: ReactionAnchors, pull = HOTSPOT_PULL): Array<{ x: number; y: number }> {

--- a/app/lib/simulation/programs/regionHoppersRealistic.ts
+++ b/app/lib/simulation/programs/regionHoppersRealistic.ts
@@ -11,7 +11,7 @@
 import { createNoise2D } from 'simplex-noise';
 import type { CursorEvent, SimContext, SimulationProgram } from '../types';
 import type { ReactionAnchors } from '../../../utils/voteRegion';
-import { makePrng, easeInOutCubic } from './_easing';
+import { makePrng, easeInOutCubic, noiseWanderOffset } from './_easing';
 
 const HOTSPOT_PULL = 0.3;     // fraction pulled from the anchor toward canvas centre
 const TARGET_JITTER = 6;      // spread of a picked target around its hotspot
@@ -110,9 +110,9 @@ export function createRealisticRegionHoppersProgram(): SimulationProgram {
             g.hotX = g.x; g.hotY = g.y; // wander around where it landed
           }
         } else {
-          const nt = tMs * 0.001 * g.restingSpeed;
-          const nx = g.hotX + noise2D(g.noiseOffX, nt) * g.restingRadius;
-          const ny = g.hotY + noise2D(g.noiseOffY, nt) * g.restingRadius;
+          const off = noiseWanderOffset(noise2D, g.noiseOffX, g.noiseOffY, tMs, g.restingSpeed, g.restingRadius);
+          const nx = g.hotX + off.x;
+          const ny = g.hotY + off.y;
           const b = easeInOutCubic(Math.min((tMs - g.restStart) / BLEND_MS, 1));
           g.x = g.arriveX + (nx - g.arriveX) * b;
           g.y = g.arriveY + (ny - g.arriveY) * b;

--- a/app/lib/simulation/programs/valenceShift.test.ts
+++ b/app/lib/simulation/programs/valenceShift.test.ts
@@ -1,7 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { createValenceShiftProgram, assignGroup, SHIFT_INTERVAL_MS, TRAVEL_DURATION_MS } from './valenceShift';
+import {
+  createValenceShiftProgram,
+  assignGroup,
+  resolveSpreadFraction,
+  SHIFT_INTERVAL_MS,
+  TRAVEL_DURATION_MS,
+} from './valenceShift';
 import type { SimContext } from '../types';
-import { DEFAULT_ANCHORS } from '../../../utils/voteRegion';
+import { DEFAULT_ANCHORS, computeCursorValence } from '../../../utils/voteRegion';
 
 const CTX: SimContext = { userCount: 20, seed: 42, regionAnchors: DEFAULT_ANCHORS, groupCount: 3 };
 
@@ -86,6 +92,37 @@ describe('valence-shift program', () => {
     expect(shifted.some((x, i) => Math.abs(x - settled[i]) > 1)).toBe(true); // but it moved
   });
 
+  it('does not put every member of a group at the exact same point (chord + spread jitter)', () => {
+    const p = createValenceShiftProgram();
+    p.init({ ...CTX, userCount: 8, groupCount: 1 });
+    let last;
+    // Settle well into the hold window of the first shift.
+    for (let i = 0; i < 100; i++) last = p.tick(i * 50, 50);
+    const xs = last!.map((e) => e.position.x);
+    const ys = last!.map((e) => e.position.y);
+    const distinctPoints = new Set(xs.map((x, i) => `${x.toFixed(3)},${ys[i].toFixed(3)}`));
+    // Chord + non-zero SPREAD jitter means members land at different points on
+    // the chord, not all glued to one shared valenceToPosition point.
+    expect(distinctPoints.size).toBeGreaterThan(1);
+  });
+
+  it('valence stays close to its chord-sampled value while holding, despite micro-wander', () => {
+    const p = createValenceShiftProgram();
+    p.init({ ...CTX, userCount: 6, groupCount: 3 });
+    const atArrival = p
+      .tick(TRAVEL_DURATION_MS, 50)
+      .map((e) => computeCursorValence(e.position.x, e.position.y, DEFAULT_ANCHORS));
+    const startStep = Math.round(TRAVEL_DURATION_MS / 50) + 1;
+    const endStep = Math.round(SHIFT_INTERVAL_MS / 50) - 1; // stay inside the hold window
+    for (let i = startStep; i < endStep; i++) {
+      const ev = p.tick(i * 50, 50);
+      ev.forEach((e, idx) => {
+        const v = computeCursorValence(e.position.x, e.position.y, DEFAULT_ANCHORS);
+        expect(Math.abs(v - atArrival[idx])).toBeLessThan(0.15);
+      });
+    }
+  });
+
   it('teardown emits a remove for every user', () => {
     const p = createValenceShiftProgram(); p.init(CTX);
     const t = p.teardown();
@@ -130,5 +167,35 @@ describe('valence-shift program', () => {
       prev = x;
     }
     expect(sawMovement).toBe(true);
+  });
+});
+
+describe('resolveSpreadFraction', () => {
+  it('passes proportional spread (<=1) through unchanged, regardless of chord length', () => {
+    expect(resolveSpreadFraction(0, 64)).toBe(0);
+    expect(resolveSpreadFraction(0.15, 64)).toBe(0.15);
+    expect(resolveSpreadFraction(1, 5)).toBe(1);
+  });
+
+  it('treats spread >1 as absolute canvas units, dividing by the chord length', () => {
+    expect(resolveSpreadFraction(10, 64)).toBeCloseTo(10 / 64, 5);
+  });
+
+  it('clamps absolute-unit spread to the full chord once the chord is shorter than it', () => {
+    expect(resolveSpreadFraction(10, 5)).toBe(1);
+  });
+
+  it('falls back to the full chord for a degenerate (zero-length) chord, without dividing by zero', () => {
+    expect(resolveSpreadFraction(10, 0)).toBe(1);
+    expect(Number.isFinite(resolveSpreadFraction(10, 0))).toBe(true);
+  });
+
+  it('scales monotonically with absolute-unit spread for a fixed chord length, then clamps at 1', () => {
+    const chordLen = 64;
+    const fractions = [2, 10, 30, 64, 100, 200].map((s) => resolveSpreadFraction(s, chordLen));
+    for (let i = 1; i < fractions.length; i++) {
+      expect(fractions[i]).toBeGreaterThanOrEqual(fractions[i - 1]);
+    }
+    expect(fractions[fractions.length - 1]).toBe(1);
   });
 });

--- a/app/lib/simulation/programs/valenceShift.test.ts
+++ b/app/lib/simulation/programs/valenceShift.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createValenceShiftProgram, assignGroup, SHIFT_INTERVAL_MS } from './valenceShift';
+import { createValenceShiftProgram, assignGroup, SHIFT_INTERVAL_MS, TRAVEL_DURATION_MS } from './valenceShift';
 import type { SimContext } from '../types';
 import { DEFAULT_ANCHORS } from '../../../utils/voteRegion';
 
@@ -93,24 +93,42 @@ describe('valence-shift program', () => {
     expect(t.every((e) => e.type === 'remove')).toBe(true);
   });
 
-  it('completes a shift as a bounded glide, then holds steady (no perpetual asymptotic creep)', () => {
+  it('settles into a small bounded band after the glide window, rather than drifting all the way to the next shift', () => {
+    const p = createValenceShiftProgram();
+    p.init({ ...CTX, userCount: 1, groupCount: 1 });
+    const settledXs: number[] = [];
+    for (let i = 0; i < 160; i++) {
+      const tMs = i * 50;
+      const x = p.tick(tMs, 50)[0].position.x;
+      // Sample only the settled portion of the *first* cycle (after its
+      // glide completes, before the *second* shift retargets). Sampling
+      // across multiple cycles would mix in the difference between
+      // unrelated random targets, not measure within-cycle stability.
+      if (tMs > SHIFT_INTERVAL_MS + TRAVEL_DURATION_MS && tMs < 2 * SHIFT_INTERVAL_MS) settledXs.push(x);
+    }
+    const spread = Math.max(...settledXs) - Math.min(...settledXs);
+    // A flat exponential ease is still closing a large residual gap well past
+    // the glide window's duration; a bounded glide (with only small organic
+    // wander layered on top) stays within a tight band once arrived.
+    expect(spread).toBeLessThan(10);
+  });
+
+  it('adds small organic micro-wander once settled, so position keeps gently varying rather than freezing solid', () => {
     const p = createValenceShiftProgram();
     p.init({ ...CTX, userCount: 1, groupCount: 1 });
     let prev: number | undefined;
-    let stableTicksAfterFirstShift = 0;
+    let sawMovement = false;
     for (let i = 0; i < 200; i++) {
       const tMs = i * 50;
       const x = p.tick(tMs, 50)[0].position.x;
-      // Only count ticks after the first shift — before that, position
-      // trivially hasn't moved from its initial value, which would pass
-      // even under the old always-creeping algorithm.
-      if (prev !== undefined && tMs > SHIFT_INTERVAL_MS && Math.abs(x - prev) < 1e-9) {
-        stableTicksAfterFirstShift++;
+      // Well into the hold window (past the glide) — should still be moving,
+      // just by a small amount, rather than pixel-frozen.
+      const sinceShift = tMs % SHIFT_INTERVAL_MS;
+      if (tMs > 0 && sinceShift > TRAVEL_DURATION_MS + 200 && prev !== undefined) {
+        if (Math.abs(x - prev) > 1e-6) sawMovement = true;
       }
       prev = x;
     }
-    // A duration-based glide holds exactly steady once travel completes; a
-    // flat exponential ease keeps moving indefinitely after every shift.
-    expect(stableTicksAfterFirstShift).toBeGreaterThan(10);
+    expect(sawMovement).toBe(true);
   });
 });

--- a/app/lib/simulation/programs/valenceShift.test.ts
+++ b/app/lib/simulation/programs/valenceShift.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { createValenceShiftProgram, assignGroup } from './valenceShift';
+import type { SimContext } from '../types';
+import { DEFAULT_ANCHORS } from '../../../utils/voteRegion';
+
+const CTX: SimContext = { userCount: 20, seed: 42, regionAnchors: DEFAULT_ANCHORS, groupCount: 3 };
+
+describe('assignGroup (Fibonacci group sizing)', () => {
+  it('splits a large population into groups sized by Fibonacci ratios (1:2:3 for 3 groups)', () => {
+    const n = 6000;
+    const counts = [0, 0, 0];
+    for (let i = 0; i < n; i++) counts[assignGroup(i, n, 3)] += 1;
+    // Weights [1,2,3] over total 6 → expected shares 1/6, 2/6, 3/6.
+    expect(counts[0] / n).toBeCloseTo(1 / 6, 1);
+    expect(counts[1] / n).toBeCloseTo(2 / 6, 1);
+    expect(counts[2] / n).toBeCloseTo(3 / 6, 1);
+  });
+
+  it('always returns a valid group index in range', () => {
+    for (let i = 0; i < 50; i++) {
+      const g = assignGroup(i, 50, 5);
+      expect(g).toBeGreaterThanOrEqual(0);
+      expect(g).toBeLessThan(5);
+    }
+  });
+});
+
+describe('valence-shift program', () => {
+  it('is deterministic for a fixed seed', () => {
+    const a = createValenceShiftProgram(); a.init(CTX);
+    const b = createValenceShiftProgram(); b.init(CTX);
+    for (let i = 0; i < 400; i++) {
+      expect(a.tick(i * 50, 50)).toEqual(b.tick(i * 50, 50));
+    }
+  });
+
+  it('diverges for a different seed', () => {
+    const a = createValenceShiftProgram(); a.init(CTX);
+    const b = createValenceShiftProgram(); b.init({ ...CTX, seed: 7 });
+    let ea, eb;
+    for (let i = 0; i < 200; i++) { ea = a.tick(i * 50, 50); eb = b.tick(i * 50, 50); }
+    expect(ea).not.toEqual(eb);
+  });
+
+  it('emits one move per user keyed sim_<i>', () => {
+    const p = createValenceShiftProgram(); p.init(CTX);
+    const ev = p.tick(50, 50);
+    expect(ev).toHaveLength(20);
+    expect(ev.map((e) => e.position.userId)).toEqual(
+      Array.from({ length: 20 }, (_, i) => `sim_${i}`),
+    );
+    expect(ev.every((e) => e.type === 'move')).toBe(true);
+  });
+
+  it('keeps coordinates within 0..100 over a long run', () => {
+    const p = createValenceShiftProgram(); p.init(CTX);
+    for (let i = 0; i < 600; i++) {
+      for (const e of p.tick(i * 50, 50)) {
+        expect(e.position.x).toBeGreaterThanOrEqual(0);
+        expect(e.position.x).toBeLessThanOrEqual(100);
+        expect(e.position.y).toBeGreaterThanOrEqual(0);
+        expect(e.position.y).toBeLessThanOrEqual(100);
+      }
+    }
+  });
+
+  it('re-randomizes group targets on a fixed interval, shifting members of the same group together', () => {
+    const p = createValenceShiftProgram();
+    p.init({ ...CTX, userCount: 6, groupCount: 1 }); // one group → all users share one target
+    // Settle near the initial target.
+    let last;
+    for (let i = 0; i < 100; i++) last = p.tick(i * 50, 50);
+    const settled = last!.map((e) => e.position.x);
+
+    // Run well past the hardcoded 8s shift interval.
+    let after;
+    for (let i = 100; i < 300; i++) after = p.tick(i * 50, 50);
+    const shifted = after!.map((e) => e.position.x);
+
+    // All members of the single group moved together, away from where they'd settled.
+    const shiftedSpread = Math.max(...shifted) - Math.min(...shifted);
+    // Max possible spread from per-user noise alone (±NOISE_SPAN through the
+    // steepest valenceToPosition slope) is well under half the canvas width —
+    // a single shared group target keeps members clustered, not scattered.
+    expect(shiftedSpread).toBeLessThan(20);
+    expect(shifted.some((x, i) => Math.abs(x - settled[i]) > 1)).toBe(true); // but it moved
+  });
+
+  it('teardown emits a remove for every user', () => {
+    const p = createValenceShiftProgram(); p.init(CTX);
+    const t = p.teardown();
+    expect(t).toHaveLength(20);
+    expect(t.every((e) => e.type === 'remove')).toBe(true);
+  });
+});

--- a/app/lib/simulation/programs/valenceShift.test.ts
+++ b/app/lib/simulation/programs/valenceShift.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createValenceShiftProgram, assignGroup } from './valenceShift';
+import { createValenceShiftProgram, assignGroup, SHIFT_INTERVAL_MS } from './valenceShift';
 import type { SimContext } from '../types';
 import { DEFAULT_ANCHORS } from '../../../utils/voteRegion';
 
@@ -91,5 +91,26 @@ describe('valence-shift program', () => {
     const t = p.teardown();
     expect(t).toHaveLength(20);
     expect(t.every((e) => e.type === 'remove')).toBe(true);
+  });
+
+  it('completes a shift as a bounded glide, then holds steady (no perpetual asymptotic creep)', () => {
+    const p = createValenceShiftProgram();
+    p.init({ ...CTX, userCount: 1, groupCount: 1 });
+    let prev: number | undefined;
+    let stableTicksAfterFirstShift = 0;
+    for (let i = 0; i < 200; i++) {
+      const tMs = i * 50;
+      const x = p.tick(tMs, 50)[0].position.x;
+      // Only count ticks after the first shift — before that, position
+      // trivially hasn't moved from its initial value, which would pass
+      // even under the old always-creeping algorithm.
+      if (prev !== undefined && tMs > SHIFT_INTERVAL_MS && Math.abs(x - prev) < 1e-9) {
+        stableTicksAfterFirstShift++;
+      }
+      prev = x;
+    }
+    // A duration-based glide holds exactly steady once travel completes; a
+    // flat exponential ease keeps moving indefinitely after every shift.
+    expect(stableTicksAfterFirstShift).toBeGreaterThan(10);
   });
 });

--- a/app/lib/simulation/programs/valenceShift.test.ts
+++ b/app/lib/simulation/programs/valenceShift.test.ts
@@ -123,6 +123,35 @@ describe('valence-shift program', () => {
     }
   });
 
+  it('re-scrambles each member\'s personal offset from the group target on every shift, not just the group target itself', () => {
+    const p = createValenceShiftProgram();
+    p.init({ ...CTX, userCount: 2, groupCount: 1 });
+    // Because sampleValencePosition round-trips exactly through computeCursorValence
+    // (spread/anchorT only move a point *along* the fixed-valence chord), the valence
+    // gap between two same-group users at any settled moment is exactly the gap
+    // between their personal offsets — group target cancels out since they share it.
+    const gapsByShift: number[] = [];
+    let lastRecordedShift = -1;
+    const totalShifts = 5;
+    for (let tMs = 0; tMs <= totalShifts * SHIFT_INTERVAL_MS; tMs += 50) {
+      const ev = p.tick(tMs, 50);
+      const shiftIndex = Math.floor(tMs / SHIFT_INTERVAL_MS);
+      const sinceShift = tMs % SHIFT_INTERVAL_MS;
+      if (shiftIndex > 0 && shiftIndex !== lastRecordedShift && sinceShift > TRAVEL_DURATION_MS + 200) {
+        const v0 = computeCursorValence(ev[0].position.x, ev[0].position.y, DEFAULT_ANCHORS);
+        const v1 = computeCursorValence(ev[1].position.x, ev[1].position.y, DEFAULT_ANCHORS);
+        gapsByShift.push(v0 - v1);
+        lastRecordedShift = shiftIndex;
+      }
+    }
+    expect(gapsByShift.length).toBeGreaterThanOrEqual(4);
+    // Wander alone perturbs this gap by at most ~0.012 within a hold window (measured);
+    // a gap that moves by more than that between shifts means the underlying personal
+    // offsets themselves were re-rolled, not just the shared group target.
+    const maxDeltaFromFirst = Math.max(...gapsByShift.slice(1).map((g) => Math.abs(g - gapsByShift[0])));
+    expect(maxDeltaFromFirst).toBeGreaterThan(0.05);
+  });
+
   it('teardown emits a remove for every user', () => {
     const p = createValenceShiftProgram(); p.init(CTX);
     const t = p.teardown();

--- a/app/lib/simulation/programs/valenceShift.ts
+++ b/app/lib/simulation/programs/valenceShift.ts
@@ -3,10 +3,12 @@
 // in docs/pages/valence-onboarding-v3.html. On a fixed interval every group's
 // target re-randomizes together; each user glides to its group's new shared
 // target valence over a bounded duration (eased, like Region-hoppers'
-// move phase), then holds steady until the next "valence shift" event.
+// move phase), then holds — with a small 2D noise wander layered on top, like
+// Region-hoppers' rest phase — until the next "valence shift" event.
 
+import { createNoise2D } from 'simplex-noise';
 import type { CursorEvent, SimContext, SimulationProgram } from '../types';
-import { makePrng, easeInOutCubic } from './_easing';
+import { makePrng, easeInOutCubic, noiseWanderOffset } from './_easing';
 import { valenceToPosition, type ReactionAnchors } from '../../../utils/voteRegion';
 
 /** Group-size weights (matches the onboarding v3 prototype's `FIBS`). */
@@ -14,11 +16,16 @@ const FIBS = [1, 2, 3, 5, 8, 13, 21];
 /** How often group targets re-randomize (ms) — the "valence shift" event. */
 export const SHIFT_INTERVAL_MS = 4000;
 /** How long a user takes to glide to its new target after a shift (ms). */
-const TRAVEL_DURATION_MS = 2000;
+export const TRAVEL_DURATION_MS = 2000;
 /** Max per-user offset from its group's shared target, so members don't overlap exactly. */
 const NOISE_SPAN = 0.15;
+/** Radius of the 2D micro-wander layered on top of the valence-derived point (canvas units). */
+const WANDER_RADIUS = 1.5;
+/** Speed the micro-wander noise field advances at. */
+const WANDER_SPEED = 0.6;
 
 const clampValence = (v: number): number => Math.max(-1, Math.min(1, v));
+const clampCoord = (n: number): number => Math.max(0, Math.min(100, n));
 
 /**
  * Assign position `i` of `n` to one of `groupCount` groups, sized by
@@ -55,6 +62,9 @@ export function createValenceShiftProgram(): SimulationProgram {
   let travelTo: number[] = [];
   let travelStart = 0;
   let rnd: () => number = () => 0;
+  let noise2D: (x: number, y: number) => number = () => 0;
+  let wanderOffX: number[] = [];
+  let wanderOffY: number[] = [];
   let nextShiftAt = SHIFT_INTERVAL_MS;
 
   return {
@@ -65,6 +75,7 @@ export function createValenceShiftProgram(): SimulationProgram {
       count = ctx.userCount;
       anchors = ctx.regionAnchors;
       rnd = makePrng(ctx.seed);
+      noise2D = createNoise2D(makePrng(ctx.seed + 1)); // independent seeded stream
       nextShiftAt = SHIFT_INTERVAL_MS;
       travelStart = 0;
 
@@ -75,6 +86,8 @@ export function createValenceShiftProgram(): SimulationProgram {
       value = group.map((g, i) => clampValence(groupTarget[g] + noiseOffset[i]));
       travelFrom = [...value];
       travelTo = [...value];
+      wanderOffX = Array.from({ length: count }, () => rnd() * 1000);
+      wanderOffY = Array.from({ length: count }, () => rnd() * 1000);
     },
 
     tick(tMs: number): CursorEvent[] {
@@ -89,9 +102,10 @@ export function createValenceShiftProgram(): SimulationProgram {
       return Array.from({ length: count }, (_, i) => {
         value[i] = travelFrom[i] + (travelTo[i] - travelFrom[i]) * e;
         const p = valenceToPosition(value[i], anchors);
+        const wander = noiseWanderOffset(noise2D, wanderOffX[i], wanderOffY[i], tMs, WANDER_SPEED, WANDER_RADIUS);
         return {
           type: 'move',
-          position: { x: p.x, y: p.y, timestamp: 0, userId: `sim_${i}` },
+          position: { x: clampCoord(p.x + wander.x), y: clampCoord(p.y + wander.y), timestamp: 0, userId: `sim_${i}` },
         };
       });
     },

--- a/app/lib/simulation/programs/valenceShift.ts
+++ b/app/lib/simulation/programs/valenceShift.ts
@@ -11,7 +11,7 @@ import { valenceToPosition, type ReactionAnchors } from '../../../utils/voteRegi
 /** Group-size weights (matches the onboarding v3 prototype's `FIBS`). */
 const FIBS = [1, 2, 3, 5, 8, 13, 21];
 /** How often group targets re-randomize (ms) — the "valence shift" event. */
-const SHIFT_INTERVAL_MS = 8000;
+const SHIFT_INTERVAL_MS = 4000;
 /** Per-tick easing fraction toward the group target (drift speed). */
 const DRIFT_EASE = 0.03;
 /** Max per-user offset from its group's shared target, so members don't overlap exactly. */

--- a/app/lib/simulation/programs/valenceShift.ts
+++ b/app/lib/simulation/programs/valenceShift.ts
@@ -1,0 +1,96 @@
+// Valence Shift program: users belong to one of N correlated opinion groups,
+// sized by Fibonacci ratios — same group model as the "correlated" trace mode
+// in docs/pages/valence-onboarding-v3.html. Each user eases toward its group's
+// shared target valence; on a fixed interval every group's target
+// re-randomizes together, reading as a "valence shift" event.
+
+import type { CursorEvent, SimContext, SimulationProgram } from '../types';
+import { makePrng } from './_easing';
+import { valenceToPosition, type ReactionAnchors } from '../../../utils/voteRegion';
+
+/** Group-size weights (matches the onboarding v3 prototype's `FIBS`). */
+const FIBS = [1, 2, 3, 5, 8, 13, 21];
+/** How often group targets re-randomize (ms) — the "valence shift" event. */
+const SHIFT_INTERVAL_MS = 8000;
+/** Per-tick easing fraction toward the group target (drift speed). */
+const DRIFT_EASE = 0.03;
+/** Max per-user offset from its group's shared target, so members don't overlap exactly. */
+const NOISE_SPAN = 0.15;
+
+const clampValence = (v: number): number => Math.max(-1, Math.min(1, v));
+
+/**
+ * Assign position `i` of `n` to one of `groupCount` groups, sized by
+ * Fibonacci ratios — e.g. 3 groups split 1:2:3, so the last group gets half
+ * of all users. Mirrors `assignBase()` in valence-onboarding-v3.html.
+ */
+export function assignGroup(i: number, n: number, groupCount: number): number {
+  const weights = FIBS.slice(0, groupCount);
+  const total = weights.reduce((a, b) => a + b, 0);
+  const pos = (i + 0.5) / n;
+  let cum = 0;
+  for (let g = 0; g < weights.length; g++) {
+    cum += weights[g] / total;
+    if (pos < cum) return g;
+  }
+  return weights.length - 1;
+}
+
+/**
+ * Create a Valence Shift program. Users ease toward a shared per-group target
+ * valence, mapped onto the canvas via `valenceToPosition`; every group's
+ * target re-randomizes together every {@link SHIFT_INTERVAL_MS}. Deterministic
+ * for a given `ctx.seed`.
+ */
+export function createValenceShiftProgram(): SimulationProgram {
+  let count = 0;
+  let anchors: ReactionAnchors;
+  let group: number[] = [];
+  let noiseOffset: number[] = [];
+  let value: number[] = [];
+  let groupTarget: number[] = [];
+  let rnd: () => number = () => 0;
+  let elapsed = 0;
+
+  return {
+    id: 'valence-shift',
+    label: 'Valence Shift (groups)',
+
+    init(ctx: SimContext) {
+      count = ctx.userCount;
+      anchors = ctx.regionAnchors;
+      rnd = makePrng(ctx.seed);
+      elapsed = 0;
+
+      const groupCount = Math.max(1, Math.min(FIBS.length, Math.round(ctx.groupCount ?? 3)));
+      groupTarget = Array.from({ length: groupCount }, () => rnd() * 2 - 1);
+      group = Array.from({ length: count }, (_, i) => assignGroup(i, count, groupCount));
+      noiseOffset = Array.from({ length: count }, () => (rnd() * 2 - 1) * NOISE_SPAN);
+      value = group.map((g, i) => clampValence(groupTarget[g] + noiseOffset[i]));
+    },
+
+    tick(_tMs: number, dtMs: number): CursorEvent[] {
+      elapsed += dtMs;
+      if (elapsed >= SHIFT_INTERVAL_MS) {
+        elapsed -= SHIFT_INTERVAL_MS;
+        groupTarget = groupTarget.map(() => rnd() * 2 - 1);
+      }
+      return Array.from({ length: count }, (_, i) => {
+        const target = clampValence(groupTarget[group[i]] + noiseOffset[i]);
+        value[i] += (target - value[i]) * DRIFT_EASE;
+        const p = valenceToPosition(value[i], anchors);
+        return {
+          type: 'move',
+          position: { x: p.x, y: p.y, timestamp: 0, userId: `sim_${i}` },
+        };
+      });
+    },
+
+    teardown(): CursorEvent[] {
+      return Array.from({ length: count }, (_, i) => ({
+        type: 'remove',
+        position: { x: 0, y: 0, timestamp: 0, userId: `sim_${i}` },
+      }));
+    },
+  };
+}

--- a/app/lib/simulation/programs/valenceShift.ts
+++ b/app/lib/simulation/programs/valenceShift.ts
@@ -1,19 +1,20 @@
 // Valence Shift program: users belong to one of N correlated opinion groups,
 // sized by Fibonacci ratios — same group model as the "correlated" trace mode
-// in docs/pages/valence-onboarding-v3.html. Each user eases toward its group's
-// shared target valence; on a fixed interval every group's target
-// re-randomizes together, reading as a "valence shift" event.
+// in docs/pages/valence-onboarding-v3.html. On a fixed interval every group's
+// target re-randomizes together; each user glides to its group's new shared
+// target valence over a bounded duration (eased, like Region-hoppers'
+// move phase), then holds steady until the next "valence shift" event.
 
 import type { CursorEvent, SimContext, SimulationProgram } from '../types';
-import { makePrng } from './_easing';
+import { makePrng, easeInOutCubic } from './_easing';
 import { valenceToPosition, type ReactionAnchors } from '../../../utils/voteRegion';
 
 /** Group-size weights (matches the onboarding v3 prototype's `FIBS`). */
 const FIBS = [1, 2, 3, 5, 8, 13, 21];
 /** How often group targets re-randomize (ms) — the "valence shift" event. */
-const SHIFT_INTERVAL_MS = 4000;
-/** Per-tick easing fraction toward the group target (drift speed). */
-const DRIFT_EASE = 0.03;
+export const SHIFT_INTERVAL_MS = 4000;
+/** How long a user takes to glide to its new target after a shift (ms). */
+const TRAVEL_DURATION_MS = 2000;
 /** Max per-user offset from its group's shared target, so members don't overlap exactly. */
 const NOISE_SPAN = 0.15;
 
@@ -37,10 +38,11 @@ export function assignGroup(i: number, n: number, groupCount: number): number {
 }
 
 /**
- * Create a Valence Shift program. Users ease toward a shared per-group target
- * valence, mapped onto the canvas via `valenceToPosition`; every group's
- * target re-randomizes together every {@link SHIFT_INTERVAL_MS}. Deterministic
- * for a given `ctx.seed`.
+ * Create a Valence Shift program. Every group's target re-randomizes together
+ * every {@link SHIFT_INTERVAL_MS}; each user then glides (eased, over
+ * {@link TRAVEL_DURATION_MS}) from its current valence to its group's new
+ * shared target, mapped onto the canvas via `valenceToPosition`, and holds
+ * steady once arrived. Deterministic for a given `ctx.seed`.
  */
 export function createValenceShiftProgram(): SimulationProgram {
   let count = 0;
@@ -49,8 +51,11 @@ export function createValenceShiftProgram(): SimulationProgram {
   let noiseOffset: number[] = [];
   let value: number[] = [];
   let groupTarget: number[] = [];
+  let travelFrom: number[] = [];
+  let travelTo: number[] = [];
+  let travelStart = 0;
   let rnd: () => number = () => 0;
-  let elapsed = 0;
+  let nextShiftAt = SHIFT_INTERVAL_MS;
 
   return {
     id: 'valence-shift',
@@ -60,24 +65,29 @@ export function createValenceShiftProgram(): SimulationProgram {
       count = ctx.userCount;
       anchors = ctx.regionAnchors;
       rnd = makePrng(ctx.seed);
-      elapsed = 0;
+      nextShiftAt = SHIFT_INTERVAL_MS;
+      travelStart = 0;
 
       const groupCount = Math.max(1, Math.min(FIBS.length, Math.round(ctx.groupCount ?? 3)));
       groupTarget = Array.from({ length: groupCount }, () => rnd() * 2 - 1);
       group = Array.from({ length: count }, (_, i) => assignGroup(i, count, groupCount));
       noiseOffset = Array.from({ length: count }, () => (rnd() * 2 - 1) * NOISE_SPAN);
       value = group.map((g, i) => clampValence(groupTarget[g] + noiseOffset[i]));
+      travelFrom = [...value];
+      travelTo = [...value];
     },
 
-    tick(_tMs: number, dtMs: number): CursorEvent[] {
-      elapsed += dtMs;
-      if (elapsed >= SHIFT_INTERVAL_MS) {
-        elapsed -= SHIFT_INTERVAL_MS;
+    tick(tMs: number): CursorEvent[] {
+      if (tMs >= nextShiftAt) {
+        nextShiftAt += SHIFT_INTERVAL_MS;
         groupTarget = groupTarget.map(() => rnd() * 2 - 1);
+        travelStart = tMs;
+        travelFrom = [...value];
+        travelTo = group.map((g, i) => clampValence(groupTarget[g] + noiseOffset[i]));
       }
+      const e = easeInOutCubic(Math.max(0, Math.min((tMs - travelStart) / TRAVEL_DURATION_MS, 1)));
       return Array.from({ length: count }, (_, i) => {
-        const target = clampValence(groupTarget[group[i]] + noiseOffset[i]);
-        value[i] += (target - value[i]) * DRIFT_EASE;
+        value[i] = travelFrom[i] + (travelTo[i] - travelFrom[i]) * e;
         const p = valenceToPosition(value[i], anchors);
         return {
           type: 'move',

--- a/app/lib/simulation/programs/valenceShift.ts
+++ b/app/lib/simulation/programs/valenceShift.ts
@@ -1,15 +1,16 @@
 // Valence Shift program: users belong to one of N correlated opinion groups,
 // sized by Fibonacci ratios — same group model as the "correlated" trace mode
 // in docs/pages/valence-onboarding-v3.html. On a fixed interval every group's
-// target re-randomizes together; each user glides to its group's new shared
-// target valence over a bounded duration (eased, like Region-hoppers'
-// move phase), then holds — with a small 2D noise wander layered on top, like
-// Region-hoppers' rest phase — until the next "valence shift" event.
+// target re-randomizes together; each user glides (eased, like Region-hoppers'
+// move phase) directly to a point sampled from its own personal-valence chord
+// (see docs/specs/valence-shift-organic-positioning.md), then holds — with a
+// small 2D noise wander layered on top, like Region-hoppers' rest phase —
+// until the next "valence shift" event.
 
 import { createNoise2D } from 'simplex-noise';
 import type { CursorEvent, SimContext, SimulationProgram } from '../types';
 import { makePrng, easeInOutCubic, noiseWanderOffset } from './_easing';
-import { valenceToPosition, type ReactionAnchors } from '../../../utils/voteRegion';
+import { valenceChordEndpoints, sampleValencePosition, type ReactionAnchors } from '../../../utils/voteRegion';
 
 /** Group-size weights (matches the onboarding v3 prototype's `FIBS`). */
 const FIBS = [1, 2, 3, 5, 8, 13, 21];
@@ -23,9 +24,33 @@ const NOISE_SPAN = 0.15;
 const WANDER_RADIUS = 1.5;
 /** Speed the micro-wander noise field advances at. */
 const WANDER_SPEED = 0.6;
+/**
+ * How far a group's members scatter around their shared anchor point on the target-valence
+ * chord. Dual-mode, inferred from magnitude — hand-edit to explore:
+ *   0 <= SPREAD <= 1 → fraction of chord length (0 = single shared point, 1 = full chord).
+ *   SPREAD > 1       → absolute canvas units (0-100 space, open-ended); holds a constant
+ *                       scatter footprint as valence gets extreme instead of shrinking toward
+ *                       the vertex, falling back to the full chord once it's shorter than this.
+ */
+const SPREAD = 0.15;
 
 const clampValence = (v: number): number => Math.max(-1, Math.min(1, v));
 const clampCoord = (n: number): number => Math.max(0, Math.min(100, n));
+const clamp01 = (n: number): number => Math.max(0, Math.min(1, n));
+const lerp = (a: number, b: number, t: number): number => a + (b - a) * t;
+
+/**
+ * Resolves `SPREAD` to a 0..1 fraction of a chord of length `chordLen`.
+ * `spread <= 1` is already a fraction and passes through unchanged. `spread > 1`
+ * is treated as absolute canvas units and divided by the chord's actual length,
+ * clamped to 1 (the full chord) — including when `chordLen` is 0 (the chord
+ * degenerates to a point at valence ±1, so there's nowhere further to scatter).
+ */
+export function resolveSpreadFraction(spread: number, chordLen: number): number {
+  if (spread <= 1) return spread;
+  if (chordLen <= 0) return 1;
+  return Math.min(1, spread / chordLen);
+}
 
 /**
  * Assign position `i` of `n` to one of `groupCount` groups, sized by
@@ -47,25 +72,51 @@ export function assignGroup(i: number, n: number, groupCount: number): number {
 /**
  * Create a Valence Shift program. Every group's target re-randomizes together
  * every {@link SHIFT_INTERVAL_MS}; each user then glides (eased, over
- * {@link TRAVEL_DURATION_MS}) from its current valence to its group's new
- * shared target, mapped onto the canvas via `valenceToPosition`, and holds
- * steady once arrived. Deterministic for a given `ctx.seed`.
+ * {@link TRAVEL_DURATION_MS}) from its current canvas position to a point
+ * sampled from its own personal-valence chord, scattered around a shared
+ * group anchor by `SPREAD`, and holds steady once arrived. Deterministic for
+ * a given `ctx.seed`.
  */
 export function createValenceShiftProgram(): SimulationProgram {
   let count = 0;
   let anchors: ReactionAnchors;
   let group: number[] = [];
   let noiseOffset: number[] = [];
-  let value: number[] = [];
   let groupTarget: number[] = [];
-  let travelFrom: number[] = [];
-  let travelTo: number[] = [];
+  let anchorT: number[] = [];
+  let travelFromX: number[] = [];
+  let travelFromY: number[] = [];
+  let travelToX: number[] = [];
+  let travelToY: number[] = [];
   let travelStart = 0;
   let rnd: () => number = () => 0;
   let noise2D: (x: number, y: number) => number = () => 0;
   let wanderOffX: number[] = [];
   let wanderOffY: number[] = [];
   let nextShiftAt = SHIFT_INTERVAL_MS;
+
+  /** Reroll every group's target valence and each member's destination point. */
+  function pickTargets() {
+    groupTarget = groupTarget.map(() => rnd() * 2 - 1);
+    anchorT = anchorT.map(() => rnd());
+    for (let i = 0; i < count; i++) {
+      const g = group[i];
+      const personalValence = clampValence(groupTarget[g] + noiseOffset[i]);
+      const { a, b } = valenceChordEndpoints(personalValence, anchors);
+      const chordLen = Math.hypot(b.x - a.x, b.y - a.y);
+      const spreadFraction = resolveSpreadFraction(SPREAD, chordLen);
+      const memberT = clamp01(anchorT[g] + (rnd() * 2 - 1) * spreadFraction / 2);
+      const p = sampleValencePosition(personalValence, memberT, anchors);
+      travelToX[i] = p.x;
+      travelToY[i] = p.y;
+    }
+  }
+
+  /** Current eased position (pre-wander) for user `i` at `tMs`, given the active glide. */
+  function currentPos(i: number, tMs: number): { x: number; y: number } {
+    const e = easeInOutCubic(clamp01((tMs - travelStart) / TRAVEL_DURATION_MS));
+    return { x: lerp(travelFromX[i], travelToX[i], e), y: lerp(travelFromY[i], travelToY[i], e) };
+  }
 
   return {
     id: 'valence-shift',
@@ -80,12 +131,15 @@ export function createValenceShiftProgram(): SimulationProgram {
       travelStart = 0;
 
       const groupCount = Math.max(1, Math.min(FIBS.length, Math.round(ctx.groupCount ?? 3)));
-      groupTarget = Array.from({ length: groupCount }, () => rnd() * 2 - 1);
+      groupTarget = new Array(groupCount).fill(0);
+      anchorT = new Array(groupCount).fill(0);
       group = Array.from({ length: count }, (_, i) => assignGroup(i, count, groupCount));
       noiseOffset = Array.from({ length: count }, () => (rnd() * 2 - 1) * NOISE_SPAN);
-      value = group.map((g, i) => clampValence(groupTarget[g] + noiseOffset[i]));
-      travelFrom = [...value];
-      travelTo = [...value];
+      travelToX = new Array(count).fill(0);
+      travelToY = new Array(count).fill(0);
+      pickTargets();
+      travelFromX = [...travelToX];
+      travelFromY = [...travelToY];
       wanderOffX = Array.from({ length: count }, () => rnd() * 1000);
       wanderOffY = Array.from({ length: count }, () => rnd() * 1000);
     },
@@ -93,15 +147,16 @@ export function createValenceShiftProgram(): SimulationProgram {
     tick(tMs: number): CursorEvent[] {
       if (tMs >= nextShiftAt) {
         nextShiftAt += SHIFT_INTERVAL_MS;
-        groupTarget = groupTarget.map(() => rnd() * 2 - 1);
+        for (let i = 0; i < count; i++) {
+          const cur = currentPos(i, tMs);
+          travelFromX[i] = cur.x;
+          travelFromY[i] = cur.y;
+        }
         travelStart = tMs;
-        travelFrom = [...value];
-        travelTo = group.map((g, i) => clampValence(groupTarget[g] + noiseOffset[i]));
+        pickTargets();
       }
-      const e = easeInOutCubic(Math.max(0, Math.min((tMs - travelStart) / TRAVEL_DURATION_MS, 1)));
       return Array.from({ length: count }, (_, i) => {
-        value[i] = travelFrom[i] + (travelTo[i] - travelFrom[i]) * e;
-        const p = valenceToPosition(value[i], anchors);
+        const p = currentPos(i, tMs);
         const wander = noiseWanderOffset(noise2D, wanderOffX[i], wanderOffY[i], tMs, WANDER_SPEED, WANDER_RADIUS);
         return {
           type: 'move',

--- a/app/lib/simulation/programs/valenceShift.ts
+++ b/app/lib/simulation/programs/valenceShift.ts
@@ -9,7 +9,7 @@
 
 import { createNoise2D } from 'simplex-noise';
 import type { CursorEvent, SimContext, SimulationProgram } from '../types';
-import { makePrng, easeInOutCubic, noiseWanderOffset } from './_easing';
+import { makePrng, easedProgress, noiseWanderOffset } from './_easing';
 import { valenceChordEndpoints, sampleValencePosition, type ReactionAnchors } from '../../../utils/voteRegion';
 
 /** Group-size weights (matches the onboarding v3 prototype's `FIBS`). */
@@ -117,7 +117,7 @@ export function createValenceShiftProgram(): SimulationProgram {
 
   /** Current eased position (pre-wander) for user `i` at `tMs`, given the active glide. */
   function currentPos(i: number, tMs: number): { x: number; y: number } {
-    const e = easeInOutCubic(clamp01((tMs - travelStart) / TRAVEL_DURATION_MS));
+    const e = easedProgress(tMs, travelStart, TRAVEL_DURATION_MS);
     return { x: lerp(travelFromX[i], travelToX[i], e), y: lerp(travelFromY[i], travelToY[i], e) };
   }
 

--- a/app/lib/simulation/programs/valenceShift.ts
+++ b/app/lib/simulation/programs/valenceShift.ts
@@ -18,7 +18,8 @@ const FIBS = [1, 2, 3, 5, 8, 13, 21];
 export const SHIFT_INTERVAL_MS = 4000;
 /** How long a user takes to glide to its new target after a shift (ms). */
 export const TRAVEL_DURATION_MS = 2000;
-/** Max per-user offset from its group's shared target, so members don't overlap exactly. */
+/** Max per-user offset from its group's shared target, re-rolled every shift so members
+ *  don't overlap exactly and don't ride the same fixed offset hop after hop. */
 const NOISE_SPAN = 0.15;
 /** Radius of the 2D micro-wander layered on top of the valence-derived point (canvas units). */
 const WANDER_RADIUS = 1.5;
@@ -95,10 +96,12 @@ export function createValenceShiftProgram(): SimulationProgram {
   let wanderOffY: number[] = [];
   let nextShiftAt = SHIFT_INTERVAL_MS;
 
-  /** Reroll every group's target valence and each member's destination point. */
+  /** Reroll every group's target valence, each member's personal offset from it, and each
+   *  member's destination point. */
   function pickTargets() {
     groupTarget = groupTarget.map(() => rnd() * 2 - 1);
     anchorT = anchorT.map(() => rnd());
+    noiseOffset = noiseOffset.map(() => (rnd() * 2 - 1) * NOISE_SPAN);
     for (let i = 0; i < count; i++) {
       const g = group[i];
       const personalValence = clampValence(groupTarget[g] + noiseOffset[i]);
@@ -134,7 +137,7 @@ export function createValenceShiftProgram(): SimulationProgram {
       groupTarget = new Array(groupCount).fill(0);
       anchorT = new Array(groupCount).fill(0);
       group = Array.from({ length: count }, (_, i) => assignGroup(i, count, groupCount));
-      noiseOffset = Array.from({ length: count }, () => (rnd() * 2 - 1) * NOISE_SPAN);
+      noiseOffset = new Array(count).fill(0);
       travelToX = new Array(count).fill(0);
       travelToY = new Array(count).fill(0);
       pickTargets();

--- a/app/lib/simulation/types.ts
+++ b/app/lib/simulation/types.ts
@@ -25,6 +25,8 @@ export interface SimContext {
   seed: number;
   /** AGREE/DISAGREE/PASS anchor points, coords 0..100. */
   regionAnchors: ReactionAnchors;
+  /** Number of correlated opinion groups (only read by group-aware programs). */
+  groupCount?: number;
 }
 
 /**

--- a/app/utils/voteRegion.ts
+++ b/app/utils/voteRegion.ts
@@ -1,5 +1,10 @@
 export type ReactionRegion = 'positive' | 'negative' | 'neutral' | null;
 
+export interface Point {
+  x: number;
+  y: number;
+}
+
 export interface ReactionAnchors {
   positive: { x: number; y: number }; // 0–100 normalized
   negative: { x: number; y: number };
@@ -87,6 +92,30 @@ export function computeCursorValence(normalizedX: number, normalizedY: number, a
   const wPos = ((neg.y - neu.y) * (x - neu.x) + (neu.x - neg.x) * (y - neu.y)) / denom;
   const wNeg = ((neu.y - pos.y) * (x - neu.x) + (pos.x - neu.x) * (y - neu.y)) / denom;
   return Math.max(-1, Math.min(1, wPos - wNeg));
+}
+
+/**
+ * Endpoints of the chord of canvas positions that all produce the given valence
+ * under computeCursorValence (one linear constraint on two free barycentric
+ * weights → a line segment, not a point). `a` sits on a neutral-adjacent edge,
+ * `b` on the negative–positive edge; both collapse to the same vertex at v=±1.
+ */
+export function valenceChordEndpoints(valence: number, anchors: ReactionAnchors): { a: Point; b: Point } {
+  const v = Math.max(-1, Math.min(1, valence));
+  const lerp = (p: Point, q: Point, t: number): Point => ({ x: p.x + (q.x - p.x) * t, y: p.y + (q.y - p.y) * t });
+  const a = v >= 0 ? lerp(anchors.neutral, anchors.positive, v) : lerp(anchors.neutral, anchors.negative, -v);
+  const b = lerp(anchors.negative, anchors.positive, (v + 1) / 2);
+  return { a, b };
+}
+
+/**
+ * Samples a point on the valence-v chord at fraction `t` (0=a, 1=b). Every
+ * point on this chord round-trips through computeCursorValence to ~v.
+ */
+export function sampleValencePosition(valence: number, t: number, anchors: ReactionAnchors): Point {
+  const { a, b } = valenceChordEndpoints(valence, anchors);
+  const clampedT = Math.max(0, Math.min(1, t));
+  return { x: a.x + (b.x - a.x) * clampedT, y: a.y + (b.y - a.y) * clampedT };
 }
 
 /**

--- a/docs/specs/valence-shift-organic-positioning.md
+++ b/docs/specs/valence-shift-organic-positioning.md
@@ -90,8 +90,11 @@ no new "ghost" abstraction needed for this program.
 Per shift, per group `g`:
 1. Roll one shared **anchor fraction** `anchorT[g] = rnd()` — "where along this group's target
    valence chord does the group tend to sit this shift."
-2. Each member `i` in group `g` computes its own (already-existing) personal valence
-   `clampValence(groupTarget[g] + noiseOffset[i])`, then its own chord endpoints
+2. Each member `i` in group `g` also re-rolls its own personal offset `noiseOffset[i] = (rnd() * 2
+   - 1) * NOISE_SPAN` **every shift**, not just once at init — a member that read as slightly more
+   extreme than its group last hop isn't locked into being "the extreme one" forever; the personal
+   deviation itself scrambles hop to hop, same as the group target does. It then computes its
+   personal valence `clampValence(groupTarget[g] + noiseOffset[i])`, then its own chord endpoints
    `{a, b} = valenceChordEndpoints(personalValence[i], anchors)` and chord length
    `chordLen[i] = hypot(b.x - a.x, b.y - a.y)`, then its own chord position:
    `spreadFraction[i] = resolveSpreadFraction(SPREAD, chordLen[i])`
@@ -144,7 +147,8 @@ switches on magnitude.
 
 - Drop `value: number[]` (scalar valence, no longer needed — position is eased directly).
 - Add `travelFromX/Y: number[]`, `travelToX/Y: number[]`, `anchorT: number[]` (per group).
-- `groupTarget`/`noiseOffset`/`group` assignment: unchanged.
+- `group` assignment: unchanged. `groupTarget` and `noiseOffset` are both re-rolled every shift
+  (previously `noiseOffset` was fixed once at init — amended mid-build, see Resolved decisions).
 - On shift (and at `init`, treating it as shift 0): reroll `anchorT`, recompute
   `travelToX/Y[i]` via the sampling above; `travelFromX/Y[i]` = current rendered (pre-wander) base
   position.
@@ -227,6 +231,11 @@ cluster," and "full scatter" — no control-bar or `SimContext` changes needed.
    `±1` because the chord itself shrinks to a point there — real people don't cluster tighter and
    tighter just because their opinion is more extreme, so absolute-unit mode holds a constant scatter
    footprint instead, only degrading once the chord is physically too short to hold it.
+6. **`noiseOffset` re-rolls every shift, not just once at init.** Added mid-build: with a
+   fixed-at-init offset, a member that happened to draw a more extreme offset stayed "the extreme
+   one" relative to its group for the whole session, every hop — read as fake/scripted. Scrambling
+   it alongside `groupTarget` on every shift means each member's personal deviation is fresh each
+   hop, same as the group's target itself.
 
 ## Files touched
 

--- a/docs/specs/valence-shift-organic-positioning.md
+++ b/docs/specs/valence-shift-organic-positioning.md
@@ -208,9 +208,13 @@ cluster," and "full scatter" — no control-bar or `SimContext` changes needed.
 3. **(Separable cleanup, do last, only if time allows)** Consider whether any further code-sharing
    with `regionHoppersRealistic.ts` is now worthwhile. Given task 2's finding — Valence Shift doesn't
    need Region-hoppers' independent per-cursor move/rest state machine, since all users glide on one
-   shared shift timer — there may be **nothing further to extract**; the two programs already share
-   `easeInOutCubic` and `noiseWanderOffset` (done earlier this branch). Don't force an abstraction
-   that isn't there; only extract if a *third* real duplication shows up.
+   shared shift timer — the state-machine shape stays unshared, but the ["compute a clamped 0..1
+   elapsed/duration fraction, then ease it"](../../app/lib/simulation/programs/_easing.ts) one-liner
+   turned out to appear a *third* time (Region-hoppers' move phase, its rest→wander blend, and
+   Valence Shift's glide) — extracted as `easedProgress(tMs, start, duration)` in `_easing.ts`,
+   alongside the already-shared `easeInOutCubic`/`noiseWanderOffset`. Pure refactor, no behavior
+   change (`p >= 1` checks became the equivalent `e >= 1`, since `easeInOutCubic` only reaches 1 at
+   `p = 1`). Nothing else warranted extracting.
 4. **CHANGELOG.md** — one concise (per established preference — see feedback memory) entry folded
    into the existing Week 33 "Valence Shift" bullet (this feature hasn't shipped yet this week),
    describing organic chord-based positioning.

--- a/docs/specs/valence-shift-organic-positioning.md
+++ b/docs/specs/valence-shift-organic-positioning.md
@@ -1,0 +1,186 @@
+# Plan: Organic 2D positioning for Valence Shift
+
+Status: **DRAFT — ready to build** · Owner: patcon · Created 2026-07-10
+
+## Objective
+
+`valenceShift.ts` currently maps a scalar valence to canvas position via `valenceToPosition()`,
+which collapses every possible position for a given valence down to **one single point** on a
+fixed line (negative → centroid → positive). Every simulated cursor with the same target valence
+rides the exact same track, which reads as visibly unnatural — real people with "neutral" opinions
+don't all stand on one line.
+
+This plan replaces that with **organic 2D positioning**: for a given valence, sample a random point
+from the *actual set* of canvas positions that produce that valence (a full chord across the anchor
+triangle, not a point), and glide each user directly to their own sampled point ("most direct
+route", independent per user — no shared track). A **spread** constant controls how tightly group
+members cluster around a shared anchor point on that chord vs. scattering across its full width, so
+the same mechanism can produce both a "tight cluster" look and a "fully organic scatter" look — the
+user wants to explore both by hand-editing the constant, no UI control needed.
+
+## Background — the math (verified)
+
+`computeCursorValence()` (`app/utils/voteRegion.ts:71`) computes valence via barycentric weights:
+`valence = wPositive − wNegative`, where `wPositive + wNegative + wNeutral = 1`. For a fixed valence
+`v`, this is **one linear constraint on two free barycentric weights** — the solution set is a line
+segment (a "chord") across the anchor triangle, not a point.
+
+Solving for the two endpoints of that chord (derivation + numeric verification done in-session, all
+round-tripped exactly through `computeCursorValence`):
+
+```
+A(v) = v >= 0 ? lerp(neutral, positive, v) : lerp(neutral, negative, -v)   // on a neutral-adjacent edge
+B(v) = lerp(negative, positive, (v + 1) / 2)                              // on the negative–positive edge
+chord(v, t) = lerp(A(v), B(v), t)   // t in [0,1] — any point on this chord has valence exactly v
+```
+
+Sanity checks (DEFAULT_ANCHORS, positive=(95,5) negative=(5,95) neutral=(95,95)):
+- `v=0`: chord runs from **(50,50)** (today's `valenceToPosition` centroid point is on this chord,
+  but so is the entire diagonal up to **(95,95)**, the neutral vertex — a ~64-unit-long chord).
+- `v=±1`: chord collapses to a single point (the positive/negative vertex) — extremes are
+  necessarily unambiguous.
+
+This chord is the real "positions consistent with valence v" set the user is asking to sample from.
+
+## New primitive: `sampleValencePosition`
+
+Add to `app/utils/voteRegion.ts`, next to `valenceToPosition`/`computeCursorValence`:
+
+```ts
+export function valenceChordEndpoints(valence: number, anchors: ReactionAnchors): { a: Point; b: Point } {
+  const v = Math.max(-1, Math.min(1, valence));
+  const lerp = (p: Point, q: Point, t: number) => ({ x: p.x + (q.x - p.x) * t, y: p.y + (q.y - p.y) * t });
+  const a = v >= 0 ? lerp(anchors.neutral, anchors.positive, v) : lerp(anchors.neutral, anchors.negative, -v);
+  const b = lerp(anchors.negative, anchors.positive, (v + 1) / 2);
+  return { a, b };
+}
+
+export function sampleValencePosition(valence: number, t: number, anchors: ReactionAnchors): Point {
+  const { a, b } = valenceChordEndpoints(valence, anchors);
+  const clampedT = Math.max(0, Math.min(1, t));
+  return { x: a.x + (b.x - a.x) * clampedT, y: a.y + (b.y - a.y) * clampedT };
+}
+```
+
+`t` is supplied by the caller's seeded PRNG — this function is pure and deterministic given its
+inputs, easy to unit test via round-trip through `computeCursorValence`.
+
+**Test** (add to `tests/voteRegion.test.ts`, matching that file's existing style):
+- For a spread of `valence` values (`-1, -0.6, -0.3, 0, 0.3, 0.6, 1`) and `t` values (`0, 0.25, 0.5,
+  0.75, 1`), assert `computeCursorValence(sampleValencePosition(v, t, anchors)) ≈ v` (within float
+  tolerance).
+- `t=0`/`t=1`/any `t` all collapse to the same point when `valence = ±1` (chord degenerates to a
+  vertex).
+- Output stays within `DEFAULT_ANCHORS`' triangle (all barycentric weights in `[0,1]`) for valid
+  inputs.
+
+## Redesigning `valenceShift.ts`
+
+The existing shift/glide architecture (global `nextShiftAt`, `travelStart`, eased-over-
+`TRAVEL_DURATION_MS`) stays — **it turns out this doesn't need Region-hoppers' independent
+per-cursor move/rest state machine at all.** All users already glide in lockstep on the shared
+`SHIFT_INTERVAL_MS` timer; the only change is *what* they glide between: swap the scalar
+`travelFrom`/`travelTo: number[]` (valence values, re-projected every tick via `valenceToPosition`)
+for `travelFromX/Y`/`travelToX/Y: number[]` (canvas points, computed once per shift via
+`sampleValencePosition`) and ease those directly. This is a smaller change than it first looks —
+no new "ghost" abstraction needed for this program.
+
+### Picking each member's destination point
+
+Per shift, per group `g`:
+1. Roll one shared **anchor fraction** `anchorT[g] = rnd()` — "where along this group's target
+   valence chord does the group tend to sit this shift."
+2. Each member `i` in group `g` computes its own (already-existing) personal valence
+   `clampValence(groupTarget[g] + noiseOffset[i])`, then its own chord position:
+   `memberT[i] = clamp(anchorT[g] + (rnd() * 2 - 1) * spread / 2, 0, 1)`
+   `travelToXY[i] = sampleValencePosition(personalValence[i], memberT[i], anchors)`
+
+`spread` (0..1, fraction of chord length members can scatter around the shared anchor):
+- `spread = 0` → every group member lands on the exact same point (today's behavior, minus the
+  scalar-line artifact — still one point, just wherever `anchorT` landed on the chord instead of
+  always the same `valenceToPosition` point).
+- `spread ≈ 0.15` → **bounded jitter around a group anchor** — groups still read as visible
+  clusters, members no longer overlap or ride one line.
+- `spread = 1` → **full free scatter** — every member independently samples anywhere on their
+  personal chord; groups may not read as visible clusters near `valence≈0` (chord ≈64 units wide).
+
+This is one mechanism, not two — a single `SPREAD` constant reaches both requested behaviors by
+hand-editing the value and re-running the demo.
+
+### State changes in `createValenceShiftProgram()`
+
+- Drop `value: number[]` (scalar valence, no longer needed — position is eased directly).
+- Add `travelFromX/Y: number[]`, `travelToX/Y: number[]`, `anchorT: number[]` (per group).
+- `groupTarget`/`noiseOffset`/`group` assignment: unchanged.
+- On shift (and at `init`, treating it as shift 0): reroll `anchorT`, recompute
+  `travelToX/Y[i]` via the sampling above; `travelFromX/Y[i]` = current rendered (pre-wander) base
+  position.
+- `tick()`: same `easeInOutCubic` progress fraction `e` as today, applied directly to x/y:
+  `x[i] = lerp(travelFromX[i], travelToX[i], e)`, same for y. Then layer the existing
+  `noiseWanderOffset` micro-wander on top (unchanged from the current implementation) and
+  `clampCoord`.
+- `valenceToPosition` import is no longer used in this file — replaced entirely by
+  `sampleValencePosition`.
+
+### Spread as a hardcoded constant
+
+No `SimContext`/UI plumbing — just a named, easily-editable constant in `valenceShift.ts`:
+
+```ts
+/** Fraction of a group's target-valence chord members can scatter around the shared anchor
+ *  point (0 = single shared point, 1 = full-chord free scatter). Hand-edit to explore. */
+const SPREAD = 0.15;
+```
+
+Editing this one value and re-running the demo moves between "tight cluster" and "full scatter" —
+no control-bar or `SimContext` changes needed.
+
+## Task breakdown (TDD, one commit per task — mirrors the pattern already used on this branch)
+
+1. **Add `sampleValencePosition` + `valenceChordEndpoints` to `voteRegion.ts`.** Tests first in
+   `tests/voteRegion.test.ts` (round-trip assertions above), watch RED (function doesn't exist),
+   implement, GREEN.
+2. **Redesign `valenceShift.ts` to glide directly between sampled XY points**, using the hardcoded
+   `SPREAD` constant. Update `valenceShift.test.ts`:
+   - Existing tests should mostly still pass conceptually but will need re-verification against the
+     new mechanism (positions are no longer literally `valenceToPosition(scalar)`); re-run and fix
+     any that assumed the old single-line geometry.
+   - New test: for `groupCount=1` with several users, after a shift, members are **not** all at the
+     exact same point (chord + spread jitter is active) — this should be RED against the
+     scalar-line implementation and GREEN after the redesign.
+   - New test: round-trip — each user's rendered position (before wander) should map back via
+     `computeCursorValence` to very close to that user's personal target valence.
+   - New test: varying `SPREAD` (e.g. reconstructing the program with the constant patched to `0` vs
+     `1` — or, more simply, testing the internal target-picking helper directly if it's exported)
+     shows the resulting within-group spread scales up accordingly (monotonic, not just
+     present/absent), proving the constant actually drives the effect claimed above.
+3. **(Separable cleanup, do last, only if time allows)** Consider whether any further code-sharing
+   with `regionHoppersRealistic.ts` is now worthwhile. Given task 2's finding — Valence Shift doesn't
+   need Region-hoppers' independent per-cursor move/rest state machine, since all users glide on one
+   shared shift timer — there may be **nothing further to extract**; the two programs already share
+   `easeInOutCubic` and `noiseWanderOffset` (done earlier this branch). Don't force an abstraction
+   that isn't there; only extract if a *third* real duplication shows up.
+4. **CHANGELOG.md** — one concise (per established preference — see feedback memory) entry folded
+   into the existing Week 33 "Valence Shift" bullet (this feature hasn't shipped yet this week),
+   describing organic chord-based positioning.
+
+## Resolved decisions (from conversation)
+
+1. Ship **one mechanism** (a `SPREAD` constant, 0..1) rather than two separate code paths for
+   "bounded jitter" vs "full scatter" — they're the same math at different parameter values.
+2. **Hardcoded constant, no UI control** — the user will hand-edit `SPREAD` in the source to explore
+   the range, not drag a live slider. No `SimContext`/`SimControlBar` changes needed.
+3. Default `SPREAD = 0.15` (bounded jitter, groups read as clusters) so the out-of-the-box demo still
+   looks like "correlated groups," with the option to hand-edit it to `1` to see full scatter.
+4. No new shared "ghost" state-machine abstraction planned — the redesign turned out simpler than
+   originally scoped (see task 3).
+
+## Files touched
+
+```
+app/utils/voteRegion.ts                          → sampleValencePosition, valenceChordEndpoints
+tests/voteRegion.test.ts                         → round-trip tests for the above
+app/lib/simulation/programs/valenceShift.ts       → redesigned glide (XY, not scalar), SPREAD const
+app/lib/simulation/programs/valenceShift.test.ts  → updated + new tests
+CHANGELOG.md                                      → Week 33 entry update
+```

--- a/docs/specs/valence-shift-organic-positioning.md
+++ b/docs/specs/valence-shift-organic-positioning.md
@@ -91,21 +91,54 @@ Per shift, per group `g`:
 1. Roll one shared **anchor fraction** `anchorT[g] = rnd()` — "where along this group's target
    valence chord does the group tend to sit this shift."
 2. Each member `i` in group `g` computes its own (already-existing) personal valence
-   `clampValence(groupTarget[g] + noiseOffset[i])`, then its own chord position:
-   `memberT[i] = clamp(anchorT[g] + (rnd() * 2 - 1) * spread / 2, 0, 1)`
+   `clampValence(groupTarget[g] + noiseOffset[i])`, then its own chord endpoints
+   `{a, b} = valenceChordEndpoints(personalValence[i], anchors)` and chord length
+   `chordLen[i] = hypot(b.x - a.x, b.y - a.y)`, then its own chord position:
+   `spreadFraction[i] = resolveSpreadFraction(SPREAD, chordLen[i])`
+   `memberT[i] = clamp(anchorT[g] + (rnd() * 2 - 1) * spreadFraction[i] / 2, 0, 1)`
    `travelToXY[i] = sampleValencePosition(personalValence[i], memberT[i], anchors)`
 
-`spread` (0..1, fraction of chord length members can scatter around the shared anchor):
-- `spread = 0` → every group member lands on the exact same point (today's behavior, minus the
+**`SPREAD` is dual-mode** — a single number whose *units* are inferred from its magnitude, so one
+constant still reaches every look without a second knob:
+- **`0 <= SPREAD <= 1`** → treated as a **fraction of chord length**, exactly as before.
+  `resolveSpreadFraction` returns `SPREAD` unchanged.
+- **`SPREAD > 1`** → treated as **absolute canvas units** (the same 0–100 normalized space as
+  anchors — note the canvas *diagonal* can exceed 100 units, so this range is open-ended, not
+  capped at 100). `resolveSpreadFraction = min(1, SPREAD / chordLen[i])`.
+
+```ts
+function resolveSpreadFraction(spread: number, chordLen: number): number {
+  if (spread <= 1) return spread;
+  if (chordLen <= 0) return 1; // degenerate chord (v=±1): whole "chord" is the point itself
+  return Math.min(1, spread / chordLen);
+}
+```
+
+**Why two modes:** the chord's length is not constant — it shrinks toward 0 as `personalValence`
+approaches `±1` (extreme opinions are geometrically less ambiguous, so there's less room to scatter
+within). A purely proportional spread (mode 1) shrinks in lockstep, which reads as "extreme voters
+all stand on top of each other" — unrealistic; real people occupy a roughly constant amount of
+physical space regardless of how strong their opinion is. Absolute-unit mode (mode 2) holds that
+footprint constant in canvas units as valence gets more extreme, and only degrades gracefully back
+toward "use the whole chord" once the chord itself becomes shorter than the requested footprint —
+never scatter than what's geometrically available, but never artificially tinier either.
+
+- `SPREAD = 0` → every group member lands on the exact same point (today's behavior, minus the
   scalar-line artifact — still one point, just wherever `anchorT` landed on the chord instead of
   always the same `valenceToPosition` point).
-- `spread ≈ 0.15` → **bounded jitter around a group anchor** — groups still read as visible
-  clusters, members no longer overlap or ride one line.
-- `spread = 1` → **full free scatter** — every member independently samples anywhere on their
+- `SPREAD ≈ 0.15` (proportional) → **bounded jitter around a group anchor** — groups still read as
+  visible clusters, members no longer overlap or ride one line, but the cluster visibly shrinks near
+  `valence ≈ ±1`.
+- `SPREAD ≈ 10` (absolute units) → **constant-footprint jitter** — same "bounded cluster" look near
+  `valence ≈ 0` (chord ≈64 units, so ≈10/64 ≈ 0.16 fraction, close to the proportional default
+  above), but groups near the extremes keep a similar-sized footprint instead of collapsing,
+  clamped to the full (shorter) chord once it's less than 10 units long.
+- `SPREAD = 1` → **full free scatter** — every member independently samples anywhere on their
   personal chord; groups may not read as visible clusters near `valence≈0` (chord ≈64 units wide).
 
-This is one mechanism, not two — a single `SPREAD` constant reaches both requested behaviors by
-hand-editing the value and re-running the demo.
+This is one mechanism, not two separate code paths — a single `SPREAD` constant reaches every
+requested behavior by hand-editing the value and re-running the demo; only its *interpretation*
+switches on magnitude.
 
 ### State changes in `createValenceShiftProgram()`
 
@@ -127,13 +160,18 @@ hand-editing the value and re-running the demo.
 No `SimContext`/UI plumbing — just a named, easily-editable constant in `valenceShift.ts`:
 
 ```ts
-/** Fraction of a group's target-valence chord members can scatter around the shared anchor
- *  point (0 = single shared point, 1 = full-chord free scatter). Hand-edit to explore. */
+/** How far a group's members scatter around their shared anchor point on the target-valence
+ *  chord. Dual-mode, inferred from magnitude — hand-edit to explore:
+ *    0 <= SPREAD <= 1 → fraction of chord length (0 = single shared point, 1 = full chord).
+ *    SPREAD > 1       → absolute canvas units (0-100 space, open-ended); holds a constant
+ *                       scatter footprint as valence gets extreme instead of shrinking toward
+ *                       the vertex, falling back to the full chord once it's shorter than this.
+ */
 const SPREAD = 0.15;
 ```
 
-Editing this one value and re-running the demo moves between "tight cluster" and "full scatter" —
-no control-bar or `SimContext` changes needed.
+Editing this one value and re-running the demo moves between "tight cluster," "constant-footprint
+cluster," and "full scatter" — no control-bar or `SimContext` changes needed.
 
 ## Task breakdown (TDD, one commit per task — mirrors the pattern already used on this branch)
 
@@ -141,7 +179,11 @@ no control-bar or `SimContext` changes needed.
    `tests/voteRegion.test.ts` (round-trip assertions above), watch RED (function doesn't exist),
    implement, GREEN.
 2. **Redesign `valenceShift.ts` to glide directly between sampled XY points**, using the hardcoded
-   `SPREAD` constant. Update `valenceShift.test.ts`:
+   `SPREAD` constant and a `resolveSpreadFraction(spread, chordLen)` helper (dual-mode: `<=1` is a
+   chord-length fraction, `>1` is absolute canvas units with a full-chord floor — see "Spread as a
+   hardcoded constant" above). Export `resolveSpreadFraction` (or keep it module-local and test via
+   the target-picking helper — whichever the existing file's export style favors) so it's unit
+   testable in isolation from the RNG-driven per-tick logic. Update `valenceShift.test.ts`:
    - Existing tests should mostly still pass conceptually but will need re-verification against the
      new mechanism (positions are no longer literally `valenceToPosition(scalar)`); re-run and fix
      any that assumed the old single-line geometry.
@@ -154,6 +196,11 @@ no control-bar or `SimContext` changes needed.
      `1` — or, more simply, testing the internal target-picking helper directly if it's exported)
      shows the resulting within-group spread scales up accordingly (monotonic, not just
      present/absent), proving the constant actually drives the effect claimed above.
+   - New test for `resolveSpreadFraction` directly: `resolveSpreadFraction(0.15, anyChordLen) ===
+     0.15` (proportional mode passes through unchanged); `resolveSpreadFraction(10, 64) ≈ 10/64`
+     (absolute mode divides by chord length); `resolveSpreadFraction(10, 5) === 1` (absolute mode
+     clamps to the full chord when the chord is shorter than the requested footprint);
+     `resolveSpreadFraction(10, 0) === 1` (degenerate v=±1 chord doesn't divide by zero).
 3. **(Separable cleanup, do last, only if time allows)** Consider whether any further code-sharing
    with `regionHoppersRealistic.ts` is now worthwhile. Given task 2's finding — Valence Shift doesn't
    need Region-hoppers' independent per-cursor move/rest state machine, since all users glide on one
@@ -166,7 +213,7 @@ no control-bar or `SimContext` changes needed.
 
 ## Resolved decisions (from conversation)
 
-1. Ship **one mechanism** (a `SPREAD` constant, 0..1) rather than two separate code paths for
+1. Ship **one mechanism** (a `SPREAD` constant) rather than two separate code paths for
    "bounded jitter" vs "full scatter" — they're the same math at different parameter values.
 2. **Hardcoded constant, no UI control** — the user will hand-edit `SPREAD` in the source to explore
    the range, not drag a live slider. No `SimContext`/`SimControlBar` changes needed.
@@ -174,6 +221,12 @@ no control-bar or `SimContext` changes needed.
    looks like "correlated groups," with the option to hand-edit it to `1` to see full scatter.
 4. No new shared "ghost" state-machine abstraction planned — the redesign turned out simpler than
    originally scoped (see task 3).
+5. **`SPREAD` is dual-mode, inferred from magnitude** (`<=1` → chord-length fraction, `>1` → absolute
+   canvas units, floored to the full chord when the chord is shorter than the requested footprint).
+   Added mid-build: a purely proportional spread shrinks toward zero as `personalValence` approaches
+   `±1` because the chord itself shrinks to a point there — real people don't cluster tighter and
+   tighter just because their opinion is more extreme, so absolute-unit mode holds a constant scatter
+   footprint instead, only degrading once the chord is physically too short to hold it.
 
 ## Files touched
 

--- a/tests/voteRegion.test.ts
+++ b/tests/voteRegion.test.ts
@@ -6,6 +6,8 @@ import {
   valenceToPosition,
   valenceToPercent,
   reactionLabelStyle,
+  valenceChordEndpoints,
+  sampleValencePosition,
   type ReactionAnchors,
 } from '../app/utils/voteRegion';
 
@@ -160,6 +162,70 @@ describe('valenceToPosition', () => {
     const p = valenceToPosition(5, DEFAULT_ANCHORS);
     expect(p.x).toBeCloseTo(DEFAULT_ANCHORS.positive.x, 5);
     expect(p.y).toBeCloseTo(DEFAULT_ANCHORS.positive.y, 5);
+  });
+});
+
+describe('sampleValencePosition', () => {
+  const valences = [-1, -0.6, -0.3, 0, 0.3, 0.6, 1];
+  const ts = [0, 0.25, 0.5, 0.75, 1];
+
+  it('round-trips through computeCursorValence for every valence/t combination', () => {
+    for (const v of valences) {
+      for (const t of ts) {
+        const p = sampleValencePosition(v, t, DEFAULT_ANCHORS);
+        expect(computeCursorValence(p.x, p.y, DEFAULT_ANCHORS)).toBeCloseTo(v, 4);
+      }
+    }
+  });
+
+  it('collapses to a single point regardless of t when valence is ±1', () => {
+    for (const v of [-1, 1]) {
+      const points = ts.map((t) => sampleValencePosition(v, t, DEFAULT_ANCHORS));
+      for (const p of points) {
+        expect(p.x).toBeCloseTo(points[0].x, 5);
+        expect(p.y).toBeCloseTo(points[0].y, 5);
+      }
+    }
+  });
+
+  it('stays within the DEFAULT_ANCHORS triangle (barycentric weights in [0,1])', () => {
+    const pos = { x: DEFAULT_ANCHORS.positive.x / 100, y: DEFAULT_ANCHORS.positive.y / 100 };
+    const neg = { x: DEFAULT_ANCHORS.negative.x / 100, y: DEFAULT_ANCHORS.negative.y / 100 };
+    const neu = { x: DEFAULT_ANCHORS.neutral.x / 100, y: DEFAULT_ANCHORS.neutral.y / 100 };
+    const denom = (neg.y - neu.y) * (pos.x - neu.x) + (neu.x - neg.x) * (pos.y - neu.y);
+
+    for (const v of valences) {
+      for (const t of ts) {
+        const p = sampleValencePosition(v, t, DEFAULT_ANCHORS);
+        const x = p.x / 100;
+        const y = p.y / 100;
+        const wPos = ((neg.y - neu.y) * (x - neu.x) + (neu.x - neg.x) * (y - neu.y)) / denom;
+        const wNeg = ((neu.y - pos.y) * (x - neu.x) + (pos.x - neu.x) * (y - neu.y)) / denom;
+        const wNeu = 1 - wPos - wNeg;
+        for (const w of [wPos, wNeg, wNeu]) {
+          expect(w).toBeGreaterThanOrEqual(-1e-9);
+          expect(w).toBeLessThanOrEqual(1 + 1e-9);
+        }
+      }
+    }
+  });
+});
+
+describe('valenceChordEndpoints', () => {
+  it('produces endpoints that both round-trip to the requested valence', () => {
+    for (const v of [-1, -0.5, 0, 0.5, 1]) {
+      const { a, b } = valenceChordEndpoints(v, DEFAULT_ANCHORS);
+      expect(computeCursorValence(a.x, a.y, DEFAULT_ANCHORS)).toBeCloseTo(v, 4);
+      expect(computeCursorValence(b.x, b.y, DEFAULT_ANCHORS)).toBeCloseTo(v, 4);
+    }
+  });
+
+  it('the v=0 chord spans from the neutral anchor to the negative-positive midpoint', () => {
+    const { a, b } = valenceChordEndpoints(0, DEFAULT_ANCHORS);
+    // a(0) = lerp(neutral, positive, 0) = neutral; b(0) = lerp(negative, positive, 0.5) = midpoint
+    expect(a).toEqual(DEFAULT_ANCHORS.neutral);
+    expect(b.x).toBeCloseTo(50, 5);
+    expect(b.y).toBeCloseTo(50, 5);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds the "Valence Shift (groups)" simulator program: sim cursors split into Fibonacci-sized opinion groups that periodically re-randomize a shared target valence, gliding (eased) to it and holding with micro-wander until the next shift.
- Redesigns positioning to be organic: instead of collapsing every valence to one fixed point on a line, users now sample from the full chord of canvas positions consistent with their target valence, with a tunable `SPREAD` constant (proportional or absolute-unit, see `docs/specs/valence-shift-organic-positioning.md`) driving tight-cluster vs. full-scatter looks. Each member's personal offset from the group target rescrambles every shift instead of staying fixed for the session.
- Extracts `easedProgress` into the shared `_easing.ts` module, used by both Region-hoppers (realistic) and Valence Shift.

## Test plan
- [x] `pnpm vitest` — full suite passes (513 tests)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] CHANGELOG.md updated under Week 33